### PR TITLE
Name the mascot: introduce DMarcus across UI and README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,9 @@ Live at dmarc.mx | Repo: github.com/schmug/dmarcheck
 - `src/analyzers/` — One module per protocol (dmarc, spf, dkim, bimi, mta-sts)
 - `src/orchestrator.ts` — Runs all analyzers in parallel via Promise.allSettled
 - `src/shared/scoring.ts` — Grade computation (F if no DMARC or p=none)
-- `src/views/` — HTML generation via template literals (styles.ts, scripts.ts, components.ts, html.ts)
+- `src/cache.ts` — SSE result caching
+- `src/csv.ts` — CSV export for scan results
+- `src/views/` — HTML generation via template literals (styles.ts, scripts.ts, components.ts, html.ts, favicon.ts)
 - `src/rate-limit.ts` — Cache API-based rate limiter (10 req/IP/60s)
 
 ## Conventions
@@ -39,7 +41,7 @@ Live at dmarc.mx | Repo: github.com/schmug/dmarcheck
 - Status is `"pass"` | `"warn"` | `"fail"` for scored protocols, `"info"` for informational (MX)
 - HTML is generated server-side as template literal strings, no JSX or build step
 - Client-side JS is minimal (expand/collapse, tooltips) — inline script tag
-- Dark theme with orange accent (#f97316)
+- Dark/light theme with OS-aware switching and manual toggle; orange accent (#f97316)
 
 ## Quality Gates
 
@@ -65,6 +67,11 @@ Live at dmarc.mx | Repo: github.com/schmug/dmarcheck
 
 - After committing or merging work, check open issues (`gh issue list`) to see if any were resolved and should be closed
 - When a commit addresses an issue, close it with a comment referencing the commit hash
+
+## Documentation
+
+- Keep `CLAUDE.md` and `README.md` up to date when adding features, changing architecture, or modifying conventions
+- `CLAUDE.md` is for AI assistants and contributors; `README.md` is for users and self-hosters
 
 ## Cloudflare MCP
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://dmarc.mx/logo.svg" alt="dmarcheck" width="120" height="120">
+  <img src="https://dmarc.mx/logo.svg" alt="DMarcus — the dmarcheck mascot" width="120" height="120">
 </p>
 
 <h1 align="center">dmarcheck</h1>
@@ -11,6 +11,8 @@
 </p>
 
 DNS email security analyzer — checks DMARC, SPF, DKIM, BIMI, and MTA-STS records for any domain.
+
+Meet **DMarcus**, the @ creature who guards your inbox.
 
 **Live at [dmarc.mx](https://dmarc.mx)**
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -231,7 +231,7 @@ app.get("/og-image.svg", (c) => {
   <!-- Tagline -->
   <text x="500" y="350" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif" font-size="24" fill="#71717a">DNS Email Security Analyzer</text>
   <!-- BIMI badge -->
-  <text x="500" y="400" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif" font-size="18" fill="#f97316">BIMI-ready brand identity</text>
+  <text x="500" y="400" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif" font-size="18" fill="#f97316">Meet DMarcus — your email security sidekick</text>
 </svg>`;
   return c.body(svg, 200, {
     "Content-Type": "image/svg+xml",

--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -101,6 +101,7 @@ export function renderLandingPage(): string {
         Free and open source &mdash; MIT License
       </a>
     </div>
+    <div class="dmarcus-credit">Guarded by DMarcus ${generateCreature("sm", "content")}</div>
   </div>
 </div>`,
   );
@@ -357,7 +358,7 @@ export function renderCheckLoading(domain: string, selectors: string): string {
   <div class="logo">${generateCreature("lg")}<span class="logo-text">dmar<span>check</span></span></div>
   <div class="loading">
     <div class="creature-loading">${generateCreature("lg")}</div>
-    <p>Scanning ${esc(domain)}&hellip;</p>
+    <p>DMarcus is scanning ${esc(domain)}&hellip;</p>
   </div>
   <noscript><meta http-equiv="refresh" content="0;url=/check?${qs}&_direct=1"></noscript>
 </div>

--- a/src/views/scripts.ts
+++ b/src/views/scripts.ts
@@ -286,7 +286,7 @@ if (!window.__dmarcheckBound) {
     creature.className = 'at-creature';
     creature.setAttribute('tabindex', '0');
     creature.setAttribute('role', 'button');
-    creature.setAttribute('aria-label', 'Stop the email creature');
+    creature.setAttribute('aria-label', 'Stop DMarcus');
 
     var body = document.createElement('div');
     body.className = 'creature-body';
@@ -320,7 +320,7 @@ if (!window.__dmarcheckBound) {
     var announce = document.createElement('div');
     announce.setAttribute('aria-live', 'polite');
     announce.setAttribute('style', 'position:absolute;left:-9999px;');
-    announce.textContent = 'An email creature appeared!';
+    announce.textContent = 'DMarcus appeared!';
     document.body.appendChild(announce);
     setTimeout(function() { announce.remove(); }, 3000);
 

--- a/src/views/styles.ts
+++ b/src/views/styles.ts
@@ -190,8 +190,19 @@ code { font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace; font-siz
   display: inline-flex; align-items: center; gap: 6px;
   color: var(--clr-text-dim); font-size: 0.8rem; text-decoration: none;
 }
+<<<<<<< HEAD
 .foss-link:hover { color: var(--clr-text-muted); text-decoration: none; }
 .foss-link:hover svg { fill: var(--clr-text-muted); }
+=======
+.foss-link:hover { color: #a1a1aa; text-decoration: none; }
+.foss-link:hover svg { fill: #a1a1aa; }
+.dmarcus-credit {
+  margin-top: 0.75rem; text-align: center; font-size: 0.75rem;
+  color: #71717a; display: inline-flex; align-items: center; gap: 4px;
+  width: 100%; justify-content: center; opacity: 0.6;
+}
+.dmarcus-credit:hover { opacity: 1; transition: opacity 0.3s; }
+>>>>>>> 352d741 (Add DMarcus branding and update CLAUDE.md for accuracy)
 .footer-creature { margin-bottom: 0.75rem; opacity: 0.6; }
 .footer-creature:hover { opacity: 1; transition: opacity 0.3s; }
 .logo-text { display: inline; }


### PR DESCRIPTION
## Summary

- Name-drops **DMarcus** (the @ creature mascot) in 5 natural places — the creature was fully visual but never named
- Easter egg now announces "DMarcus appeared!" and "Stop DMarcus" (aria-live/aria-label)
- Loading page says "DMarcus is scanning {domain}…"
- OG image tagline updated to "Meet DMarcus — your email security sidekick"
- Landing footer adds subtle "Guarded by DMarcus" credit with small creature
- README introduces DMarcus with a tagline and updated logo alt text
- CLAUDE.md updated for accuracy (new files, conventions)

## Test plan

- [ ] `npm test` — all 616 tests pass (no behavioral changes)
- [ ] `npm run typecheck` — clean
- [ ] `npm run lint` — clean
- [ ] Visual: visit landing page, check footer "Guarded by DMarcus" line
- [ ] Visual: trigger a scan, confirm loading text says "DMarcus is scanning…"
- [ ] Visual: wait 60s idle, confirm easter egg announces "DMarcus appeared!"
- [ ] Check `/og-image.svg` for updated tagline
- [ ] Review README rendering on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)