### PR TITLE
⚡ Bolt: Optimize orchestrator concurrency and clean up DNS timeouts

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,7 @@
+## 2024-05-18 - Avoid Promise Waterfalls in High-Latency Scans
+**Learning:** In the `scan` function (`src/orchestrator.ts`), waiting for all initial scans (including the notoriously slow DKIM analysis) to complete before starting BIMI analysis (which only depends on DMARC) creates an unnecessary promise waterfall.
+**Action:** Chain dependent promises directly off the specific promises they depend on (e.g., `dmarcPromise.then(...)`) rather than `Promise.all` results to maximize concurrency and overall throughput.
+
+## 2024-05-18 - Clear lingering timeouts
+**Learning:** `Promise.race` with a `setTimeout` (as seen in `src/dns/client.ts`) doesn't automatically clear the timer if the main promise resolves first. In a high-concurrency environment (like 30+ DKIM lookups), these lingering timers keep the event loop busy and delay garbage collection.
+**Action:** Always capture the `setTimeout` reference and explicitly `clearTimeout` in a `.finally()` block when using timeouts with `Promise.race`.

--- a/src/dns/client.ts
+++ b/src/dns/client.ts
@@ -5,12 +5,15 @@ const resolver = new dns.promises.Resolver();
 const DNS_TIMEOUT_MS = 3000;
 
 function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
-  return Promise.race([
-    promise,
-    new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error("DNS timeout")), ms),
-    ),
-  ]);
+  let timer: NodeJS.Timeout;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error("DNS timeout")), ms);
+  });
+
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    // Clear timeout to prevent memory leaks/event loop blocking if promise resolves early
+    clearTimeout(timer);
+  });
 }
 
 export async function queryTxt(name: string): Promise<TxtRecord | null> {

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -57,17 +57,33 @@ export async function scan(
   domain: string,
   customSelectors: string[] = [],
 ): Promise<ScanResult> {
-  const [mxResult, dmarcResult, spfResult, dkimResult, mtaStsResult] =
-    await Promise.all([
-      analyzeMx(domain),
-      analyzeDmarc(domain),
-      analyzeSpf(domain),
-      analyzeDkim(domain, customSelectors),
-      analyzeMtaSts(domain),
-    ]);
+  const mxPromise = analyzeMx(domain);
+  const dmarcPromise = analyzeDmarc(domain);
+  const spfPromise = analyzeSpf(domain);
+  const dkimPromise = analyzeDkim(domain, customSelectors);
+  const mtaStsPromise = analyzeMtaSts(domain);
 
-  const dmarcPolicy = dmarcResult.tags?.p?.toLowerCase() ?? null;
-  const bimiResult = await analyzeBimi(domain, dmarcPolicy);
+  // Run BIMI analysis concurrently once DMARC resolves, rather than waiting for all scans (like DKIM)
+  const bimiPromise = dmarcPromise.then((dmarcResult) => {
+    const dmarcPolicy = dmarcResult.tags?.p?.toLowerCase() ?? null;
+    return analyzeBimi(domain, dmarcPolicy);
+  });
+
+  const [
+    mxResult,
+    dmarcResult,
+    spfResult,
+    dkimResult,
+    mtaStsResult,
+    bimiResult,
+  ] = await Promise.all([
+    mxPromise,
+    dmarcPromise,
+    spfPromise,
+    dkimPromise,
+    mtaStsPromise,
+    bimiPromise,
+  ]);
 
   return buildScanResult(domain, {
     mx: mxResult,


### PR DESCRIPTION
This PR implements two performance improvements:

1. **Fix Promise Waterfall**: Chained `analyzeBimi` directly to `dmarcPromise` using `.then()` so that it runs concurrently with the slow DKIM scans.
2. **Clear Timeout**: Fixed `withTimeout` to capture the timer reference and clear it in a `.finally()` block, preventing lingering timeouts from delaying garbage collection.

All unit tests have been run and verify that the logic changes are safe and regressions are avoided. Also added the `.jules/bolt.md` journal file.

---
*PR created automatically by Jules for task [9975142367608608595](https://jules.google.com/task/9975142367608608595) started by @schmug*