### PR TITLE
fix: clear DNS timeout timers to prevent event loop blocking

### DIFF
--- a/src/dns/client.ts
+++ b/src/dns/client.ts
@@ -5,12 +5,14 @@ const resolver = new dns.promises.Resolver();
 const DNS_TIMEOUT_MS = 3000;
 
 function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
-  return Promise.race([
-    promise,
-    new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error("DNS timeout")), ms),
-    ),
-  ]);
+  let timer: NodeJS.Timeout;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error("DNS timeout")), ms);
+  });
+
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    clearTimeout(timer);
+  });
 }
 
 export async function queryTxt(name: string): Promise<TxtRecord | null> {


### PR DESCRIPTION
## Summary

- `withTimeout` in `src/dns/client.ts` now captures the `setTimeout` reference and clears it in `.finally()` when the main promise resolves first
- Prevents lingering timers from blocking the event loop during high-concurrency DKIM scans (30+ parallel lookups)

Cherry-picked from #37 (closed — orchestrator changes were superseded by #47).

## Test plan

- [x] `npm test` — 247 tests pass
- [x] `npm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)