### PR TITLE
⚡ Bolt: Optimize SPF DNS lookup recursion and orchestrator concurrency

### DIFF
--- a/src/analyzers/spf.ts
+++ b/src/analyzers/spf.ts
@@ -158,21 +158,25 @@ async function resolveSpfTree(
   }
 
   // Resolve includes in parallel
-  const resolved = await Promise.allSettled(
-    includeTargets.map((target) => resolveSpfTree(target, ctx, depth + 1)),
-  );
+  // Optimization: If we've already exceeded the SPF lookup limit, avoid fetching further includes.
+  // We still record the mechanism to accurately reflect the original SPF, but skip the recursion.
+  if (ctx.lookups <= MAX_LOOKUPS) {
+    const resolved = await Promise.allSettled(
+      includeTargets.map((target) => resolveSpfTree(target, ctx, depth + 1)),
+    );
 
-  for (const result of resolved) {
-    if (result.status === "fulfilled" && result.value) {
-      includes.push(result.value);
+    for (const result of resolved) {
+      if (result.status === "fulfilled" && result.value) {
+        includes.push(result.value);
+      }
     }
-  }
 
-  // Handle redirect (processed after all mechanisms)
-  if (redirect) {
-    const redirectNode = await resolveSpfTree(redirect, ctx, depth + 1);
-    if (redirectNode) {
-      includes.push(redirectNode);
+    // Handle redirect (processed after all mechanisms)
+    if (redirect) {
+      const redirectNode = await resolveSpfTree(redirect, ctx, depth + 1);
+      if (redirectNode) {
+        includes.push(redirectNode);
+      }
     }
   }
 

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -92,15 +92,36 @@ export async function scan(
     return analyzeDkim(domain, customSelectors, providerNames);
   });
 
-  const [dmarcResult, spfResult, dkimResult, mtaStsResult, bimiDns, mxResult] =
-    await Promise.all([
-      dmarcPromise,
-      spfPromise,
-      dkimPromise,
-      mtaStsPromise,
-      bimiDnsPromise,
-      mxPromise,
-    ]);
+  // Optimize: Chain BIMI off DMARC and prefetch so it runs concurrently with other scans
+  const bimiPromise = Promise.all([dmarcPromise, bimiDnsPromise]).then(
+    async ([dmarcResult, bimiDns]) => {
+      const dmarcPolicy = dmarcResult.tags?.p?.toLowerCase() ?? null;
+      const bimiResult = await analyzeBimi(domain, dmarcPolicy, bimiDns);
+      Sentry.addBreadcrumb({
+        category: "analyzer.complete",
+        message: `bimi: ${bimiResult.status}`,
+        data: { protocol: "bimi", status: bimiResult.status },
+        level: "info",
+      });
+      return bimiResult;
+    },
+  );
+
+  const [
+    dmarcResult,
+    spfResult,
+    dkimResult,
+    mtaStsResult,
+    bimiResult,
+    mxResult,
+  ] = await Promise.all([
+    dmarcPromise,
+    spfPromise,
+    dkimPromise,
+    mtaStsPromise,
+    bimiPromise,
+    mxPromise,
+  ]);
 
   Sentry.addBreadcrumb({
     category: "analyzer.complete",
@@ -127,15 +148,6 @@ export async function scan(
     level: "info",
   });
 
-  const dmarcPolicy = dmarcResult.tags?.p?.toLowerCase() ?? null;
-  const bimiResult = await analyzeBimi(domain, dmarcPolicy, bimiDns);
-  Sentry.addBreadcrumb({
-    category: "analyzer.complete",
-    message: `bimi: ${bimiResult.status}`,
-    data: { protocol: "bimi", status: bimiResult.status },
-    level: "info",
-  });
-
   return await buildScanResult(domain, {
     mx: mxResult,
     dmarc: dmarcResult,
@@ -156,19 +168,23 @@ export async function scanStreaming(
   const spfPromise = analyzeSpf(domain);
   const mtaStsPromise = analyzeMtaSts(domain);
   const bimiDnsPromise = prefetchBimiDns(domain);
+  const mxPromise = analyzeMx(domain);
 
-  const mxResult = await analyzeMx(domain);
-  Sentry.addBreadcrumb({
-    category: "analyzer.complete",
-    message: `mx: ${mxResult.status}`,
-    data: { protocol: "mx", status: mxResult.status },
-    level: "info",
+  mxPromise.then((mxResult) => {
+    Sentry.addBreadcrumb({
+      category: "analyzer.complete",
+      message: `mx: ${mxResult.status}`,
+      data: { protocol: "mx", status: mxResult.status },
+      level: "info",
+    });
+    onResult("mx", mxResult);
   });
-  onResult("mx", mxResult);
-  const providerNames = mxResult.providers.map((p) => p.name);
 
   // Start DKIM query after MX resolution provides email provider names
-  const dkimPromise = analyzeDkim(domain, customSelectors, providerNames);
+  const dkimPromise = mxPromise.then((mxResult) => {
+    const providerNames = mxResult.providers.map((p) => p.name);
+    return analyzeDkim(domain, customSelectors, providerNames);
+  });
 
   spfPromise.then((r) => {
     Sentry.addBreadcrumb({
@@ -198,32 +214,46 @@ export async function scanStreaming(
     onResult("mta_sts", r);
   });
 
-  const [dmarcResult, bimiDns] = await Promise.all([
+  dmarcPromise.then((r) => {
+    Sentry.addBreadcrumb({
+      category: "analyzer.complete",
+      message: `dmarc: ${r.status}`,
+      data: { protocol: "dmarc", status: r.status },
+      level: "info",
+    });
+    onResult("dmarc", r);
+  });
+
+  // Optimize: Chain BIMI off DMARC and prefetch so it streams independently
+  const bimiPromise = Promise.all([dmarcPromise, bimiDnsPromise]).then(
+    async ([dmarcResult, bimiDns]) => {
+      const dmarcPolicy = dmarcResult.tags?.p?.toLowerCase() ?? null;
+      const bimiResult = await analyzeBimi(domain, dmarcPolicy, bimiDns);
+      Sentry.addBreadcrumb({
+        category: "analyzer.complete",
+        message: `bimi: ${bimiResult.status}`,
+        data: { protocol: "bimi", status: bimiResult.status },
+        level: "info",
+      });
+      onResult("bimi", bimiResult);
+      return bimiResult;
+    },
+  );
+
+  const [
+    dmarcResult,
+    spfResult,
+    dkimResult,
+    mtaStsResult,
+    bimiResult,
+    mxResult,
+  ] = await Promise.all([
     dmarcPromise,
-    bimiDnsPromise,
-  ]);
-  Sentry.addBreadcrumb({
-    category: "analyzer.complete",
-    message: `dmarc: ${dmarcResult.status}`,
-    data: { protocol: "dmarc", status: dmarcResult.status },
-    level: "info",
-  });
-  onResult("dmarc", dmarcResult);
-
-  const dmarcPolicy = dmarcResult.tags?.p?.toLowerCase() ?? null;
-  const bimiResult = await analyzeBimi(domain, dmarcPolicy, bimiDns);
-  Sentry.addBreadcrumb({
-    category: "analyzer.complete",
-    message: `bimi: ${bimiResult.status}`,
-    data: { protocol: "bimi", status: bimiResult.status },
-    level: "info",
-  });
-  onResult("bimi", bimiResult);
-
-  const [spfResult, dkimResult, mtaStsResult] = await Promise.all([
     spfPromise,
     dkimPromise,
     mtaStsPromise,
+    bimiPromise,
+    mxPromise,
   ]);
 
   return await buildScanResult(domain, {


### PR DESCRIPTION
💡 What: 
1. Added an early exit boundary check in `resolveSpfTree` (`src/analyzers/spf.ts`) to stop evaluating recursive SPF includes and redirects once the lookup limit (`MAX_LOOKUPS`) is reached.
2. Refactored the orchestrator (`src/orchestrator.ts`) to process dependent lookups concurrently through Promise chaining instead of sequential awaits.

🎯 Why: 
1. SPF records with deeply nested, complex, or maliciously crafted include trees previously caused indiscriminate recursive DNS lookups even after the 10-lookup limit specified by RFC 7208 was reached. This wasted execution time and resulted in excessive, unnecessary concurrent DNS queries.
2. The orchestrator previously awaited promises like `analyzeMx` and the intermediate `Promise.all` for DMARC and BIMI sequentially, blocking the event loop from kicking off subsequent queries or streaming intermediate results efficiently.

📊 Impact: 
1. SPF Optimization: Prevents wasted concurrent DNS lookups for large SPF trees, improving overall performance and protecting against resource exhaustion.
2. Orchestrator Optimization: Reduces scan latency by instantiating independent DNS lookups immediately and streaming dependent lookups (like BIMI) as soon as they resolve.

🔬 Measurement: 
To verify the improvement, run `pnpm test` and `pnpm lint`. The test suite covers existing behaviors, ensuring that standard operation functions as intended, while significantly saving CPU cycles and network overhead on complex SPF structures.

---
*PR created automatically by Jules for task [10082638175841224914](https://jules.google.com/task/10082638175841224914) started by @schmug*