### PR TITLE
🎨 Palette: Add aria-describedby to DKIM selector helper text

### DIFF
--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -78,8 +78,8 @@ export function renderLandingPage(): string {
           <label for="selectors">Custom DKIM selectors</label>
           <input type="text" id="selectors" name="selectors"
                  placeholder="e.g. myselector, custom2"
-                 autocomplete="off" />
-          <small>Comma-separated. These are checked in addition to the 38 common selectors.</small>
+                 autocomplete="off" aria-describedby="selectors-help" />
+          <small id="selectors-help">Comma-separated. These are checked in addition to the 38 common selectors.</small>
         </div>
       </details>
     </form>


### PR DESCRIPTION
### 💡 What:
Added an `id="selectors-help"` to the `<small>` helper text for the custom DKIM selectors input and linked it to the `<input>` using `aria-describedby="selectors-help"`. Added a new entry to the `.jules/palette.md` UX/a11y journal.

### 🎯 Why:
To ensure that screen readers announce the critical instructions (e.g., "Comma-separated. These are checked in addition to the 38 common selectors.") when a user focuses the custom DKIM selectors input field. Without this ARIA attribute, screen reader users might not know the expected format of the input.

### 📸 Before/After:
No visual changes (verified by Playwright screenshot). The enhancement is entirely structural for screen readers.

### ♿ Accessibility:
Improved form accessibility by explicitly associating instructional helper text with its form input field, ensuring proper context is provided during keyboard and screen reader navigation.

---
*PR created automatically by Jules for task [15853401906475980690](https://jules.google.com/task/15853401906475980690) started by @schmug*