### PR TITLE
🎨 Palette: Improve accessibility of DKIM selectors input

### DIFF
--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -78,8 +78,8 @@ export function renderLandingPage(): string {
           <label for="selectors">Custom DKIM selectors</label>
           <input type="text" id="selectors" name="selectors"
                  placeholder="e.g. myselector, custom2"
-                 autocomplete="off" />
-          <small>Comma-separated. These are checked in addition to the 38 common selectors.</small>
+                 autocomplete="off" aria-describedby="selectors-help" />
+          <small id="selectors-help">Comma-separated. These are checked in addition to the 38 common selectors.</small>
         </div>
       </details>
     </form>


### PR DESCRIPTION
💡 What: Added `id="selectors-help"` to the `<small>` helper text and `aria-describedby="selectors-help"` to the corresponding input for "Custom DKIM selectors".
🎯 Why: Helper text near form inputs is not automatically associated with the input by screen readers, making it difficult for visually impaired users to understand constraints (like "Comma-separated...").
📸 Before/After: Visuals remain unchanged.
♿ Accessibility: Screen readers will now announce the helper text when the input is focused.

---
*PR created automatically by Jules for task [17635126497817180634](https://jules.google.com/task/17635126497817180634) started by @schmug*