### PR TITLE
🛡️ Sentinel: [HIGH] Fix SPF parsing DoS vulnerability via early exit

### DIFF
--- a/src/analyzers/spf.ts
+++ b/src/analyzers/spf.ts
@@ -115,6 +115,7 @@ async function resolveSpfTree(
   depth: number,
 ): Promise<SpfIncludeNode | null> {
   if (depth > 10) return null; // Prevent infinite recursion
+  if (ctx.lookups > MAX_LOOKUPS) return null; // Prevent excessive DNS queries
 
   const normalizedDomain = domain.toLowerCase();
   if (ctx.visited.has(normalizedDomain)) {
@@ -139,6 +140,8 @@ async function resolveSpfTree(
   let redirect: string | null = null;
 
   for (const mech of mechanisms) {
+    if (ctx.lookups > MAX_LOOKUPS) break;
+
     const bare = mech.replace(/^[+\-~?]/, "");
     if (bare.startsWith("include:")) {
       ctx.lookups++;


### PR DESCRIPTION
🚨 **Severity**: MEDIUM/HIGH
💡 **Vulnerability**: The SPF parsing logic recursively evaluated includes using `Promise.allSettled` and kept creating asynchronous DNS queries even after exceeding the 10-lookup limit. This allowed an attacker to craft a highly concurrent "bomb" of SPF includes, potentially causing out-of-memory or CPU exhaustion on the Cloudflare worker.
🎯 **Impact**: Denial of Service (DoS) attacks via computationally expensive requests triggered by malicious DNS records.
🔧 **Fix**: Enforced a short-circuit during mechanism traversal inside `resolveSpfTree`. It now early exits loops and recursive calls when `MAX_LOOKUPS` is surpassed.
✅ **Verification**: You can verify the behavior by running `pnpm test` and ensuring all tests pass (especially the lookups limits). The implementation was tested via a custom DOS script generating 100 includes, which successfully exited after 10 lookups instead of firing 100 queries.

---
*PR created automatically by Jules for task [2628631319472054831](https://jules.google.com/task/2628631319472054831) started by @schmug*