### PR TITLE
⚡ Bolt: Optimize recursive SPF DNS lookups

### DIFF
--- a/src/analyzers/spf.ts
+++ b/src/analyzers/spf.ts
@@ -158,9 +158,16 @@ async function resolveSpfTree(
   }
 
   // Resolve includes in parallel
-  const resolved = await Promise.allSettled(
-    includeTargets.map((target) => resolveSpfTree(target, ctx, depth + 1)),
-  );
+  // ⚡ Bolt: Only recurse on includes if we haven't already exceeded the DNS lookup limit
+  // Prevents cascading excessive parallel DNS queries for complex or malicious SPF trees
+  const resolved =
+    ctx.lookups > MAX_LOOKUPS
+      ? []
+      : await Promise.allSettled(
+          includeTargets.map((target) =>
+            resolveSpfTree(target, ctx, depth + 1),
+          ),
+        );
 
   for (const result of resolved) {
     if (result.status === "fulfilled" && result.value) {
@@ -169,7 +176,7 @@ async function resolveSpfTree(
   }
 
   // Handle redirect (processed after all mechanisms)
-  if (redirect) {
+  if (redirect && ctx.lookups <= MAX_LOOKUPS) {
     const redirectNode = await resolveSpfTree(redirect, ctx, depth + 1);
     if (redirectNode) {
       includes.push(redirectNode);


### PR DESCRIPTION
💡 What: Optimized the SPF tree resolver to skip recursive DNS queries (`include` and `redirect`) if the `MAX_LOOKUPS` limit has already been exceeded.
🎯 Why: Without this check, the application would continue firing potentially unbounded parallel DNS queries for complex or maliciously crafted nested SPF trees, wasting CPU, network IO, and memory, even when the record was already guaranteed to trigger a PermError limit failure.
📊 Impact: Expected to significantly reduce latency and worker compute time on complex SPF lookups, while eliminating the worst-case scenario of unbounded nested `Promise.allSettled` queries.
🔬 Measurement: Verify via `pnpm lint` and `pnpm test`. Code tests ensure the parsing of standard mechanisms like `~all` or `ip4:` operates flawlessly even if the `include` lookups exceed the limit limit.

---
*PR created automatically by Jules for task [10964088981380959395](https://jules.google.com/task/10964088981380959395) started by @schmug*