### PR TITLE
🎨 Palette: Improve accessibility of DKIM selectors input

### DIFF
--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -78,8 +78,8 @@ export function renderLandingPage(): string {
           <label for="selectors">Custom DKIM selectors</label>
           <input type="text" id="selectors" name="selectors"
                  placeholder="e.g. myselector, custom2"
-                 autocomplete="off" />
-          <small>Comma-separated. These are checked in addition to the 38 common selectors.</small>
+                 autocomplete="off" aria-describedby="selectors-help" />
+          <small id="selectors-help">Comma-separated. These are checked in addition to the 38 common selectors.</small>
         </div>
       </details>
     </form>


### PR DESCRIPTION
💡 **What:** Added `aria-describedby` attribute to the "Custom DKIM selectors" input to properly link the `<small>` helper text using an `id`.

🎯 **Why:** Screen readers might not correctly announce the important helper text associated with the custom DKIM selectors input. Linking it explicitly via `aria-describedby` ensures that users relying on assistive technologies receive the context and formatting guidance needed.

📸 **Before/After:** No visual changes since this only modifies underlying ARIA attributes and IDs.

♿ **Accessibility:**
- Added `id="selectors-help"` to the `<small>` helper text element.
- Linked the input element using `aria-describedby="selectors-help"` to improve semantic connection.

---
*PR created automatically by Jules for task [17825861657481351938](https://jules.google.com/task/17825861657481351938) started by @schmug*