### PR TITLE
🎨 Palette: [a11y] add aria-describedby to custom DKIM selectors input

### DIFF
--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -78,8 +78,9 @@ export function renderLandingPage(): string {
           <label for="selectors">Custom DKIM selectors</label>
           <input type="text" id="selectors" name="selectors"
                  placeholder="e.g. myselector, custom2"
-                 autocomplete="off" />
-          <small>Comma-separated. These are checked in addition to the 38 common selectors.</small>
+                 autocomplete="off"
+                 aria-describedby="selectors-help" />
+          <small id="selectors-help">Comma-separated. These are checked in addition to the 38 common selectors.</small>
         </div>
       </details>
     </form>


### PR DESCRIPTION
💡 **What:** Added `aria-describedby` to the custom DKIM selectors input field and an `id` to its corresponding helper text in the landing page view.
🎯 **Why:** To ensure screen readers announce the helper instructions ("Comma-separated...") when users focus on the input, improving accessibility.
♿ **Accessibility:** Form inputs with helper text should programmatically associate the text with the input using `aria-describedby` for screen reader users.

---
*PR created automatically by Jules for task [18276425320040669202](https://jules.google.com/task/18276425320040669202) started by @schmug*