### PR TITLE
SEO: robots.txt, sitemap.xml, canonical, JSON-LD, and H1s

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,17 @@ app.use("*", async (c, next) => {
 
 // Security headers middleware (HSTS is handled at Cloudflare edge)
 
+// Content types that should be hidden from search engines. HTML is the opposite:
+// it's the whole point of the site and must stay crawlable. Images/CSS/JS are
+// skipped because noindex on subresources is a no-op for how Googlebot renders
+// pages. XML (sitemap) and text/plain (robots.txt) need to stay crawlable.
+const NOINDEX_CONTENT_TYPES = [
+  "application/json",
+  "application/manifest+json",
+  "text/csv",
+  "text/event-stream",
+];
+
 app.use("*", async (c, next) => {
   await next();
   c.res.headers.set("X-Content-Type-Options", "nosniff");
@@ -86,14 +97,30 @@ app.use("*", async (c, next) => {
     "camera=(), microphone=(), geolocation=()",
   );
 
-  const isHtml = c.res.headers.get("content-type")?.includes("text/html");
+  const contentType = c.res.headers.get("content-type") ?? "";
+  const isHtml = contentType.includes("text/html");
   if (isHtml) {
     c.res.headers.set(
       "Content-Security-Policy",
       `default-src 'none'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; manifest-src 'self'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'`,
     );
+    // Short edge cache so Cloudflare can absorb landing/scoring/report traffic
+    // without hitting the Worker on every request. Browsers still revalidate.
+    if (!c.res.headers.has("Cache-Control")) {
+      c.res.headers.set(
+        "Cache-Control",
+        "public, max-age=0, s-maxage=300, stale-while-revalidate=600",
+      );
+    }
   } else {
     c.res.headers.set("Content-Security-Policy", "default-src 'none'");
+  }
+
+  // Keep the JSON API, CSV exports, the SSE stream, and the PWA manifest out
+  // of Google's index. These showed up in Search Console as "Crawled - currently
+  // not indexed" noise — no reason to spend crawl budget on them.
+  if (NOINDEX_CONTENT_TYPES.some((t) => contentType.includes(t))) {
+    c.res.headers.set("X-Robots-Tag", "noindex");
   }
 });
 
@@ -432,6 +459,50 @@ app.get("/health", (c) => {
   return c.json({ status: "ok", timestamp: new Date().toISOString() });
 });
 
+// Crawl guidance for search engines. Block the API namespace (Google was
+// logging `/api/check?domain=dmarc.mx` as "Crawled - currently not indexed"
+// noise) and point to the sitemap.
+app.get("/robots.txt", (c) => {
+  const body = `User-agent: *
+Allow: /
+Disallow: /api/
+Sitemap: https://dmarc.mx/sitemap.xml
+`;
+  return c.body(body, 200, {
+    "Content-Type": "text/plain; charset=utf-8",
+    "Cache-Control": "public, max-age=86400",
+  });
+});
+
+// Static URLs worth reinforcing to search engines. The three example domains
+// are already in Google's index and one of them ranks position 9 for a
+// long-tail query — listing them as canonical crawl targets is a cheap
+// authority signal.
+const SITEMAP_URLS: Array<{ loc: string; priority: string }> = [
+  { loc: "https://dmarc.mx/", priority: "1.0" },
+  { loc: "https://dmarc.mx/scoring", priority: "0.8" },
+  { loc: "https://dmarc.mx/check?domain=dmarc.mx", priority: "0.6" },
+  { loc: "https://dmarc.mx/check?domain=google.com", priority: "0.6" },
+  { loc: "https://dmarc.mx/check?domain=github.com", priority: "0.6" },
+];
+const SITEMAP_LASTMOD = "2026-04-10";
+
+app.get("/sitemap.xml", (c) => {
+  const urls = SITEMAP_URLS.map(
+    ({ loc, priority }) =>
+      `  <url><loc>${loc}</loc><lastmod>${SITEMAP_LASTMOD}</lastmod><priority>${priority}</priority></url>`,
+  ).join("\n");
+  const body = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
+</urlset>
+`;
+  return c.body(body, 200, {
+    "Content-Type": "application/xml; charset=utf-8",
+    "Cache-Control": "public, max-age=86400",
+  });
+});
+
 app.get("/", (c) => {
   return c.html(renderLandingPage());
 });
@@ -510,15 +581,26 @@ app.get("/check/score", async (c) => {
 });
 
 app.get("/check", async (c) => {
-  const domain = normalizeDomain(c.req.query("domain"));
-  if (!domain) {
-    return c.html(renderError("Please provide a valid domain name."), 400);
-  }
-
   const format = c.req.query("format");
   const wantsJson =
     format === "json" || c.req.header("Accept")?.includes("application/json");
   const wantsCsv = format === "csv";
+
+  const domain = normalizeDomain(c.req.query("domain"));
+  if (!domain) {
+    // API clients still get a structured error. Browsers get a 302 to `/` so
+    // Google doesn't report `/check` (bare) as a crawl error — the human intent
+    // of landing on `/check` with no query is "I want to scan something".
+    if (wantsJson) {
+      return c.json({ error: "Missing or invalid domain parameter" }, 400);
+    }
+    if (wantsCsv) {
+      return c.body("error,Missing or invalid domain parameter\n", 400, {
+        "Content-Type": "text/csv; charset=utf-8",
+      });
+    }
+    return c.redirect("/", 302);
+  }
 
   const selectors = parseSelectors(c.req.query("selectors"));
 

--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -30,27 +30,51 @@ import {
   validationList,
 } from "./components.js";
 
-function page(title: string, body: string): string {
+export const SITE_ORIGIN = "https://dmarc.mx";
+export const DEFAULT_DESCRIPTION =
+  "Free, open-source DNS email security analyzer. Check DMARC, SPF, DKIM, BIMI, and MTA-STS records for any domain.";
+
+interface PageOptions {
+  title: string;
+  body: string;
+  /** Absolute-path form, e.g. "/" or "/scoring" or "/check?domain=example.com". Defaults to "/". */
+  path?: string;
+  /** Overrides the default meta/og/twitter description. */
+  description?: string;
+  /** Pre-stringified JSON for a `<script type="application/ld+json">` block. */
+  jsonLd?: string;
+}
+
+function page(opts: PageOptions): string {
+  const { title, body, path = "/", description = DEFAULT_DESCRIPTION } = opts;
+  const canonical = `${SITE_ORIGIN}${path}`;
+  const jsonLdBlock = opts.jsonLd
+    ? `\n<script type="application/ld+json">${opts.jsonLd}</script>`
+    : "";
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="description" content="Free, open-source DNS email security analyzer. Check DMARC, SPF, DKIM, BIMI, and MTA-STS records for any domain.">
+<meta name="theme-color" content="#f97316">
+<meta name="description" content="${esc(description)}">
+<link rel="canonical" href="${esc(canonical)}">
 <meta property="og:title" content="${esc(title)}">
-<meta property="og:description" content="Free, open-source DNS email security analyzer. Check DMARC, SPF, DKIM, BIMI, and MTA-STS records for any domain.">
+<meta property="og:description" content="${esc(description)}">
 <meta property="og:type" content="website">
-<meta property="og:url" content="https://dmarc.mx">
-<meta property="og:image" content="https://dmarc.mx/og-image.svg">
+<meta property="og:url" content="${esc(canonical)}">
+<meta property="og:image" content="${SITE_ORIGIN}/og-image.svg">
 <meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="${esc(title)}">
+<meta name="twitter:description" content="${esc(description)}">
+<meta name="twitter:image" content="${SITE_ORIGIN}/og-image.svg">
 <link rel="icon" href="/favicon.ico" sizes="any">
 <link rel="icon" href="/favicon.svg" type="image/svg+xml">
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.webmanifest">
-<link rel="preconnect" href="/">
 <title>${esc(title)}</title>
 <script>(function(){var t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t)})()</script>
-<link rel="stylesheet" href="${CSS_PATH}">
+<link rel="stylesheet" href="${CSS_PATH}">${jsonLdBlock}
 </head>
 <body>
 ${body}
@@ -60,13 +84,53 @@ ${themeToggle()}
 </html>`;
 }
 
+const LANDING_JSON_LD = JSON.stringify({
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebSite",
+      "@id": `${SITE_ORIGIN}/#website`,
+      url: `${SITE_ORIGIN}/`,
+      name: "dmarcheck",
+      description: DEFAULT_DESCRIPTION,
+      publisher: { "@id": `${SITE_ORIGIN}/#org` },
+      potentialAction: {
+        "@type": "SearchAction",
+        target: {
+          "@type": "EntryPoint",
+          urlTemplate: `${SITE_ORIGIN}/check?domain={domain}`,
+        },
+        "query-input": "required name=domain",
+      },
+    },
+    {
+      "@type": "Organization",
+      "@id": `${SITE_ORIGIN}/#org`,
+      name: "dmarcheck",
+      url: `${SITE_ORIGIN}/`,
+      logo: `${SITE_ORIGIN}/logo.svg`,
+    },
+    {
+      "@type": "SoftwareApplication",
+      name: "dmarcheck",
+      url: `${SITE_ORIGIN}/`,
+      applicationCategory: "SecurityApplication",
+      operatingSystem: "Any",
+      description: DEFAULT_DESCRIPTION,
+      offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+    },
+  ],
+});
+
 export function renderLandingPage(): string {
-  return page(
-    "dmarcheck — DNS Email Security Analyzer",
-    `<main class="landing">
+  return page({
+    title: "dmarcheck — DNS Email Security Analyzer",
+    path: "/",
+    jsonLd: LANDING_JSON_LD,
+    body: `<main class="landing">
   <div class="landing-main">
     <div class="logo">${generateCreature("lg")}<span class="logo-text">dmar<span>check</span></span></div>
-    <div class="tagline">DNS email security analyzer &mdash; DMARC, SPF, DKIM, BIMI &amp; MTA-STS</div>
+    <h1 class="tagline">DNS email security analyzer &mdash; DMARC, SPF, DKIM, BIMI &amp; MTA-STS</h1>
     <form action="/check" method="GET">
       <div class="search-box">
         <input type="text" name="domain" placeholder="Enter a domain (e.g., google.com)" aria-label="Enter a domain" autofocus required>
@@ -88,6 +152,16 @@ export function renderLandingPage(): string {
       <a href="/check?domain=google.com">google.com</a> &middot;
       <a href="/check?domain=github.com">github.com</a>
     </div>
+    <section class="landing-explainer" aria-label="What dmarcheck checks">
+      <p>dmarcheck is a free DMARC, SPF, DKIM, BIMI, and MTA-STS checker for any domain. Enter a hostname and it pulls the live DNS records, validates them against the specs, and grades the overall posture from F to A+.</p>
+      <dl class="explainer-grid">
+        <div><dt>DMARC</dt><dd>The policy record that tells receivers how to treat unauthenticated mail and where to send aggregate reports.</dd></div>
+        <div><dt>SPF</dt><dd>The list of hosts authorized to send on your behalf, including the 10-DNS-lookup budget.</dd></div>
+        <div><dt>DKIM</dt><dd>Per-selector signing keys and their key length, checked against 38 common selectors.</dd></div>
+        <div><dt>BIMI</dt><dd>The brand logo record that can render next to authenticated messages in supporting inboxes.</dd></div>
+        <div><dt>MTA-STS</dt><dd>The TLS enforcement policy that prevents downgrade attacks on inbound mail.</dd></div>
+      </dl>
+    </section>
     <div class="learn-link">Analyze message headers: <a href="https://toolbox.googleapps.com/apps/messageheader/" target="_blank" rel="noopener">Google &#8599;</a> &middot; <a href="https://mha.azurewebsites.net/" target="_blank" rel="noopener">Microsoft &#8599;</a></div>
   </div>
   <div class="landing-footer">
@@ -104,7 +178,7 @@ export function renderLandingPage(): string {
     <div class="dmarcus-credit">Guarded by DMarcus ${generateCreature("sm", "content")}</div>
   </div>
 </main>`,
-  );
+  });
 }
 
 export function renderDmarcCard(dmarc: DmarcResult): string {
@@ -190,7 +264,7 @@ function reportBody(result: ScanResult): string {
   <div class="report-header">
     <div class="overall-grade ${gradeClass(result.grade)}">${esc(result.grade)}</div>
     ${result.grade === "S" ? generateCreature("md", "celebrating", true) : ""}
-    <div class="domain-name">${esc(result.domain)}</div>
+    <h1 class="domain-name">${esc(result.domain)}</h1>
   </div>
   ${scoreSnippet(result)}
   <button class="confetti-toggle" data-grade="${esc(result.grade)}"
@@ -218,14 +292,19 @@ function reportBody(result: ScanResult): string {
 }
 
 export function renderReport(result: ScanResult): string {
-  return page(`${result.domain} — dmarcheck`, reportBody(result));
+  return page({
+    title: `${result.domain} — dmarcheck`,
+    path: `/check?domain=${encodeURIComponent(result.domain)}`,
+    description: `Live DMARC, SPF, DKIM, BIMI, and MTA-STS check for ${result.domain}. Grade: ${result.grade}.`,
+    body: reportBody(result),
+  });
 }
 
 export function renderReportHeader(result: ScanResult): string {
   return `<div class="report-header">
     <div class="overall-grade ${gradeClass(result.grade)}">${esc(result.grade)}</div>
     ${result.grade === "S" ? generateCreature("md", "celebrating", true) : ""}
-    <div class="domain-name">${esc(result.domain)}</div>
+    <h1 class="domain-name">${esc(result.domain)}</h1>
   </div>
   ${scoreSnippet(result)}
   <button class="confetti-toggle" data-grade="${esc(result.grade)}"
@@ -277,15 +356,17 @@ export function renderStreamingLoading(
     ? `domain=${encodeURIComponent(domain)}&selectors=${encodeURIComponent(selectors)}`
     : `domain=${encodeURIComponent(domain)}`;
 
-  return page(
-    `Scanning ${domain} — dmarcheck`,
-    `<main class="report" data-qs="${esc(qs)}">
+  return page({
+    title: `Scanning ${domain} — dmarcheck`,
+    path: `/check?domain=${encodeURIComponent(domain)}`,
+    description: `Live DMARC, SPF, DKIM, BIMI, and MTA-STS check for ${domain}.`,
+    body: `<main class="report" data-qs="${esc(qs)}">
   <div class="report-nav">
     <a href="/">${generateCreature("sm")} dmarcheck</a>
   </div>
   <div class="stream-header">
     <div class="grade-skeleton" style="margin:0 auto"></div>
-    <div class="domain-name">${esc(domain)}</div>
+    <h1 class="domain-name">${esc(domain)}</h1>
   </div>
   <div id="protocol-cards">
     ${skeletonCard("MX", false)}
@@ -354,7 +435,7 @@ export function renderStreamingLoading(
   });
 })();
 </script>`,
-  );
+  });
 }
 
 export function renderScoreBreakdown(result: ScanResult): string {
@@ -368,7 +449,7 @@ export function renderScoreBreakdown(result: ScanResult): string {
   <div class="report-header">
     <div class="overall-grade ${gradeClass(result.grade)}">${esc(result.grade)}</div>
     ${result.grade === "S" ? generateCreature("md", "celebrating", true) : ""}
-    <div class="domain-name">${esc(result.domain)}</div>
+    <h1 class="domain-name">${esc(result.domain)}</h1>
   </div>
   <div class="report-meta">
     <time datetime="${esc(result.timestamp)}">Scanned ${esc(new Date(result.timestamp).toUTCString())}</time>
@@ -380,8 +461,68 @@ export function renderScoreBreakdown(result: ScanResult): string {
   <div class="learn-link" style="margin-top:2rem;margin-bottom:1rem"><a href="/scoring">How is my score calculated?</a> &middot; <a href="https://www.cloudflare.com/learning/email-security/dmarc-dkim-spf/" target="_blank" rel="noopener">What is email security? &#8599;</a></div>
 </main>`;
 
-  return page(`Scoring breakdown — ${result.domain} — dmarcheck`, body);
+  return page({
+    title: `Scoring breakdown — ${result.domain} — dmarcheck`,
+    path: `/check/score?domain=${encodeURIComponent(result.domain)}`,
+    description: `Detailed scoring breakdown for ${result.domain}: tier, modifiers, and per-protocol contributions.`,
+    body,
+  });
 }
+
+const SCORING_JSON_LD = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "What is DMARC?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Domain-based Message Authentication, Reporting & Conformance. The policy layer that ties SPF and DKIM together and tells receivers what to do with unauthenticated mail. This is the most important factor in your grade.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "What is SPF?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Sender Policy Framework. A DNS record listing which IP addresses are authorized to send mail for your domain. Receivers check the sending server's IP against this list.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "What is DKIM?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "DomainKeys Identified Mail. Adds a cryptographic signature to outgoing messages, proving they haven't been tampered with in transit. Key strength of 2048 bits or more and multiple selectors improve your score.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "What is BIMI?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Brand Indicators for Message Identification. Displays your brand logo next to authenticated messages in supporting email clients. Requires DMARC p=reject.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "What is MTA-STS?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Mail Transfer Agent Strict Transport Security. Forces TLS encryption for inbound mail delivery, preventing downgrade attacks. Modes: testing (report only) and enforce (reject unencrypted).",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "How is the dmarcheck grade calculated?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "The grade has two parts: a base tier determined by your DMARC policy and authentication setup (F through A+), and modifiers that adjust the grade up (+) or down (-) based on reporting, SPF lookup budget, DKIM key length, BIMI, and MTA-STS.",
+      },
+    },
+  ],
+});
 
 export function renderScoringRubric(): string {
   const body = `<main class="breakdown">
@@ -493,13 +634,21 @@ export function renderScoringRubric(): string {
   </div>
 </main>`;
 
-  return page("Email Security Scoring — dmarcheck", body);
+  return page({
+    title: "Email Security Scoring — dmarcheck",
+    path: "/scoring",
+    description:
+      "How dmarcheck grades email security: DMARC policy tiers, SPF/DKIM requirements, and the modifiers that push grades up or down.",
+    jsonLd: SCORING_JSON_LD,
+    body,
+  });
 }
 
 export function renderError(message: string): string {
-  return page(
-    "Error — dmarcheck",
-    `<main class="landing">
+  return page({
+    title: "Error — dmarcheck",
+    path: "/",
+    body: `<main class="landing">
   <div class="landing-main">
     <div class="logo">${generateCreature("lg", "worried")}<span class="logo-text">dmar<span>check</span></span></div>
     <div class="error-box">
@@ -509,5 +658,5 @@ export function renderError(message: string): string {
     <a href="/">&larr; Try again</a>
   </div>
 </main>`,
-  );
+  });
 }

--- a/src/views/styles.ts
+++ b/src/views/styles.ts
@@ -130,7 +130,24 @@ code { font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace; font-siz
 }
 .logo { font-size: 2.8rem; font-weight: 800; letter-spacing: -0.5px; margin-bottom: 0.5rem; display: flex; align-items: center; gap: 12px; justify-content: center; }
 .logo-text span { color: var(--clr-accent); }
-.tagline { color: var(--clr-text-dim); font-size: 1.1rem; margin-bottom: 2.5rem; text-align: center; }
+h1.tagline, .tagline { color: var(--clr-text-dim); font-size: 1.1rem; font-weight: 400; margin: 0 0 2.5rem; text-align: center; }
+
+/* Landing explainer (SEO / intro copy, below the search form) */
+.landing-explainer {
+  max-width: 760px; margin: 2rem auto 0; padding: 0 0.5rem;
+  color: var(--clr-text-muted); font-size: 0.92rem; line-height: 1.55;
+}
+.landing-explainer p { margin: 0 0 1.25rem; }
+.explainer-grid {
+  display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin: 0;
+}
+.explainer-grid > div { margin: 0; }
+.explainer-grid dt {
+  font-weight: 700; color: var(--clr-text); font-size: 0.85rem;
+  letter-spacing: 0.04em; text-transform: uppercase; margin-bottom: 0.2rem;
+}
+.explainer-grid dd { margin: 0; color: var(--clr-text-dim); font-size: 0.85rem; }
 
 .search-box {
   display: flex; width: 100%; max-width: 560px;
@@ -214,7 +231,7 @@ code { font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace; font-siz
 .report-nav a { font-size: 0.85rem; display: inline-flex; align-items: center; gap: 6px; }
 .report-header { display: flex; align-items: center; gap: 1rem; margin-bottom: 0.5rem; }
 .report-header .creature { margin-left: 8px; }
-.domain-name { font-size: 1.5rem; font-weight: 700; }
+h1.domain-name, .domain-name { font-size: 1.5rem; font-weight: 700; margin: 0; }
 .overall-grade {
   display: inline-flex; align-items: center; justify-content: center;
   width: 44px; height: 44px; border-radius: 10px; font-weight: 800; font-size: 1.2rem;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import app, { normalizeDomain, parseSelectors } from "../src/index.js";
+import { _memoryStore } from "../src/rate-limit.js";
 
 vi.mock("../src/cache.js", () => ({
   getCachedScan: vi.fn().mockResolvedValue(null),
@@ -19,6 +20,13 @@ vi.mock("../src/dns/client.js", () => ({
   queryTxt: vi.fn().mockResolvedValue(null),
   queryMx: vi.fn().mockResolvedValue(null),
 }));
+
+// Rate limit is 10 req/IP/60s and all app.request() calls in this file share
+// the synthetic "unknown" IP. Wipe the in-memory bucket between tests so
+// ordering-dependent 429s don't mask unrelated regressions.
+beforeEach(() => {
+  _memoryStore.clear();
+});
 
 describe("normalizeDomain", () => {
   it("returns null for undefined input", () => {
@@ -387,12 +395,6 @@ describe("HTML head tags", () => {
     expect(html).toContain('rel="manifest"');
   });
 
-  it("includes preconnect hint", async () => {
-    const res = await app.request("/");
-    const html = await res.text();
-    expect(html).toContain('rel="preconnect"');
-  });
-
   it("references external CSS and JS instead of inlining", async () => {
     const res = await app.request("/");
     const html = await res.text();
@@ -400,6 +402,147 @@ describe("HTML head tags", () => {
     expect(html).toContain('<script src="/assets/scripts-');
     expect(html).not.toMatch(/<style>[^<]{500,}<\/style>/);
     expect(html).not.toMatch(/<script>[^<]{500,}<\/script>/);
+  });
+
+  it("includes canonical link, theme-color, and twitter:image", async () => {
+    const res = await app.request("/");
+    const html = await res.text();
+    expect(html).toContain('<link rel="canonical" href="https://dmarc.mx/">');
+    expect(html).toContain('<meta name="theme-color" content="#f97316">');
+    expect(html).toContain(
+      '<meta name="twitter:image" content="https://dmarc.mx/og-image.svg">',
+    );
+    expect(html).toContain(
+      '<meta property="og:url" content="https://dmarc.mx/">',
+    );
+  });
+
+  it("does not include the old self-pointing preconnect", async () => {
+    const res = await app.request("/");
+    const html = await res.text();
+    expect(html).not.toContain('<link rel="preconnect" href="/">');
+  });
+
+  it("landing page uses a proper h1 and includes the explainer section", async () => {
+    const res = await app.request("/");
+    const html = await res.text();
+    expect(html).toMatch(/<h1 class="tagline">[^<]*DMARC[^<]*<\/h1>/);
+    expect(html).toContain('<section class="landing-explainer"');
+    // Keyword targets observed in Search Console: we want these strings on the page
+    expect(html).toContain("DKIM");
+    expect(html).toContain("MTA-STS");
+  });
+
+  it("landing page embeds WebSite + SoftwareApplication JSON-LD", async () => {
+    const res = await app.request("/");
+    const html = await res.text();
+    expect(html).toContain('<script type="application/ld+json">');
+    expect(html).toContain('"@type":"WebSite"');
+    expect(html).toContain('"@type":"SoftwareApplication"');
+    expect(html).toContain("SearchAction");
+  });
+
+  it("scoring page has a canonical pointing to /scoring and FAQ JSON-LD", async () => {
+    const res = await app.request("/scoring");
+    const html = await res.text();
+    expect(html).toContain(
+      '<link rel="canonical" href="https://dmarc.mx/scoring">',
+    );
+    expect(html).toContain('"@type":"FAQPage"');
+    expect(html).toContain("What is DMARC?");
+  });
+});
+
+describe("SEO routes", () => {
+  it("serves /robots.txt with sitemap pointer and API disallow", async () => {
+    const res = await app.request("/robots.txt");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("text/plain; charset=utf-8");
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=86400");
+    const body = await res.text();
+    expect(body).toContain("User-agent: *");
+    expect(body).toContain("Disallow: /api/");
+    expect(body).toContain("Sitemap: https://dmarc.mx/sitemap.xml");
+  });
+
+  it("serves /sitemap.xml listing the core URLs", async () => {
+    const res = await app.request("/sitemap.xml");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe(
+      "application/xml; charset=utf-8",
+    );
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=86400");
+    const body = await res.text();
+    expect(body).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(body).toContain(
+      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    );
+    expect(body).toContain("<loc>https://dmarc.mx/</loc>");
+    expect(body).toContain("<loc>https://dmarc.mx/scoring</loc>");
+    expect(body).toContain(
+      "<loc>https://dmarc.mx/check?domain=github.com</loc>",
+    );
+  });
+
+  it("/robots.txt is NOT marked noindex (must stay crawlable)", async () => {
+    const res = await app.request("/robots.txt");
+    expect(res.headers.get("X-Robots-Tag")).toBeNull();
+  });
+
+  it("/sitemap.xml is NOT marked noindex (must stay crawlable)", async () => {
+    const res = await app.request("/sitemap.xml");
+    expect(res.headers.get("X-Robots-Tag")).toBeNull();
+  });
+});
+
+describe("bare /check request", () => {
+  it("redirects browsers to / when no domain query parameter is supplied", async () => {
+    const res = await app.request("/check");
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/");
+  });
+
+  it("returns 400 JSON to API clients missing the domain parameter", async () => {
+    const res = await app.request("/check?format=json");
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("domain");
+  });
+
+  it("returns 400 to Accept: application/json clients", async () => {
+    const res = await app.request("/check", {
+      headers: { Accept: "application/json" },
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("HTML Cache-Control and X-Robots-Tag", () => {
+  it("sets a short edge Cache-Control on HTML responses", async () => {
+    const res = await app.request("/");
+    const cc = res.headers.get("Cache-Control");
+    expect(cc).toContain("s-maxage=300");
+    expect(cc).toContain("stale-while-revalidate");
+  });
+
+  it("does not set X-Robots-Tag on HTML responses", async () => {
+    const res = await app.request("/");
+    expect(res.headers.get("X-Robots-Tag")).toBeNull();
+  });
+
+  it("sets X-Robots-Tag: noindex on the JSON API", async () => {
+    const res = await app.request("/api/check?domain=dmarc.mx");
+    expect(res.headers.get("X-Robots-Tag")).toBe("noindex");
+  });
+
+  it("sets X-Robots-Tag: noindex on /manifest.webmanifest", async () => {
+    const res = await app.request("/manifest.webmanifest");
+    expect(res.headers.get("X-Robots-Tag")).toBe("noindex");
+  });
+
+  it("sets X-Robots-Tag: noindex on /health JSON", async () => {
+    const res = await app.request("/health");
+    expect(res.headers.get("X-Robots-Tag")).toBe("noindex");
   });
 });
 


### PR DESCRIPTION
## Summary

Landing the SEO foundations the site was missing. Pulled signal from Google Search Console — the site is stranded around average position 75 for high-intent queries (`dmarc check`, `dmarc tester`, `dmarc scanner`) with 0 clicks on 13 impressions, and several mechanical discoverability signals were just absent.

### What GSC showed before this PR

- **Not indexed (4):** `/check` bare (400 Blocked), `http://dmarc.mx/` (HTTP→HTTPS redirect, fine), `/api/check?domain=dmarc.mx` (crawled but not HTML), `/manifest.webmanifest` (crawled but not HTML).
- **Indexed (5):** `/`, `/scoring`, and three `/check?domain=...` example pages. One of them — `/check?domain=github.com` — ranked **position 9** for a long-tail technical query, which is why the report pages also get H1s in this PR.
- **Sitemaps submitted:** 0. `/robots.txt` and `/sitemap.xml` both returned 404.
- **Enhancements detected:** none.

### Changes

- **Crawl guidance**
  - `GET /robots.txt` — allow all, `Disallow: /api/`, link to sitemap.
  - `GET /sitemap.xml` — lists `/`, `/scoring`, and the three example report pages that are already indexed.
  - `GET /check` with no domain: **302 to /** for browsers, **400 JSON/CSV** for API clients. GSC had been flagging the bare URL as "Blocked due to other 4xx issue".
- **Middleware**
  - `X-Robots-Tag: noindex` on `application/json`, `application/manifest+json`, `text/csv`, `text/event-stream` (clears the "Crawled - currently not indexed" noise).
  - `Cache-Control: public, max-age=0, s-maxage=300, stale-while-revalidate=600` on HTML — lets Cloudflare absorb edge traffic and gives CrUX something to measure once CWV data lands.
- **Head template (`page()` in `src/views/html.ts`)** — now accepts an options object with `title`, `body`, `path`, `description`, `jsonLd`. Emits `rel=canonical`, `meta theme-color`, `twitter:image`/`title`/`description`, per-page meta description, and an inline JSON-LD block when supplied. Removed the self-pointing `rel="preconnect"` no-op.
- **Landing page** — promoted the tagline to an `<h1>`, added a short explainer section covering DMARC/SPF/DKIM/BIMI/MTA-STS (direct hits on the queries showing up in GSC), and embedded `WebSite` + `Organization` + `SoftwareApplication` JSON-LD with a `SearchAction`.
- **Scoring page** — embedded `FAQPage` JSON-LD generated from the protocol copy already on the page.
- **Report + score-breakdown pages** — promoted `.domain-name` to `<h1>` to strengthen the signal on the dynamic `/check?domain=...` pages that are already earning long-tail impressions.
- **Tests** — +16 covering routes, head tags, redirect vs 400 split, Cache-Control, X-Robots-Tag, and JSON-LD presence. Added a `beforeEach()` that resets the in-memory rate-limit bucket so cumulative hits across tests don't spuriously 429 each other.

### Out of scope (tracked separately)

- schmug/dmarcheck#101 — Dedicated per-protocol learn pages
- schmug/dmarcheck#102 — Revisit Core Web Vitals once CrUX data is available

## Test plan

- [x] `npm test` — 294 passed (was 278; +16 new SEO tests)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (one pre-existing `as any` warning unrelated to this PR)
- [x] `npm run dev` + curl verification:
  - [x] `/robots.txt` → 200 with `Sitemap: https://dmarc.mx/sitemap.xml`
  - [x] `/sitemap.xml` → 200 `application/xml` with 5 URLs
  - [x] `/check` (bare) → 302 Location `/`
  - [x] `/check` (bare, `Accept: application/json`) → 400 JSON
  - [x] `/api/check?domain=...` → `X-Robots-Tag: noindex`
  - [x] `/manifest.webmanifest` → `X-Robots-Tag: noindex`
  - [x] `/` → `Cache-Control: public, max-age=0, s-maxage=300, stale-while-revalidate=600`, no `X-Robots-Tag`
  - [x] `/` HTML contains `rel="canonical"`, `theme-color`, `twitter:image`, `<h1 class="tagline">`, `landing-explainer`, `WebSite` + `SoftwareApplication` JSON-LD
  - [x] `/scoring` HTML contains `rel="canonical" href="https://dmarc.mx/scoring"` and `FAQPage` JSON-LD
- [ ] **Post-deploy:** URL-inspect `/`, `/scoring`, `/check?domain=github.com` in GSC; submit `https://dmarc.mx/sitemap.xml`; watch ranking for `dmarc check` / `dmarc tester` over 1–2 weeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)