### PR TITLE
🎨 Palette: [UX improvement] Add aria-describedby to custom DKIM selectors input

### DIFF
--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -142,8 +142,8 @@ export function renderLandingPage(): string {
           <label for="selectors">Custom DKIM selectors</label>
           <input type="text" id="selectors" name="selectors"
                  placeholder="e.g. myselector, custom2"
-                 autocomplete="off" />
-          <small>Comma-separated. These are checked in addition to the 38 common selectors.</small>
+                 autocomplete="off" aria-describedby="selectors-help" />
+          <small id="selectors-help">Comma-separated. These are checked in addition to the 38 common selectors.</small>
         </div>
       </details>
     </form>


### PR DESCRIPTION
💡 **What**: Added `aria-describedby` attribute to the "Custom DKIM selectors" input field to programmatically link it to its adjacent `<small>` helper text.
🎯 **Why**: Improves accessibility by ensuring that screen readers properly announce the helper text when the input element receives focus.
📸 **Before/After**: No visual changes to the UI, strictly an accessibility tree improvement.
♿ **Accessibility**: Enhanced screen reader accessibility by creating a programmatic relationship between the input control and its descriptive context.

---
*PR created automatically by Jules for task [5448116614094687975](https://jules.google.com/task/5448116614094687975) started by @schmug*