### PR TITLE
chore(deps): bump hono from 4.12.11 to 4.12.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@sentry/cloudflare": "^10.47.0",
-        "hono": "^4.12.11"
+        "hono": "^4.12.12"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.10",
@@ -1543,9 +1543,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.11",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.11.tgz",
-      "integrity": "sha512-r4xbIa3mGGGoH9nN4A14DOg2wx7y2oQyJEb5O57C/xzETG/qx4c7CVDQ5WMeKHZ7ORk2W0hZ/sQKXTav3cmYBA==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   },
   "dependencies": {
     "@sentry/cloudflare": "^10.47.0",
-    "hono": "^4.12.11"
+    "hono": "^4.12.12"
   }
 }


### PR DESCRIPTION
## Summary

Patch release that fixes five moderate security advisories disclosed against `hono@<=4.12.11`:

| GHSA | Vulnerable API |
|------|----------------|
| `GHSA-wmmm-f939-6g9c` | `serveStatic` middleware bypass via repeated slashes |
| `GHSA-xf4j-xp2r-rqqx` | `toSSG()` path traversal via crafted `ssgParams` |
| `GHSA-xpcf-pg52-r92g` | `ipRestriction()` bypass for IPv4-mapped IPv6 |
| `GHSA-26pp-8wgv-hjvm` | `setCookie()` missing cookie name validation |
| `GHSA-r5rp-j6wh-rvv4` | `getCookie()` non-breaking space prefix bypass |

**dmarcheck has zero actual exposure** — `src/` only imports `Hono`, `hono/cors`, and `hono/streaming`. Grep confirms no use of cookies, `ipRestriction`, `serveStatic`, or `toSSG` anywhere. Bumping clears the `npm audit` noise and the 5 open Dependabot alerts, and protects against future code paths (e.g., if auth/cookies are added later).

Patch version only — hono has zero runtime dependencies, so the lockfile delta is surgical: the caret in `package.json` and the one `node_modules/hono` entry (version + resolved + integrity).

## Why manual instead of waiting for Dependabot

The main directory's `.github/dependabot.yml` sets `open-pull-requests-limit: 5`, and that cap was saturated by the v4/v6 dependency sweep that just landed. Doing the one-line bump by hand is faster than waiting for Dependabot's next run.

## Test plan

- [x] `npm ci` — installs cleanly against the hand-edited lockfile
- [x] `npm run lint` — clean (1 pre-existing warning, also present on main)
- [x] `npm run typecheck` — clean under TS 6
- [x] `npm test` — 296/296 pass under vitest 4
- [x] `npm audit` — `found 0 vulnerabilities`
- [ ] CI green on this PR
- [ ] Dependabot alerts auto-close after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)