### PR TITLE
fix: reject IPv4 literals in normalizeDomain (SSRF defense in depth)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -699,6 +699,19 @@ export function normalizeDomain(raw: string | undefined): string | null {
   if (!/^[a-z0-9.-]+$/.test(domain)) return null;
   // Must have at least one dot
   if (!domain.includes(".")) return null;
+  // Reject IPv4 literals. DMARC/SPF/DKIM/BIMI/MTA-STS records are published
+  // in DNS at domain names, not IPs — there is no legitimate dmarcheck use
+  // case for scanning `1.2.3.4`. This also closes a defense-in-depth gap
+  // around the MTA-STS fetch in `src/analyzers/mta-sts.ts`, which interpolates
+  // the validated domain into a URL (flagged CWE-918 by static analysis);
+  // previously, metadata-service IPs like 169.254.169.254 were only shielded
+  // by the `mta-sts.` prefix happening to route them back through public DNS.
+  // WHATWG URL (used above) normalizes hex, integer, and short-form IPv4
+  // inputs into canonical dotted-decimal, so a single anchored check covers
+  // `0xc0a80101`, `3232235777`, `127.1`, and `1.2.3` as well as plain forms.
+  // `999.999.999.999` throws from `new URL` and is caught by the fallback
+  // branch above, then rejected here by regex shape.
+  if (/^(?:\d{1,3}\.){3}\d{1,3}$/.test(domain)) return null;
   return domain;
 }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -182,8 +182,82 @@ describe("normalizeDomain — XSS payload rejection", () => {
     expect(normalizeDomain("a-b.example.com")).toBe("a-b.example.com");
   });
 
-  it("accepts IPv4 addresses (dotted quads pass the charset)", () => {
-    expect(normalizeDomain("192.168.1.1")).toBe("192.168.1.1");
+  it("accepts numeric subdomain labels (not confused with IPv4 literals)", () => {
+    // Numeric labels in a longer hostname must still be accepted — anchored
+    // IPv4 rejection below must not over-fire on legitimate domains like
+    // `123.example.com` or `1.2.3.4.example.com`.
+    expect(normalizeDomain("123.example.com")).toBe("123.example.com");
+    expect(normalizeDomain("1.2.3.4.example.com")).toBe("1.2.3.4.example.com");
+    expect(normalizeDomain("10.example.com")).toBe("10.example.com");
+  });
+});
+
+describe("normalizeDomain — IPv4 literal rejection", () => {
+  // DMARC/SPF/DKIM/BIMI/MTA-STS records are published in DNS at domain names,
+  // not IP addresses — there is no legitimate dmarcheck use case for scanning
+  // a bare IPv4 literal. Rejecting them at the boundary also closes a
+  // defense-in-depth gap flagged by static analysis around the MTA-STS fetch:
+  // the `mta-sts.<domain>` prefix previously happened to shield metadata-
+  // service IPs like 169.254.169.254 by accident. Make that rejection explicit.
+  //
+  // WHATWG URL (used by `new URL(...).hostname` inside normalizeDomain)
+  // normalizes hex, integer, and short-form IPv4 inputs into canonical dotted-
+  // decimal, so a single anchored regex on the post-URL form catches all of
+  // them. `999.999.999.999` throws from the URL constructor and is caught by
+  // the fallback branch — it must also be rejected as a dotted-quad form.
+
+  it("rejects AWS/GCP metadata service IPv4 (the original motivation)", () => {
+    expect(normalizeDomain("169.254.169.254")).toBeNull();
+  });
+
+  it("rejects loopback IPv4", () => {
+    expect(normalizeDomain("127.0.0.1")).toBeNull();
+  });
+
+  it("rejects RFC 1918 private IPv4 ranges", () => {
+    expect(normalizeDomain("192.168.1.1")).toBeNull();
+    expect(normalizeDomain("10.0.0.1")).toBeNull();
+    expect(normalizeDomain("172.16.0.1")).toBeNull();
+  });
+
+  it("rejects public IPv4 literals", () => {
+    expect(normalizeDomain("1.1.1.1")).toBeNull();
+    expect(normalizeDomain("8.8.8.8")).toBeNull();
+  });
+
+  it("rejects boundary IPv4 values", () => {
+    expect(normalizeDomain("0.0.0.0")).toBeNull();
+    expect(normalizeDomain("255.255.255.255")).toBeNull();
+  });
+
+  it("rejects hex-encoded IPv4 (WHATWG URL normalizes to dotted-decimal)", () => {
+    // 0xc0a80101 === 192.168.1.1; URL constructor canonicalizes before our check.
+    expect(normalizeDomain("0xc0a80101")).toBeNull();
+  });
+
+  it("rejects integer-encoded IPv4 (WHATWG URL normalizes to dotted-decimal)", () => {
+    // 3232235777 === 192.168.1.1
+    expect(normalizeDomain("3232235777")).toBeNull();
+  });
+
+  it("rejects short-form IPv4 (WHATWG URL normalizes to dotted-decimal)", () => {
+    // `127.1` is normalized to `127.0.0.1` by the URL constructor.
+    expect(normalizeDomain("127.1")).toBeNull();
+    // `1.2.3` is silently rewritten to `1.2.0.3` (the third component is
+    // interpreted as a 16-bit word). Previously this surfaced to the user
+    // as a bogus scan of `1.2.0.3` instead of an error.
+    expect(normalizeDomain("1.2.3")).toBeNull();
+  });
+
+  it("rejects out-of-range dotted-quad forms (caught via fallback path)", () => {
+    // `999.999.999.999` throws from the URL constructor and falls through
+    // to the manual-parse branch. It must still be rejected as IPv4-shaped.
+    expect(normalizeDomain("999.999.999.999")).toBeNull();
+  });
+
+  it("rejects IPv4 with http:// prefix", () => {
+    expect(normalizeDomain("http://192.168.1.1")).toBeNull();
+    expect(normalizeDomain("https://169.254.169.254/path")).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

- Reject IPv4 literals at the domain-input boundary in `normalizeDomain` (`src/index.ts`). DMARC/SPF/DKIM/BIMI/MTA-STS records are published in DNS at domain names, not IPs — there is no legitimate dmarcheck use case for scanning a bare IPv4.
- Closes a defense-in-depth gap around the MTA-STS fetch in `src/analyzers/mta-sts.ts` (CWE-918, flagged by a local [foxguard](https://github.com/PwnKit-Labs/foxguard) run). Previously, metadata-service IPs like `169.254.169.254` were shielded only by the `mta-sts.` prefix happening to route them back through public DNS — that defense was accidental, not explicit.
- Incidentally fixes a UX bug: WHATWG URL silently rewrites short-form inputs like `"1.2.3"` to `"1.2.0.3"` (the last component is treated as a 16-bit word), which used to surface to users as a bogus scan of `1.2.0.3` instead of an error. It now returns `null` → "invalid domain."

## Why the single regex is enough

`normalizeDomain` already runs user input through `new URL(\`http://\${domain}\`).hostname`, which canonicalizes every WHATWG-valid IPv4 form into dotted-decimal before our check:

| Input              | Post-URL hostname |
|--------------------|-------------------|
| `0xc0a80101`       | `192.168.1.1`     |
| `3232235777`       | `192.168.1.1`     |
| `127.1`            | `127.0.0.1`       |
| `1.2.3`            | `1.2.0.3`         |
| `169.254.169.254`  | `169.254.169.254` |

So one anchored regex `^(?:\d{1,3}\.){3}\d{1,3}$` covers hex, integer, short-form, and plain dotted-quad. Out-of-range shapes like `999.999.999.999` throw from `new URL`, fall through to the existing fallback parse, and are rejected by the same regex.

Anchoring (`^...$`) preserves legitimate numeric-labeled hostnames — `123.example.com`, `1.2.3.4.example.com`, `10.example.com` all still pass and have explicit preservation tests.

## Test plan

- [x] `npm test` — 306 passed (was 296; +10 new rejection cases)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (one pre-existing `as any` warning in a mock fixture, unrelated to this PR)
- [x] Updated the existing "accepts IPv4 addresses" test — it was added in the XSS fix PR (#59) to document that charset tightening didn't break IPv4, not to assert IPv4 as a product feature — and repurposed it as a preservation contract for numeric-labeled subdomains.
- [x] New `normalizeDomain — IPv4 literal rejection` describe block covers:
  - AWS/GCP metadata service (`169.254.169.254`)
  - Loopback (`127.0.0.1`)
  - RFC 1918 private (`192.168.1.1`, `10.0.0.1`, `172.16.0.1`)
  - Public (`1.1.1.1`, `8.8.8.8`)
  - Boundaries (`0.0.0.0`, `255.255.255.255`)
  - Hex (`0xc0a80101`)
  - Integer (`3232235777`)
  - Short form (`127.1`, `1.2.3`)
  - Out-of-range dotted quads (`999.999.999.999`, exercises the URL-constructor-throws fallback path)
  - With `http://` / `https://` prefix

## Behavior change for users

Previously-accepted inputs that now return an error:

- Any dotted-quad IPv4 (`192.168.1.1`, `8.8.8.8`, etc.)
- WHATWG alternate forms (hex / integer / short) — these were already producing surprising post-normalized scans
- `1.2.3` → was silently scanning `1.2.0.3`, now rejected

None of these produced useful scan results before, so this is a user-facing quality improvement as well as a security hardening.

## Out of scope

- No changes to `src/analyzers/mta-sts.ts`. The `redirect: "manual"` guard and the opaque-redirect rejection there remain load-bearing per the existing comment block and `CLAUDE.md` Security section. This PR only tightens input validation upstream.
- No foxguard CI integration — that's a separate decision. This PR just addresses the one finding that survived triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)