### PR TITLE
ci: gate merges on npm audit for runtime deps (HIGH/CRITICAL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,11 @@ jobs:
       - run: npm run lint
       - run: npm run typecheck
       - run: npm test
+      # Supply-chain gate: block merges on HIGH/CRITICAL CVEs in runtime deps.
+      # --audit-level=high filters out perennial low/moderate noise in transitive
+      # chains that often have no patch available. --omit=dev excludes dev-only
+      # tooling (biome, vitest, wrangler, sharp) which never ships to the Worker
+      # runtime; dev-dep CVEs are still surfaced by Dependabot alerts in the
+      # Security tab, they just don't block PRs here. Tighten if the threat
+      # model expands to cover developer machines.
+      - run: npm audit --audit-level=high --omit=dev


### PR DESCRIPTION
## Summary

- Adds `npm audit --audit-level=high --omit=dev` as the final step of the `check` job in `.github/workflows/ci.yml`. Any HIGH/CRITICAL CVE in a runtime dep now fails the build, and via branch protection on `check`, blocks the merge.
- Forward-looking gate, not a remediation: `npm audit` on `main` today reports **0 vulnerabilities** across both runtime and dev trees.

## Why this is needed

Current dependency-security posture:

| Mechanism | Covers | Gaps |
|---|---|---|
| Dependabot version updates (weekly, `.github/dependabot.yml`) | Bumps versions on a schedule | Not a CVE scanner |
| Dependabot security alerts (repo setting) | Notifies + opens PRs on known CVEs | Async — nothing blocks a PR from landing while a vulnerable lockfile version exists |
| CI `check` job | `npm ci`, lint, typecheck, test | No CVE check |

So today a PR could touch an unrelated file while the lockfile contains a package with an active HIGH advisory, and CI would wave it through. This PR closes that by making the audit a required status.

## Why these specific flags

**`--audit-level=high`**
The top reason teams disable audit gates is low/moderate noise from transitive chains with no patch available. HIGH/CRITICAL is the standard merge-block threshold — tight enough to be meaningful, loose enough that the gate doesn't become an obstacle everyone starts bypassing. Tighten to `moderate` later if the signal holds up.

**`--omit=dev`**
Scopes the gate to what actually ships to the Cloudflare Worker runtime (currently `hono`, `@sentry/cloudflare`). Dev-only tooling (`biome`, `vitest`, `wrangler`, `sharp`) runs on developer machines and in CI, never in production — a dev-dep CVE doesn't endanger end users of dmarc.mx.

Dev-dep CVEs are still surfaced by Dependabot alerts in the **Security tab**, so nothing is hidden; they just don't block PRs. Tighten if the threat model expands to cover developer-laptop compromise.

## Test plan

- [x] `npm audit --audit-level=high --omit=dev` locally → **0 vulnerabilities**, exit 0
- [x] `npm audit` (full, includes dev deps, all severities) → **0 vulnerabilities**, exit 0
- [x] YAML diff is 8 lines added, no other steps touched
- [ ] CI green on this PR (will verify after push)

## Not in scope (follow-ups worth considering)

- **`npm audit signatures`** — verifies Sigstore signatures on packages in the lockfile, catches a class of post-publish tampering that CVE databases miss. Newer and produces non-fatal "unsigned package" warnings by default, so worth its own PR with a trial run first.
- **SAST in CI** — GitHub CodeQL (free on public repos) would catch SSRF/injection classes that neither Biome nor `npm audit` looks at. Different axis of coverage; different PR.
- **Integration test against a real Worker runtime** — the bigger gap in the dev loop. `wrangler dev` smoke test hitting `/api/check?domain=dmarc.mx` would have caught the MTA-STS `redirect: "error"` regression that has landed twice (#58, #92). Higher value per incident-avoided than any of the above, but needs a scoping conversation about target domain and transient DNS handling.
- **Audit the `mta-sts-worker/` subproject** — the subproject only has devDeps (wrangler, workers-types), so `--omit=dev` would be a no-op there today. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)