### PR TITLE
chore(deps): pin @emnapi/core and @emnapi/runtime as direct devDeps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.10",
         "@cloudflare/workers-types": "^4.20260409.1",
+        "@emnapi/core": "^1.9.0",
+        "@emnapi/runtime": "^1.9.0",
         "@types/node": "^25.5.0",
         "sharp": "^0.34.5",
         "typescript": "^6.0.2",
@@ -300,7 +302,8 @@
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260409.1.tgz",
       "integrity": "sha512-0rGuppPeip6dqlI6013wC8tE+kbRK+tcaDfqCxKf9sEHDNfSWWUuKgIEDpt6IHHP2O0iYBQpngk5Siv4CL/HGQ==",
       "devOptional": true,
-      "license": "MIT OR Apache-2.0"
+      "license": "MIT OR Apache-2.0",
+      "peer": true
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -321,7 +324,7 @@
       "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -333,7 +336,7 @@
       "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -344,7 +347,6 @@
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1297,6 +1299,7 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1910,6 +1913,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2131,8 +2135,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/typescript": {
       "version": "6.0.2",
@@ -2171,6 +2174,7 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -2181,6 +2185,7 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -2367,6 +2372,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.10",
     "@cloudflare/workers-types": "^4.20260409.1",
+    "@emnapi/core": "^1.9.0",
+    "@emnapi/runtime": "^1.9.0",
     "@types/node": "^25.5.0",
     "sharp": "^0.34.5",
     "typescript": "^6.0.2",


### PR DESCRIPTION
## Summary

Structural fix for the cross-platform lockfile drift that bit #110 (see commit `01e043c` there for the one-off splice repair). Pins `@emnapi/core` and `@emnapi/runtime` as direct devDependencies so npm 11 on macOS stops stripping them from `package-lock.json` when someone adds an unrelated dep locally.

## The drift chain

```
wrangler (devDep)
  └─ miniflare
       └─ sharp  ← declared directly in devDeps but actually already transitive via miniflare
            └─ @img/sharp-libvips-<platform>
                 └─ @napi-rs/wasm-runtime  (WASM fallback for libvips)
                      ├─ @emnapi/runtime  ← marked optional, stripped on macOS
                      └─ @emnapi/core     ← marked optional, stripped on macOS
```

On `darwin-arm64` the native `sharp-libvips` binary is always available, so npm treats the WASM fallback chain as unused and prunes the two `@emnapi/*` entries from the lockfile. On Linux CI, `npm ci` then rejects the lockfile with:

```
Missing: @emnapi/runtime@1.9.2 from lock file
Missing: @emnapi/core@1.9.2 from lock file
```

Dependabot runs on Linux and keeps `main` correct, but any macOS-side `npm install` between Dependabot runs undoes it. This hits any time we add a dev dep locally — it's already bitten twice in the same session (#110 baseline + the splice commit).

## Why not remove sharp?

I investigated this first. Sharp cannot be removed: it's a **runtime dependency of miniflare**, which is a transitive dep of wrangler. The `"sharp": "^0.34.5"` entry in our own `devDependencies` is redundant with the transitive one — removing it has no effect on the lockfile.

## Why `^1.9.0` specifically

`@napi-rs/wasm-runtime` pins `@emnapi/core@1.9.2` and `@emnapi/runtime@1.9.2` exactly. Our `^1.9.0` constraint is compatible with that exact pin and leaves room for patch bumps. If sharp's chain ever moves to `@emnapi 2.x`, npm will fail resolution with a clear error and we can bump this alongside the sharp update — Dependabot will surface it automatically.

## Test plan

- [x] `npm ci` → exit 0, 173 packages installed
- [x] `npm test` → 306 passed (unchanged vs `main` baseline)
- [x] `npm run typecheck` → clean
- [x] `npm run lint` → 1 pre-existing warning only (the `as any` at `test/index.test.ts:680`, not touched by this PR)
- [x] **Two consecutive `npm install` runs produce byte-identical lockfiles** (stable on macOS)
- [ ] CI green on ubuntu-latest `npm ci` — will verify on push

## Expected side effect in the diff

npm's re-resolution also flipped `"optional": true` → `"peer": true` on a handful of entries (`tslib`, `@cloudflare/workers-types`, `@types/node`, `workerd`, lightningcss-related). This is npm's semantic reinterpretation of the graph after `@emnapi` became a direct dep, **not** platform-specific drift. Linux should produce the same flags — if CI on Linux disagrees, the error will tell us which entries differ and I'll iterate.

## What this does NOT fix

- **Other optional-dep chains** from different packages. If a future dep introduces a similar WASM fallback pattern, we'll need to pin those too. This PR only closes the known-bad `@emnapi` chain.
- **The npm bug itself.** This is a workaround. The real bug is in npm 11.x's optional-dep pruning logic on non-Linux platforms.

## Follow-ups

- If this approach holds up across a few Dependabot cycles, consider adding a CLAUDE.md note under the security/quality section documenting the pattern so anyone adding a similar dep in future knows why the `@emnapi` pin exists.
- If CI is still flaky after this lands, a heavier fix (GitHub Action that regenerates lockfiles on push to Linux, before PR check runs) would eliminate the drift class entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)