### PR TITLE
fix: keep landing footer visible on mobile, polish explainer

### DIFF
--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -128,56 +128,59 @@ export function renderLandingPage(): string {
     path: "/",
     jsonLd: LANDING_JSON_LD,
     body: `<main class="landing">
-  <div class="landing-main">
-    <div class="logo">${generateCreature("lg")}<span class="logo-text">dmar<span>check</span></span></div>
-    <h1 class="tagline">DNS email security analyzer &mdash; DMARC, SPF, DKIM, BIMI &amp; MTA-STS</h1>
-    <form action="/check" method="GET">
-      <div class="search-box">
-        <input type="text" name="domain" placeholder="Enter a domain (e.g., google.com)" aria-label="Enter a domain" autofocus required>
-        <button type="submit">Scan</button>
-      </div>
-      <details class="advanced-options">
-        <summary>Advanced options</summary>
-        <div class="advanced-body">
-          <label for="selectors">Custom DKIM selectors</label>
-          <input type="text" id="selectors" name="selectors"
-                 placeholder="e.g. myselector, custom2"
-                 autocomplete="off"
-                 aria-describedby="selectors-help" />
-          <small id="selectors-help">Comma-separated. These are checked in addition to the 38 common selectors.</small>
+  <div class="landing-hero">
+    <div class="landing-main">
+      <div class="logo">${generateCreature("lg")}<span class="logo-text">dmar<span>check</span></span></div>
+      <h1 class="tagline">DNS email security analyzer &mdash; DMARC, SPF, DKIM, BIMI &amp; MTA-STS</h1>
+      <form action="/check" method="GET">
+        <div class="search-box">
+          <input type="text" name="domain" placeholder="Enter a domain (e.g., google.com)" aria-label="Enter a domain" autofocus required>
+          <button type="submit">Scan</button>
         </div>
-      </details>
-    </form>
-    <div class="examples">
-      Try: <a href="/check?domain=dmarc.mx">dmarc.mx</a> &middot;
-      <a href="/check?domain=google.com">google.com</a> &middot;
-      <a href="/check?domain=github.com">github.com</a>
+        <details class="advanced-options">
+          <summary>Advanced options</summary>
+          <div class="advanced-body">
+            <label for="selectors">Custom DKIM selectors</label>
+            <input type="text" id="selectors" name="selectors"
+                   placeholder="e.g. myselector, custom2"
+                   autocomplete="off"
+                   aria-describedby="selectors-help" />
+            <small id="selectors-help">Comma-separated. These are checked in addition to the 38 common selectors.</small>
+          </div>
+        </details>
+      </form>
+      <div class="examples">
+        Try: <a href="/check?domain=dmarc.mx">dmarc.mx</a> &middot;
+        <a href="/check?domain=google.com">google.com</a> &middot;
+        <a href="/check?domain=github.com">github.com</a>
+      </div>
+      <div class="learn-link">Analyze message headers: <a href="https://toolbox.googleapps.com/apps/messageheader/" target="_blank" rel="noopener">Google &#8599;</a> &middot; <a href="https://mha.azurewebsites.net/" target="_blank" rel="noopener">Microsoft &#8599;</a></div>
     </div>
-    <section class="landing-explainer" aria-label="What dmarcheck checks">
-      <p>dmarcheck is a free DMARC, SPF, DKIM, BIMI, and MTA-STS checker for any domain. Enter a hostname and it pulls the live DNS records, validates them against the specs, and grades the overall posture from F to A+.</p>
-      <dl class="explainer-grid">
-        <div><dt>DMARC</dt><dd>The policy record that tells receivers how to treat unauthenticated mail and where to send aggregate reports.</dd></div>
-        <div><dt>SPF</dt><dd>The list of hosts authorized to send on your behalf, including the 10-DNS-lookup budget.</dd></div>
-        <div><dt>DKIM</dt><dd>Per-selector signing keys and their key length, checked against 38 common selectors.</dd></div>
-        <div><dt>BIMI</dt><dd>The brand logo record that can render next to authenticated messages in supporting inboxes.</dd></div>
-        <div><dt>MTA-STS</dt><dd>The TLS enforcement policy that prevents downgrade attacks on inbound mail.</dd></div>
-      </dl>
-    </section>
-    <div class="learn-link">Analyze message headers: <a href="https://toolbox.googleapps.com/apps/messageheader/" target="_blank" rel="noopener">Google &#8599;</a> &middot; <a href="https://mha.azurewebsites.net/" target="_blank" rel="noopener">Microsoft &#8599;</a></div>
+    <div class="landing-footer">
+      <div class="api-hint">
+        <span>curl</span> https://dmarc.mx/api/check?domain=dmarc.mx
+      </div>
+      <div class="learn-link"><a href="/scoring">How is my score calculated?</a> &middot; <a href="https://www.cloudflare.com/learning/email-security/dmarc-dkim-spf/" target="_blank" rel="noopener">What is email security? &#8599;</a></div>
+      <div class="foss-callout">
+        <a href="https://github.com/schmug/dmarcheck" class="foss-link">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+          Free and open source &mdash; MIT License
+        </a>
+      </div>
+      <div class="dmarcus-credit">Guarded by DMarcus ${generateCreature("sm", "content")}</div>
+    </div>
   </div>
-  <div class="landing-footer">
-    <div class="api-hint">
-      <span>curl</span> https://dmarc.mx/api/check?domain=dmarc.mx
-    </div>
-    <div class="learn-link"><a href="/scoring">How is my score calculated?</a> &middot; <a href="https://www.cloudflare.com/learning/email-security/dmarc-dkim-spf/" target="_blank" rel="noopener">What is email security? &#8599;</a></div>
-    <div class="foss-callout">
-      <a href="https://github.com/schmug/dmarcheck" class="foss-link">
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-        Free and open source &mdash; MIT License
-      </a>
-    </div>
-    <div class="dmarcus-credit">Guarded by DMarcus ${generateCreature("sm", "content")}</div>
-  </div>
+  <section class="landing-explainer" id="what-we-check" aria-labelledby="explainer-heading">
+    <h2 id="explainer-heading">What dmarcheck checks</h2>
+    <p>dmarcheck is a free DMARC, SPF, DKIM, BIMI, and MTA-STS checker for any domain. Enter a hostname and it pulls the live DNS records, validates them against the specs, and grades the overall posture from F to A+.</p>
+    <dl class="explainer-grid">
+      <div><dt>DMARC</dt><dd>The policy record that tells receivers how to treat unauthenticated mail and where to send aggregate reports.</dd></div>
+      <div><dt>SPF</dt><dd>The list of hosts authorized to send on your behalf, including the 10-DNS-lookup budget.</dd></div>
+      <div><dt>DKIM</dt><dd>Per-selector signing keys and their key length, checked against 38 common selectors.</dd></div>
+      <div><dt>BIMI</dt><dd>The brand logo record that can render next to authenticated messages in supporting inboxes.</dd></div>
+      <div><dt>MTA-STS</dt><dd>The TLS enforcement policy that prevents downgrade attacks on inbound mail.</dd></div>
+    </dl>
+  </section>
 </main>`,
   });
 }

--- a/src/views/styles.ts
+++ b/src/views/styles.ts
@@ -116,9 +116,12 @@ a:hover { text-decoration: underline; }
 code { font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace; font-size: 0.9em; }
 
 /* Landing */
-.landing {
+.landing { display: block; }
+.landing-hero {
   display: flex; flex-direction: column; align-items: center;
-  min-height: 100vh; padding: 2rem;
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: 2rem;
 }
 .landing-main {
   flex: 1; display: flex; flex-direction: column; align-items: center;
@@ -132,22 +135,38 @@ code { font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace; font-siz
 .logo-text span { color: var(--clr-accent); }
 h1.tagline, .tagline { color: var(--clr-text-dim); font-size: 1.1rem; font-weight: 400; margin: 0 0 2.5rem; text-align: center; }
 
-/* Landing explainer (SEO / intro copy, below the search form) */
+/* Landing explainer (SEO / intro copy — sits below the hero viewport) */
 .landing-explainer {
-  max-width: 760px; margin: 2rem auto 0; padding: 0 0.5rem;
+  max-width: 860px; margin: 0 auto; padding: 3.5rem 1.5rem 3rem;
+  border-top: 1px solid var(--clr-border);
   color: var(--clr-text-muted); font-size: 0.92rem; line-height: 1.55;
+  scroll-margin-top: 1rem;
 }
-.landing-explainer p { margin: 0 0 1.25rem; }
+.landing-explainer h2 {
+  margin: 0 0 0.5rem; text-align: center;
+  font-size: 1.15rem; font-weight: 700; color: var(--clr-text);
+  letter-spacing: -0.01em;
+}
+.landing-explainer > p {
+  margin: 0 auto 1.75rem; max-width: 680px;
+  text-align: center; color: var(--clr-text-dim);
+}
 .explainer-grid {
-  display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  display: grid; gap: 0.85rem; grid-template-columns: repeat(3, 1fr);
   margin: 0;
 }
-.explainer-grid > div { margin: 0; }
+.explainer-grid > div {
+  margin: 0; padding: 14px 16px;
+  background: var(--clr-surface);
+  border: 1px solid var(--clr-border);
+  border-left: 3px solid var(--clr-accent);
+  border-radius: 8px;
+}
 .explainer-grid dt {
   font-weight: 700; color: var(--clr-text); font-size: 0.85rem;
-  letter-spacing: 0.04em; text-transform: uppercase; margin-bottom: 0.2rem;
+  letter-spacing: 0.04em; text-transform: uppercase; margin-bottom: 0.25rem;
 }
-.explainer-grid dd { margin: 0; color: var(--clr-text-dim); font-size: 0.85rem; }
+.explainer-grid dd { margin: 0; color: var(--clr-text-dim); font-size: 0.88rem; line-height: 1.5; }
 
 .search-box {
   display: flex; width: 100%; max-width: 560px;
@@ -804,6 +823,10 @@ h1.domain-name, .domain-name { font-size: 1.5rem; font-weight: 700; margin: 0; }
 /* Responsive */
 @media (max-width: 640px) {
   .logo { font-size: 2rem; }
+  .landing-hero { padding: 1.5rem 1rem; }
+  .landing-explainer { padding: 2.5rem 1rem 2rem; }
+  .explainer-grid { grid-template-columns: repeat(2, 1fr); gap: 0.75rem; }
+  .explainer-grid > div:last-child { grid-column: 1 / -1; }
   .search-box { flex-direction: column; border-radius: 12px; }
   .search-box button { padding: 14px; }
   .report { padding: 1rem; }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -502,6 +502,9 @@ describe("HTML head tags", () => {
     const html = await res.text();
     expect(html).toMatch(/<h1 class="tagline">[^<]*DMARC[^<]*<\/h1>/);
     expect(html).toContain('<section class="landing-explainer"');
+    expect(html).toContain(
+      '<h2 id="explainer-heading">What dmarcheck checks</h2>',
+    );
     // Keyword targets observed in Search Console: we want these strings on the page
     expect(html).toContain("DKIM");
     expect(html).toContain("MTA-STS");


### PR DESCRIPTION
## Summary
- Move `.landing-explainer` out of `.landing-main` and make it a sibling of a new `.landing-hero` wrapper that owns `min-height: 100dvh`. Fixes the regression from #103 where the SEO explainer pushed the API hint / FOSS callout / DMarcus credit off-screen on mobile, while keeping every explainer string in the DOM for Google.
- Polish the section: top divider, centered `<h2>` "What dmarcheck checks" (one extra on-page heading for SEO; `aria-labelledby` replaces `aria-label`), 3-col card grid on desktop with a 3px orange accent per protocol, 2-col on `<640px` with MTA-STS spanning both cells.
- Upgrade `min-height: 100vh` → `100dvh` on the hero while we're here (iOS URL-bar bug).

## Test plan
- [x] `npm run lint` — clean (pre-existing warning at test/index.test.ts:683 unrelated)
- [x] `npm run typecheck` — clean
- [x] `npm test` — 307/307 passing, including new `<h2 id="explainer-heading">` assertion
- [x] Desktop 1512×758: hero pinned to 758px, `.landing-footer` spans y=578–726 (visible), explainer starts at y=758 with a 3-col grid at 261px/col
- [x] Mobile 375px: grid collapses to 2 cols at 165.5px, MTA-STS spans both cells; natural hero content is 460px (main 233 + footer 179 + padding 48) — fits iPhone SE 667, iPhone 5 568, Android 640 with footer visible
- [x] Dark + light themes: orange accent stripe visible against surface card in both
- [x] SEO contract preserved: `<section class="landing-explainer">`, `<h2>`, `<dl>`, all 5 `<dt>` protocol labels, and intro paragraph all present in raw HTML with no JS

🤖 Generated with [Claude Code](https://claude.com/claude-code)