### PR TITLE
⚡ Bolt: Remove Cache API write latency from critical path

### DIFF
--- a/patch_cache.mjs
+++ b/patch_cache.mjs
@@ -1,0 +1,15 @@
+import fs from 'fs';
+
+let code = fs.readFileSync('src/cache.ts', 'utf8');
+
+code = code.replace(
+  'await cache.put(cacheKey(domain, selectors), resp);',
+  '// ⚡ Bolt Optimization: Do not await cache.put on the critical path.\n    // Return the promise so the caller can pass it to executionCtx.waitUntil(),\n    // removing Cache API write latency from scan endpoints.\n    return cache.put(cacheKey(domain, selectors), resp);'
+);
+
+code = code.replace(
+  'export async function setCachedScan(\n  domain: string,\n  selectors: string[],\n  result: ScanResult,\n): Promise<void> {',
+  'export async function setCachedScan(\n  domain: string,\n  selectors: string[],\n  result: ScanResult,\n): Promise<Promise<void> | void> {'
+);
+
+fs.writeFileSync('src/cache.ts', code);

--- a/patch_cache_2.mjs
+++ b/patch_cache_2.mjs
@@ -1,0 +1,10 @@
+import fs from 'fs';
+
+let code = fs.readFileSync('src/cache.ts', 'utf8');
+
+code = code.replace(
+  'export async function setCachedScan(\n  domain: string,\n  selectors: string[],\n  result: ScanResult,\n): Promise<Promise<void> | void> {',
+  'export function setCachedScan(\n  domain: string,\n  selectors: string[],\n  result: ScanResult,\n): Promise<void> | void {'
+);
+
+fs.writeFileSync('src/cache.ts', code);

--- a/patch_index.mjs
+++ b/patch_index.mjs
@@ -1,0 +1,34 @@
+import fs from 'fs';
+
+let code = fs.readFileSync('src/index.ts', 'utf8');
+
+code = code.replace(
+  'const { allowed, remaining } = await checkRateLimit(ip);',
+  'const { allowed, remaining, pendingWrite } = await checkRateLimit(ip);\n  if (pendingWrite) {\n    c.executionCtx.waitUntil(pendingWrite.catch(() => {}));\n  }'
+);
+code = code.replace(
+  'const { allowed, remaining } = await checkRateLimit(ip);',
+  'const { allowed, remaining, pendingWrite } = await checkRateLimit(ip);\n  if (pendingWrite) {\n    c.executionCtx.waitUntil(pendingWrite.catch(() => {}));\n  }'
+);
+code = code.replace(
+  'const { allowed, remaining } = await checkRateLimit(ip);',
+  'const { allowed, remaining, pendingWrite } = await checkRateLimit(ip);\n  if (pendingWrite) {\n    c.executionCtx.waitUntil(pendingWrite.catch(() => {}));\n  }'
+);
+code = code.replace(
+  'const { allowed, remaining } = await checkRateLimit(ip);',
+  'const { allowed, remaining, pendingWrite } = await checkRateLimit(ip);\n  if (pendingWrite) {\n    c.executionCtx.waitUntil(pendingWrite.catch(() => {}));\n  }'
+);
+
+
+code = code.replace(
+  'await cache.put(cacheKey(domain, selectors), resp);',
+  '// ⚡ Bolt Optimization: Do not await cache.put on the critical path.\n    // Return the promise so the caller can pass it to executionCtx.waitUntil(),\n    // removing Cache API write latency from scan endpoints.\n    return cache.put(cacheKey(domain, selectors), resp);'
+);
+
+code = code.replace(
+  'export async function setCachedScan(\n  domain: string,\n  selectors: string[],\n  result: ScanResult,\n): Promise<void> {',
+  'export async function setCachedScan(\n  domain: string,\n  selectors: string[],\n  result: ScanResult,\n): Promise<Promise<void> | void> {'
+);
+
+
+fs.writeFileSync('src/index.ts', code);

--- a/patch_index_2.mjs
+++ b/patch_index_2.mjs
@@ -1,0 +1,22 @@
+import fs from 'fs';
+
+let code = fs.readFileSync('src/index.ts', 'utf8');
+
+code = code.replace(
+  'if (!cached) setCachedScan(domain, selectors, result);',
+  'if (!cached) {\n      const pendingCacheWrite = await setCachedScan(domain, selectors, result);\n      if (pendingCacheWrite) {\n        c.executionCtx.waitUntil(pendingCacheWrite.catch(() => {}));\n      }\n    }'
+);
+code = code.replace(
+  'if (!cached) setCachedScan(domain, selectors, result);',
+  'if (!cached) {\n      const pendingCacheWrite = await setCachedScan(domain, selectors, result);\n      if (pendingCacheWrite) {\n        c.executionCtx.waitUntil(pendingCacheWrite.catch(() => {}));\n      }\n    }'
+);
+code = code.replace(
+  'if (!cached) setCachedScan(domain, selectors, result);',
+  'if (!cached) {\n      const pendingCacheWrite = await setCachedScan(domain, selectors, result);\n      if (pendingCacheWrite) {\n        c.executionCtx.waitUntil(pendingCacheWrite.catch(() => {}));\n      }\n    }'
+);
+code = code.replace(
+  'setCachedScan(domain, selectors, result);',
+  'const pendingCacheWrite = await setCachedScan(domain, selectors, result);\n    if (pendingCacheWrite) {\n      c.executionCtx.waitUntil(pendingCacheWrite.catch(() => {}));\n    }'
+);
+
+fs.writeFileSync('src/index.ts', code);

--- a/patch_index_3.mjs
+++ b/patch_index_3.mjs
@@ -1,0 +1,20 @@
+import fs from 'fs';
+
+let code = fs.readFileSync('src/index.ts', 'utf8');
+
+code = code.replace(
+  'const pendingCacheWrite = await setCachedScan(domain, selectors, result);',
+  'const pendingCacheWrite = setCachedScan(domain, selectors, result);'
+);
+code = code.replace(
+  'const pendingCacheWrite = await setCachedScan(domain, selectors, result);',
+  'const pendingCacheWrite = setCachedScan(domain, selectors, result);'
+);
+
+code = code.replace(
+  'const pendingCacheWrite = await setCachedScan(\n          domain,\n          selectors,\n          result,\n        );',
+  'const pendingCacheWrite = setCachedScan(\n          domain,\n          selectors,\n          result,\n        );'
+);
+
+
+fs.writeFileSync('src/index.ts', code);

--- a/patch_rate_limit.js
+++ b/patch_rate_limit.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+let code = fs.readFileSync('src/rate-limit.ts', 'utf8');
+
+code = code.replace(
+  'export async function checkRateLimit(\n  ip: string,\n): Promise<{ allowed: boolean; remaining: number }> {',
+  'export async function checkRateLimit(\n  ip: string,\n): Promise<{ allowed: boolean; remaining: number; pendingWrite?: Promise<void> }> {'
+);
+
+code = code.replace(
+  'async function checkRateLimitCache(\n  ip: string,\n): Promise<{ allowed: boolean; remaining: number }> {',
+  'async function checkRateLimitCache(\n  ip: string,\n): Promise<{ allowed: boolean; remaining: number; pendingWrite?: Promise<void> }> {'
+);
+
+code = code.replace(
+  '  await cache.put(key, response);\n\n  return { allowed, remaining };',
+  '  // ⚡ Bolt Optimization: Do not await cache.put on the critical path.\n  // Return the promise so the caller can pass it to executionCtx.waitUntil(),\n  // removing Cache API write latency from every rate-limited request.\n  const pendingWrite = cache.put(key, response);\n\n  return { allowed, remaining, pendingWrite };'
+);
+
+fs.writeFileSync('src/rate-limit.ts', code);

--- a/patch_rate_limit.mjs
+++ b/patch_rate_limit.mjs
@@ -1,0 +1,20 @@
+import fs from 'fs';
+
+let code = fs.readFileSync('src/rate-limit.ts', 'utf8');
+
+code = code.replace(
+  'export async function checkRateLimit(\n  ip: string,\n): Promise<{ allowed: boolean; remaining: number }> {',
+  'export async function checkRateLimit(\n  ip: string,\n): Promise<{ allowed: boolean; remaining: number; pendingWrite?: Promise<void> }> {'
+);
+
+code = code.replace(
+  'async function checkRateLimitCache(\n  ip: string,\n): Promise<{ allowed: boolean; remaining: number }> {',
+  'async function checkRateLimitCache(\n  ip: string,\n): Promise<{ allowed: boolean; remaining: number; pendingWrite?: Promise<void> }> {'
+);
+
+code = code.replace(
+  '  await cache.put(key, response);\n\n  return { allowed, remaining };',
+  '  // ⚡ Bolt Optimization: Do not await cache.put on the critical path.\n  // Return the promise so the caller can pass it to executionCtx.waitUntil(),\n  // removing Cache API write latency from every rate-limited request.\n  const pendingWrite = cache.put(key, response);\n\n  return { allowed, remaining, pendingWrite };'
+);
+
+fs.writeFileSync('src/rate-limit.ts', code);

--- a/patch_test.mjs
+++ b/patch_test.mjs
@@ -1,0 +1,10 @@
+import fs from 'fs';
+
+let code = fs.readFileSync('test/index.test.ts', 'utf8');
+
+code = code.replace(
+  '} as any,',
+  '} as unknown as ScanResult,'
+);
+
+fs.writeFileSync('test/index.test.ts', code);

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -24,11 +24,11 @@ export async function getCachedScan(
   }
 }
 
-export async function setCachedScan(
+export function setCachedScan(
   domain: string,
   selectors: string[],
   result: ScanResult,
-): Promise<void> {
+): Promise<void> | void {
   try {
     if (typeof caches === "undefined" || !caches.default) return;
     const cache = caches.default;
@@ -38,7 +38,10 @@ export async function setCachedScan(
         "Cache-Control": `s-maxage=${CACHE_TTL_SECONDS}, stale-while-revalidate=${STALE_REVALIDATE_SECONDS}`,
       },
     });
-    await cache.put(cacheKey(domain, selectors), resp);
+    // ⚡ Bolt Optimization: Do not await cache.put on the critical path.
+    // Return the promise so the caller can pass it to executionCtx.waitUntil(),
+    // removing Cache API write latency from scan endpoints.
+    return cache.put(cacheKey(domain, selectors), resp);
   } catch {
     // Cache write failure is non-fatal
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,7 +162,10 @@ function getClientIp(c: Context): string {
 // Rate limit scan endpoints (not the landing page)
 app.use("/check", async (c, next) => {
   const ip = getClientIp(c);
-  const { allowed, remaining } = await checkRateLimit(ip);
+  const { allowed, remaining, pendingWrite } = await checkRateLimit(ip);
+  if (pendingWrite) {
+    c.executionCtx.waitUntil(pendingWrite.catch(() => {}));
+  }
 
   if (!allowed) {
     const headers = rateLimitHeaders(remaining);
@@ -193,7 +196,10 @@ app.use("/check", async (c, next) => {
 
 app.use("/check/score", async (c, next) => {
   const ip = getClientIp(c);
-  const { allowed, remaining } = await checkRateLimit(ip);
+  const { allowed, remaining, pendingWrite } = await checkRateLimit(ip);
+  if (pendingWrite) {
+    c.executionCtx.waitUntil(pendingWrite.catch(() => {}));
+  }
 
   if (!allowed) {
     const headers = rateLimitHeaders(remaining);
@@ -214,7 +220,10 @@ app.use("/check/score", async (c, next) => {
 
 app.use("/api/check", async (c, next) => {
   const ip = getClientIp(c);
-  const { allowed, remaining } = await checkRateLimit(ip);
+  const { allowed, remaining, pendingWrite } = await checkRateLimit(ip);
+  if (pendingWrite) {
+    c.executionCtx.waitUntil(pendingWrite.catch(() => {}));
+  }
 
   if (!allowed) {
     const headers = rateLimitHeaders(remaining);
@@ -236,7 +245,10 @@ app.use("/api/check", async (c, next) => {
 // Give it its own limiter so it cannot be used as a DNS amplification vector.
 app.use("/api/check/stream", async (c, next) => {
   const ip = getClientIp(c);
-  const { allowed, remaining } = await checkRateLimit(ip);
+  const { allowed, remaining, pendingWrite } = await checkRateLimit(ip);
+  if (pendingWrite) {
+    c.executionCtx.waitUntil(pendingWrite.catch(() => {}));
+  }
 
   if (!allowed) {
     const headers = rateLimitHeaders(remaining);
@@ -339,7 +351,10 @@ app.get("/api/check/stream", async (c) => {
     );
 
     tagScanResult(result);
-    setCachedScan(domain, selectors, result);
+    const pendingCacheWrite = setCachedScan(domain, selectors, result);
+    if (pendingCacheWrite) {
+      c.executionCtx.waitUntil(pendingCacheWrite.catch(() => {}));
+    }
 
     stream.writeSSE({
       event: "done",
@@ -556,7 +571,12 @@ app.get("/api/check", async (c) => {
     });
     const result = cached ?? (await scan(domain, selectors));
     tagScanResult(result);
-    if (!cached) setCachedScan(domain, selectors, result);
+    if (!cached) {
+      const pendingCacheWrite = setCachedScan(domain, selectors, result);
+      if (pendingCacheWrite) {
+        c.executionCtx.waitUntil(pendingCacheWrite.catch(() => {}));
+      }
+    }
 
     if (c.req.query("format") === "csv") {
       return c.body(generateCsv(result), 200, {
@@ -682,7 +702,12 @@ app.get("/check", async (c) => {
       });
       const result = cached ?? (await scan(domain, selectors));
       tagScanResult(result);
-      if (!cached) setCachedScan(domain, selectors, result);
+      if (!cached) {
+        const pendingCacheWrite = setCachedScan(domain, selectors, result);
+        if (pendingCacheWrite) {
+          c.executionCtx.waitUntil(pendingCacheWrite.catch(() => {}));
+        }
+      }
       return c.html(renderReport(result));
     } catch (err) {
       Sentry.captureException(err);

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -6,9 +6,11 @@ const memoryStore = new Map<string, { count: number; expires: number }>();
 let callCount = 0;
 const SWEEP_INTERVAL = 100;
 
-export async function checkRateLimit(
-  ip: string,
-): Promise<{ allowed: boolean; remaining: number }> {
+export async function checkRateLimit(ip: string): Promise<{
+  allowed: boolean;
+  remaining: number;
+  pendingWrite?: Promise<void>;
+}> {
   try {
     if (typeof caches !== "undefined" && caches.default) {
       return await checkRateLimitCache(ip);
@@ -19,9 +21,11 @@ export async function checkRateLimit(
   return checkRateLimitMemory(ip);
 }
 
-async function checkRateLimitCache(
-  ip: string,
-): Promise<{ allowed: boolean; remaining: number }> {
+async function checkRateLimitCache(ip: string): Promise<{
+  allowed: boolean;
+  remaining: number;
+  pendingWrite?: Promise<void>;
+}> {
   const cache = caches.default;
   const key = new Request(`https://dmarc-mx-ratelimit.internal/${ip}`);
 
@@ -41,9 +45,12 @@ async function checkRateLimitCache(
       "Cache-Control": `s-maxage=${WINDOW_SECONDS}`,
     },
   });
-  await cache.put(key, response);
+  // ⚡ Bolt Optimization: Do not await cache.put on the critical path.
+  // Return the promise so the caller can pass it to executionCtx.waitUntil(),
+  // removing Cache API write latency from every rate-limited request.
+  const pendingWrite = cache.put(key, response);
 
-  return { allowed, remaining };
+  return { allowed, remaining, pendingWrite };
 }
 
 function checkRateLimitMemory(ip: string): {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -810,7 +810,7 @@ describe("SSE streaming cache", () => {
           bimi: { status: "fail", summary: "No BIMI record" },
           mta_sts: { status: "fail", summary: "No MTA-STS policy" },
         },
-      } as any,
+      } as unknown as ScanResult,
       summary: {
         mx_records: 1,
         mx_providers: ["Google Workspace"],


### PR DESCRIPTION
**💡 What:** Removed `await` from `cache.put()` calls in `src/cache.ts` and `src/rate-limit.ts`. The returned Promise is now passed up to the Hono context and handled via `c.executionCtx.waitUntil()`.

**🎯 Why:** In Cloudflare Workers, writing to the Cache API adds measurable latency to the request lifecycle (typically 5–30ms). Awaiting these writes on the critical path delays the response to the user unnecessarily. This is especially impactful for the rate limiter, which runs on every single request.

**📊 Impact:** Decreases response latency for all endpoints by the duration of a Cache API write operation. Rate-limited endpoints will see the most consistent benefit.

**🔬 Measurement:** Verified by running the test suite (`pnpm test`) and typechecker to ensure the `waitUntil` usage and type signatures are correct and do not introduce unhandled promise rejections.

---
*PR created automatically by Jules for task [6936733336993637466](https://jules.google.com/task/6936733336993637466) started by @schmug*