### PR TITLE
🎨 Palette: Add global keyboard focus and disabled button states

### DIFF
--- a/src/views/styles.ts
+++ b/src/views/styles.ts
@@ -113,6 +113,15 @@ body {
 }
 a { color: var(--clr-accent); text-decoration: none; }
 a:hover { text-decoration: underline; }
+a:focus-visible, button:focus-visible, summary:focus-visible {
+  outline: 2px solid var(--clr-accent);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
 code { font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace; font-size: 0.9em; }
 
 /* Landing */


### PR DESCRIPTION
**💡 What:** 
Added global `:focus-visible` styles to `a`, `button`, and `summary` elements. Added a consistent visual treatment for `button:disabled` elements (opacity and `cursor: not-allowed`).

**🎯 Why:** 
The application previously lacked clear, global focus states for keyboard navigation, making it difficult for keyboard users to see which element had focus. Disabled buttons also lacked a consistent visual indication that they could not be clicked.

**📸 Before/After:** 
Before, tabbing to buttons or links showed default browser outlines (or no outlines depending on the browser).
Now, tabbing highlights interactive elements with a clear 2px accent-colored outline with a slight offset, which matches the application's design system.

**♿ Accessibility:** 
Improves keyboard navigation visibility significantly for screen reader users and power users who navigate via `Tab`. The disabled treatment also clarifies interactive states for all users.

---
*PR created automatically by Jules for task [9083230897839356262](https://jules.google.com/task/9083230897839356262) started by @schmug*