### PR TITLE
feat: allow cortech.online to embed dmarc.mx via iframe (#116)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -95,10 +95,15 @@ const NOINDEX_CONTENT_TYPES = [
   "text/event-stream",
 ];
 
+// Origins permitted to embed the HTML report in an iframe. Anything not listed
+// here (including subdomains) is blocked by the `frame-ancestors` directive
+// below. X-Frame-Options is intentionally NOT set — older browsers honor it
+// over `frame-ancestors`, which would defeat this allowlist.
+const EMBED_ALLOWED_ORIGINS = ["https://cortech.online"];
+
 app.use("*", async (c, next) => {
   await next();
   c.res.headers.set("X-Content-Type-Options", "nosniff");
-  c.res.headers.set("X-Frame-Options", "DENY");
   c.res.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
   c.res.headers.set(
     "Permissions-Policy",
@@ -108,9 +113,10 @@ app.use("*", async (c, next) => {
   const contentType = c.res.headers.get("content-type") ?? "";
   const isHtml = contentType.includes("text/html");
   if (isHtml) {
+    const frameAncestors = ["'self'", ...EMBED_ALLOWED_ORIGINS].join(" ");
     c.res.headers.set(
       "Content-Security-Policy",
-      `default-src 'none'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; manifest-src 'self'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'`,
+      `default-src 'none'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; manifest-src 'self'; form-action 'self'; base-uri 'none'; frame-ancestors ${frameAncestors}`,
     );
     // Short edge cache so Cloudflare can absorb landing/scoring/report traffic
     // without hitting the Worker on every request. Browsers still revalidate.
@@ -121,7 +127,12 @@ app.use("*", async (c, next) => {
       );
     }
   } else {
-    c.res.headers.set("Content-Security-Policy", "default-src 'none'");
+    // `frame-ancestors` does not inherit from `default-src`, so it must be
+    // declared explicitly to keep JSON/CSV/SSE responses unframable.
+    c.res.headers.set(
+      "Content-Security-Policy",
+      "default-src 'none'; frame-ancestors 'none'",
+    );
   }
 
   // Keep the JSON API, CSV exports, the SSE stream, and the PWA manifest out

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -352,7 +352,7 @@ describe("CSV format routes", () => {
   it("sets strict CSP on CSV responses (non-HTML)", async () => {
     const res = await app.request("/api/check?domain=&format=csv");
     const csp = res.headers.get("Content-Security-Policy");
-    expect(csp).toBe("default-src 'none'");
+    expect(csp).toBe("default-src 'none'; frame-ancestors 'none'");
   });
 });
 
@@ -360,13 +360,24 @@ describe("security headers", () => {
   it("sets security headers on landing page", async () => {
     const res = await app.request("/");
     expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
-    expect(res.headers.get("X-Frame-Options")).toBe("DENY");
     expect(res.headers.get("Referrer-Policy")).toBe(
       "strict-origin-when-cross-origin",
     );
     expect(res.headers.get("Permissions-Policy")).toBe(
       "camera=(), microphone=(), geolocation=()",
     );
+  });
+
+  // X-Frame-Options would override `frame-ancestors` in older browsers and
+  // defeat the cortech.online embed allowlist, so it must not be sent.
+  it("does not set X-Frame-Options on HTML responses", async () => {
+    const res = await app.request("/");
+    expect(res.headers.get("X-Frame-Options")).toBeNull();
+  });
+
+  it("does not set X-Frame-Options on non-HTML responses", async () => {
+    const res = await app.request("/api/check?domain=");
+    expect(res.headers.get("X-Frame-Options")).toBeNull();
   });
 
   it("sets CSP with inline scripts allowed on HTML responses", async () => {
@@ -376,13 +387,22 @@ describe("security headers", () => {
       "script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com",
     );
     expect(csp).toContain("style-src 'self' 'unsafe-inline'");
-    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).toContain("frame-ancestors 'self' https://cortech.online");
   });
 
-  it("sets strict CSP on JSON responses", async () => {
+  it("allows only cortech.online to embed (no wildcards, exact origin)", async () => {
+    const res = await app.request("/");
+    const csp = res.headers.get("Content-Security-Policy") ?? "";
+    const match = csp.match(/frame-ancestors ([^;]+)/);
+    expect(match).not.toBeNull();
+    const sources = match?.[1].trim().split(/\s+/) ?? [];
+    expect(sources).toEqual(["'self'", "https://cortech.online"]);
+  });
+
+  it("sets strict CSP with frame-ancestors 'none' on JSON responses", async () => {
     const res = await app.request("/api/check?domain=");
     const csp = res.headers.get("Content-Security-Policy");
-    expect(csp).toBe("default-src 'none'");
+    expect(csp).toBe("default-src 'none'; frame-ancestors 'none'");
   });
 
   it("does not include HSTS header (handled by Cloudflare)", async () => {


### PR DESCRIPTION
Closes #116.

## Summary
- Drop `X-Frame-Options: DENY` — older browsers honor XFO over `frame-ancestors`, which would defeat the allowlist.
- HTML responses: `frame-ancestors 'self' https://cortech.online` (exact origin, no subdomain wildcard, HTTPS-only).
- Non-HTML responses (JSON/CSV/SSE): add explicit `frame-ancestors 'none'` since the directive does not inherit from `default-src`. Keeps API responses unframable now that XFO is gone.
- Allowlist centralized in `EMBED_ALLOWED_ORIGINS` for easy audit.

## Security notes
- Only `https://cortech.online` (exact match) can frame. No subdomains, no HTTP, no wildcards.
- dmarc.mx is stateless and has no auth/cookies, so clickjacking blast radius is bounded — worst case is a single rate-limited scan triggered on a domain the attacker chose.
- The same-origin policy still blocks cortech.online from reading the iframe's DOM/cookies; only framing is allowed.

## Test plan
- [x] `npm test` — 325 tests pass (322 baseline + 3 new for the allowlist + non-HTML CSP).
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — only the pre-existing `as any` warning at `test/index.test.ts:833`.
- [ ] After deploy, `curl -sI https://dmarc.mx/ | grep -iE 'content-security-policy|x-frame-options'` shows the new CSP and no XFO.
- [ ] Embed loads inside cortech.online with no console errors.
- [ ] Iframe attempt from a third-party origin is blocked by the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)