### PR TITLE
🎨 Palette: Add global keyboard focus visibility and disabled button styles

### DIFF
--- a/src/views/styles.ts
+++ b/src/views/styles.ts
@@ -113,6 +113,18 @@ body {
 }
 a { color: var(--clr-accent); text-decoration: none; }
 a:hover { text-decoration: underline; }
+
+a:focus-visible, button:focus-visible, summary:focus-visible {
+  outline: 2px solid var(--clr-accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
 code { font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace; font-size: 0.9em; }
 
 /* Landing */


### PR DESCRIPTION
💡 **What:** Added global `:focus-visible` styles for interactive elements (`a`, `button`, `summary`) and styled disabled buttons (`button:disabled`).

🎯 **Why:** To improve the accessibility baseline of the application. The absence of a global `:focus-visible` ring made keyboard navigation extremely difficult as interactive elements did not give visual feedback when focused. Additionally, buttons in a disabled state appeared active.

📸 **Before/After:**
*(Before)* Keyboard navigation gave no visual feedback on major components like the scan button and "Advanced options" summary.
*(After)* Focus is now clearly indicated by an accent-colored outline on all standard interactive elements.

♿ **Accessibility:**
- Ensures all standard interactive elements visually display keyboard focus.
- Improves cognitive feedback by distinctly styling disabled controls.

---
*PR created automatically by Jules for task [13322574631614708528](https://jules.google.com/task/13322574631614708528) started by @schmug*