### PR TITLE
claude/cache-domain-per-grade-34fIb

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,6 +1,34 @@
 import type { ScanResult } from "./analyzers/types.js";
 
 const CACHE_TTL_SECONDS = 300; // 5 minutes
+const GRADE_CACHE_TTL_SECONDS = 3600; // 1 hour
+
+const ALL_GRADES = [
+  "A+",
+  "A",
+  "A-",
+  "B+",
+  "B",
+  "B-",
+  "C+",
+  "C",
+  "C-",
+  "D+",
+  "D",
+  "D-",
+  "F",
+] as const;
+
+export interface GradeExample {
+  domain: string;
+  timestamp: string;
+}
+
+function gradeKey(grade: string): Request {
+  return new Request(
+    `https://dmarc-mx-cache.internal/_grade/${encodeURIComponent(grade)}`,
+  );
+}
 
 function cacheKey(domain: string, selectors: string[]): Request {
   const sorted = [...selectors].sort().join(",");
@@ -38,7 +66,59 @@ export async function setCachedScan(
       },
     });
     await cache.put(cacheKey(domain, selectors), resp);
+    // Fire-and-forget: track last domain per grade
+    setLastDomainForGrade(result.grade, domain);
   } catch {
     // Cache write failure is non-fatal
   }
+}
+
+async function setLastDomainForGrade(
+  grade: string,
+  domain: string,
+): Promise<void> {
+  try {
+    if (typeof caches === "undefined" || !caches.default) return;
+    const cache = caches.default;
+    const body: GradeExample = {
+      domain,
+      timestamp: new Date().toISOString(),
+    };
+    const resp = new Response(JSON.stringify(body), {
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": `s-maxage=${GRADE_CACHE_TTL_SECONDS}`,
+      },
+    });
+    await cache.put(gradeKey(grade), resp);
+  } catch {
+    // Non-fatal
+  }
+}
+
+export async function getAllGradeExamples(): Promise<
+  Record<string, GradeExample | null>
+> {
+  const result: Record<string, GradeExample | null> = {};
+  try {
+    if (typeof caches === "undefined" || !caches.default) {
+      for (const g of ALL_GRADES) result[g] = null;
+      return result;
+    }
+    const cache = caches.default;
+    const entries = await Promise.all(
+      ALL_GRADES.map(async (grade) => {
+        const resp = await cache.match(gradeKey(grade));
+        if (!resp) return [grade, null] as const;
+        const data = (await resp.json()) as GradeExample;
+        return [grade, data] as const;
+      }),
+    );
+    for (const [grade, data] of entries) {
+      result[grade] = data;
+    }
+  } catch {
+    for (const g of ALL_GRADES) result[g] = null;
+  }
+  return result;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import type {
   MxResult,
   SpfResult,
 } from "./analyzers/types.js";
-import { getCachedScan, setCachedScan } from "./cache.js";
+import { getAllGradeExamples, getCachedScan, setCachedScan } from "./cache.js";
 import { generateCsv } from "./csv.js";
 import type { ProtocolId, ProtocolResult } from "./orchestrator.js";
 import { scan, scanStreaming } from "./orchestrator.js";
@@ -329,6 +329,11 @@ app.get("/api/check", async (c) => {
     const message = err instanceof Error ? err.message : "Internal error";
     return c.json({ error: message }, 500);
   }
+});
+
+app.get("/api/grades/latest", async (c) => {
+  const grades = await getAllGradeExamples();
+  return c.json({ grades });
 });
 
 app.get("/check/score", async (c) => {

--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -88,6 +88,7 @@ export function renderLandingPage(): string {
       <a href="/check?domain=google.com">google.com</a> &middot;
       <a href="/check?domain=github.com">github.com</a>
     </div>
+    <div id="recent-grades" class="recent-grades"></div>
     <div class="learn-link">Analyze message headers: <a href="https://toolbox.googleapps.com/apps/messageheader/" target="_blank" rel="noopener">Google &#8599;</a> &middot; <a href="https://mha.azurewebsites.net/" target="_blank" rel="noopener">Microsoft &#8599;</a></div>
   </div>
   <div class="landing-footer">

--- a/src/views/scripts.ts
+++ b/src/views/scripts.ts
@@ -590,4 +590,39 @@ if (!window.__dmarcheckBound) {
     isActive = false;
   }
 })();
+
+/* Recent grades on landing page */
+(function() {
+  var el = document.getElementById('recent-grades');
+  if (!el) return;
+  fetch('/api/grades/latest').then(function(r) { return r.json(); }).then(function(data) {
+    var grades = data.grades;
+    var order = ['A+','A','A-','B+','B','B-','C+','C','C-','D+','D','D-','F'];
+    var items = [];
+    for (var i = 0; i < order.length; i++) {
+      var g = order[i];
+      if (grades[g] && grades[g].domain) {
+        items.push({ grade: g, domain: grades[g].domain });
+      }
+    }
+    if (items.length === 0) return;
+    /* Pick up to 4 spread across the grade spectrum */
+    var picks = [];
+    if (items.length <= 4) { picks = items; }
+    else {
+      var step = (items.length - 1) / 3;
+      for (var j = 0; j < 4; j++) {
+        picks.push(items[Math.round(j * step)]);
+      }
+    }
+    var html = 'Recent: ';
+    for (var k = 0; k < picks.length; k++) {
+      if (k > 0) html += ' &middot; ';
+      var letter = picks[k].grade.charAt(0).toUpperCase();
+      var cls = (letter === 'A' || letter === 'B') ? 'grade-a' : (letter === 'C' || letter === 'D') ? 'grade-c' : 'grade-f';
+      html += '<a href="/check?domain=' + encodeURIComponent(picks[k].domain) + '">' + picks[k].domain + '</a> <span class="grade-pill ' + cls + '">' + picks[k].grade + '</span>';
+    }
+    el.innerHTML = html;
+  }).catch(function() {});
+})();
 `;

--- a/src/views/styles.ts
+++ b/src/views/styles.ts
@@ -180,6 +180,9 @@ code { font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace; font-siz
 .landing-footer .api-hint { margin-top: 0; margin-bottom: 0.75rem; }
 .landing-footer .foss-callout { margin-top: 0; }
 .examples { margin-top: 2rem; color: var(--clr-text-faint); font-size: 0.85rem; }
+.recent-grades { margin-top: 0.75rem; color: var(--clr-text-faint); font-size: 0.85rem; }
+.recent-grades:empty { display: none; }
+.grade-pill { display: inline-block; padding: 1px 6px; border-radius: 4px; font-size: 0.75rem; font-weight: 600; vertical-align: middle; }
 .api-hint {
   margin-top: 1.5rem; padding: 10px 16px; background: var(--clr-surface); border: 1px solid var(--clr-border);
   border-radius: 8px; font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.78rem; color: var(--clr-text-dim);


### PR DESCRIPTION
Track the most recent domain scanned for each grade level using the
Cloudflare Cache API (1-hour TTL). Add GET /api/grades/latest endpoint
and show a "Recent:" row on the landing page with grade-colored pills.

https://claude.ai/code/session_017oaSxUhP8s4a8WmnTaLv89