### PR TITLE
🎨 Palette: Improve screen reader announcements for loading and error states

### DIFF
--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -655,7 +655,7 @@ export function renderError(message: string): string {
     body: `<main class="landing">
   <div class="landing-main">
     <div class="logo">${generateCreature("lg", "worried")}<span class="logo-text">dmar<span>check</span></span></div>
-    <div class="error-box">
+    <div class="error-box" role="alert">
       <h3>Error</h3>
       <p>${esc(message)}</p>
     </div>

--- a/src/views/scripts.ts
+++ b/src/views/scripts.ts
@@ -73,8 +73,11 @@ if (!window.__dmarcheckBound) {
       var domain = form.querySelector('input[name="domain"]').value;
       var wrapper = document.createElement('div');
       wrapper.className = 'loading';
+      wrapper.setAttribute('role', 'status');
+      wrapper.setAttribute('aria-live', 'polite');
       var spinner = document.createElement('div');
       spinner.className = 'spinner';
+      spinner.setAttribute('aria-hidden', 'true');
       var msg = document.createElement('p');
       msg.textContent = 'Scanning ' + domain + '...';
       wrapper.appendChild(spinner);


### PR DESCRIPTION
💡 What:
- Added `role="status"` and `aria-live="polite"` to the dynamically injected loading wrapper in `src/views/scripts.ts`.
- Hid the purely visual loading spinner from screen readers via `aria-hidden="true"`.
- Added `role="alert"` to the static error box container in `src/views/html.ts`.

🎯 Why: 
When users submitted a domain check, the form was replaced with a loading state, but this change was completely silent to screen readers. Similarly, when landing on a direct error page, the error text wasn't immediately announced.

♿ Accessibility:
These changes ensure that assistive technologies properly announce "Scanning [domain]..." when the form is submitted and immediately read out error messages when an error page loads, improving the overall inclusiveness of the application.

---
*PR created automatically by Jules for task [2927689325198996449](https://jules.google.com/task/2927689325198996449) started by @schmug*