### PR TITLE
🛡️ Sentinel: [HIGH] Fix IP spoofing vulnerability in rate limiting

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,10 +73,7 @@ app.use("*", async (c, next) => {
     path: c.req.path,
   });
   scope.setUser({
-    ip_address:
-      c.req.header("CF-Connecting-IP") ||
-      c.req.header("X-Forwarded-For") ||
-      undefined,
+    ip_address: c.req.header("CF-Connecting-IP") || undefined,
   });
 
   await next();
@@ -161,11 +158,6 @@ app.use("/api/*", cors());
 function getClientIp(c: Context): string {
   const cfIp = c.req.header("CF-Connecting-IP");
   if (cfIp) return cfIp;
-
-  // Prevent rate limit bypass by extracting only the first IP address
-  // if multiple comma-separated IPs are present in X-Forwarded-For.
-  const xff = c.req.header("X-Forwarded-For");
-  if (xff) return xff.split(",")[0].trim();
 
   return "unknown";
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The application was using the `X-Forwarded-For` header as a fallback for IP address tracking, which could be easily spoofed by a client.
🎯 **Impact:** Malicious actors could manipulate the `X-Forwarded-For` header to bypass rate limiting or inject arbitrary IP data into Sentry logs.
🔧 **Fix:** Exclusively rely on the `CF-Connecting-IP` header (which is sanitized and set by Cloudflare and cannot be spoofed by the client) and remove the `X-Forwarded-For` fallback in both `getClientIp` and the Sentry context setup.
✅ **Verification:** Ran `pnpm lint` and `pnpm test` successfully. A critical learning journal entry was added to `.jules/sentinel.md` documenting the IP spoofing vulnerability and how to prevent it.

---
*PR created automatically by Jules for task [4776459285387595477](https://jules.google.com/task/4776459285387595477) started by @schmug*