### PR TITLE
🎨 Palette: [UX improvement] Improve screen reader announcements for loading and error states

### DIFF
--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -655,7 +655,7 @@ export function renderError(message: string): string {
     body: `<main class="landing">
   <div class="landing-main">
     <div class="logo">${generateCreature("lg", "worried")}<span class="logo-text">dmar<span>check</span></span></div>
-    <div class="error-box">
+    <div class="error-box" role="alert">
       <h3>Error</h3>
       <p>${esc(message)}</p>
     </div>

--- a/src/views/scripts.ts
+++ b/src/views/scripts.ts
@@ -73,8 +73,11 @@ if (!window.__dmarcheckBound) {
       var domain = form.querySelector('input[name="domain"]').value;
       var wrapper = document.createElement('div');
       wrapper.className = 'loading';
+      wrapper.setAttribute('role', 'status');
+      wrapper.setAttribute('aria-live', 'polite');
       var spinner = document.createElement('div');
       spinner.className = 'spinner';
+      spinner.setAttribute('aria-hidden', 'true');
       var msg = document.createElement('p');
       msg.textContent = 'Scanning ' + domain + '...';
       wrapper.appendChild(spinner);


### PR DESCRIPTION
💡 **What**: Added `role="status"` and `aria-live="polite"` to the dynamic full-page loading wrapper, and `role="alert"` to the static error box. Also hid the visual loading spinner from screen readers with `aria-hidden="true"`.
🎯 **Why**: When dynamically changing the page to show a loading state, screen readers wouldn't announce the change, leaving users confused. Similarly, error messages need immediate announcement via `role="alert"`.
♿ **Accessibility**: Improved screen reader experience during async scans and error states by using standard WAI-ARIA properties.

---
*PR created automatically by Jules for task [11814013648081284230](https://jules.google.com/task/11814013648081284230) started by @schmug*