### PR TITLE
🎨 Palette: Improve mobile typing UX and SVG accessibility

### DIFF
--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -134,7 +134,7 @@ export function renderLandingPage(): string {
       <h1 class="tagline">DNS email security analyzer &mdash; DMARC, SPF, DKIM, BIMI &amp; MTA-STS</h1>
       <form action="/check" method="GET">
         <div class="search-box">
-          <input type="text" name="domain" placeholder="Enter a domain (e.g., google.com)" aria-label="Enter a domain" autofocus required>
+          <input type="text" name="domain" placeholder="Enter a domain (e.g., google.com)" aria-label="Enter a domain" autocapitalize="none" autocorrect="off" spellcheck="false" autofocus required>
           <button type="submit">Scan</button>
         </div>
         <details class="advanced-options">

--- a/src/views/learn.ts
+++ b/src/views/learn.ts
@@ -123,7 +123,7 @@ function learnCta(placeholder: string): string {
     <div class="bd-card-body">
       <form action="/check" method="GET" class="learn-cta-form">
         <div class="search-box">
-          <input type="text" name="domain" placeholder="${esc(placeholder)}" aria-label="Enter a domain" required>
+          <input type="text" name="domain" placeholder="${esc(placeholder)}" aria-label="Enter a domain" autocapitalize="none" autocorrect="off" spellcheck="false" required>
           <button type="submit">Scan</button>
         </div>
       </form>

--- a/src/views/scripts.ts
+++ b/src/views/scripts.ts
@@ -233,9 +233,9 @@ if (!window.__dmarcheckBound) {
 (function() {
   var toggles = document.querySelectorAll('.theme-toggle');
   if (!toggles.length) return;
-  var sunIcon = '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><circle cx="8" cy="8" r="3"/><path d="M8 1v2M8 13v2M1 8h2M13 8h2M3.05 3.05l1.41 1.41M11.54 11.54l1.41 1.41M3.05 12.95l1.41-1.41M11.54 4.46l1.41-1.41"/></svg>';
-  var moonIcon = '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M13.5 8.5a5.5 5.5 0 01-7-7 5.5 5.5 0 107 7z"/></svg>';
-  var autoIcon = '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="2" width="14" height="10" rx="1.5"/><path d="M5 15h6M8 12v3"/></svg>';
+  var sunIcon = '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" aria-hidden="true"><circle cx="8" cy="8" r="3"/><path d="M8 1v2M8 13v2M1 8h2M13 8h2M3.05 3.05l1.41 1.41M11.54 11.54l1.41 1.41M3.05 12.95l1.41-1.41M11.54 4.46l1.41-1.41"/></svg>';
+  var moonIcon = '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M13.5 8.5a5.5 5.5 0 01-7-7 5.5 5.5 0 107 7z"/></svg>';
+  var autoIcon = '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="1" y="2" width="14" height="10" rx="1.5"/><path d="M5 15h6M8 12v3"/></svg>';
 
   function updateToggles() {
     var stored = localStorage.getItem('theme');


### PR DESCRIPTION
### 💡 What
Added mobile keyboard configuration attributes (`autocapitalize="none" autocorrect="off" spellcheck="false"`) to the domain search inputs. Added `aria-hidden="true"` to the theme toggle SVG icons.

### 🎯 Why
- Domain names should never be auto-capitalized or spell-checked. On mobile devices, keyboards often aggressively "correct" domains (e.g. `dmarc.mx` becomes `Dmarc. mx`), frustrating the user.
- The theme toggle SVGs were being read out as shapes/paths by screen readers, creating clutter since the parent button already has a perfectly descriptive `aria-label`.

### ♿ Accessibility
- Prevents screen readers from redundantly announcing SVG structures in the theme toggle button.

---
*PR created automatically by Jules for task [6888827601507238989](https://jules.google.com/task/6888827601507238989) started by @schmug*