### PR TITLE
Add agent-readiness discovery surface (Link headers, API catalog, OpenAPI, markdown, WebMCP)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,9 +31,20 @@ Live at dmarc.mx | Repo: github.com/schmug/dmarcheck
 - `src/shared/scoring.ts` — Grade computation (F if no DMARC or p=none)
 - `src/cache.ts` — SSE result caching
 - `src/csv.ts` — CSV export for scan results
+- `src/api/catalog.ts` + `src/api/openapi.ts` — Agent discovery (RFC 9727 linkset at `/.well-known/api-catalog`, OpenAPI 3.1 at `/openapi.json`)
 - `src/views/` — HTML generation via template literals (styles.ts, scripts.ts, components.ts, html.ts, favicon.ts)
   - `components.ts` — `generateCreature(size, mood, partyHat?)` helper and `gradeToMood()` mapping
+  - `markdown.ts` — markdown renderings served when `Accept: text/markdown` (landing, /check report, /scoring, /learn, /docs/api)
 - `src/rate-limit.ts` — Cache API-based rate limiter (10 req/IP/60s)
+
+## Agent discovery
+
+- `/.well-known/api-catalog` — RFC 9727 linkset (`application/linkset+json`) pointing to OpenAPI + docs + health
+- `/openapi.json` — OpenAPI 3.1 service description (`application/openapi+json`)
+- `/docs/api` — Human-readable API reference (HTML, or markdown with `Accept: text/markdown`)
+- Every HTML page ships a `Link` header advertising four relations (`api-catalog`, `service-desc`, `service-doc`, `status`)
+- Content negotiation: `Accept: text/markdown` (or `?format=md`) on `/`, `/check`, `/scoring`, `/learn`, `/docs/api` returns a markdown rendering (noindexed)
+- The client JS bundle registers a WebMCP `scan_domain` tool via `navigator.modelContext.provideContext()` when that API is available — silent no-op in browsers without WebMCP
 
 ## Conventions
 

--- a/src/api/catalog.ts
+++ b/src/api/catalog.ts
@@ -1,0 +1,41 @@
+// RFC 9727 API catalog — advertises the public scan API to automated agents.
+// https://www.rfc-editor.org/rfc/rfc9727
+
+export const CANONICAL_ORIGIN = "https://dmarc.mx";
+
+export interface LinksetEntry {
+  anchor: string;
+  "service-desc": Array<{ href: string; type: string }>;
+  "service-doc": Array<{ href: string; type: string }>;
+  status: Array<{ href: string }>;
+}
+
+export interface ApiCatalog {
+  linkset: LinksetEntry[];
+}
+
+export function buildApiCatalog(origin: string = CANONICAL_ORIGIN): ApiCatalog {
+  return {
+    linkset: [
+      {
+        anchor: `${origin}/api/check`,
+        "service-desc": [
+          {
+            href: `${origin}/openapi.json`,
+            type: "application/openapi+json",
+          },
+        ],
+        "service-doc": [
+          {
+            href: `${origin}/docs/api`,
+            type: "text/html",
+          },
+        ],
+        status: [{ href: `${origin}/health` }],
+      },
+    ],
+  };
+}
+
+// Built once per Worker instance — payload is ~300 bytes.
+export const API_CATALOG_JSON = JSON.stringify(buildApiCatalog());

--- a/src/api/openapi.ts
+++ b/src/api/openapi.ts
@@ -1,0 +1,524 @@
+import { CANONICAL_ORIGIN } from "./catalog.js";
+
+// OpenAPI 3.1 service description for the dmarcheck public API.
+// Kept in a single static object so it's trivial to diff when the surface
+// changes. Schemas mirror `src/analyzers/types.ts` closely but do NOT import
+// from it — OpenAPI schemas need to stay stable across TypeScript refactors.
+
+const statusEnum = {
+  type: "string",
+  enum: ["pass", "warn", "fail", "info"],
+} as const;
+
+const validation = {
+  type: "object",
+  required: ["status", "message"],
+  properties: {
+    status: statusEnum,
+    message: { type: "string" },
+  },
+} as const;
+
+const validations = {
+  type: "array",
+  items: { $ref: "#/components/schemas/Validation" },
+} as const;
+
+export const OPENAPI_DOCUMENT = {
+  openapi: "3.1.0",
+  info: {
+    title: "dmarcheck API",
+    version: "1.0.0",
+    summary: "DNS email-security (DMARC, SPF, DKIM, BIMI, MTA-STS) scanner.",
+    description:
+      "Public, unauthenticated API that grades a domain's email-security DNS posture. Rate-limited to 10 requests per minute per IP.",
+    license: { name: "MIT", identifier: "MIT" },
+    contact: { url: "https://github.com/schmug/dmarcheck" },
+  },
+  servers: [{ url: CANONICAL_ORIGIN, description: "Production" }],
+  paths: {
+    "/api/check": {
+      get: {
+        summary: "Scan a domain's email-security posture",
+        description:
+          "Runs DMARC, SPF, DKIM, BIMI, MTA-STS, and MX analyzers in parallel and returns a graded result. Results are cached for a short period.",
+        operationId: "scanDomain",
+        parameters: [
+          {
+            name: "domain",
+            in: "query",
+            required: true,
+            description: "Domain to scan, lowercase, `[a-z0-9.-]` only.",
+            schema: {
+              type: "string",
+              pattern: "^[a-z0-9.-]+$",
+              maxLength: 253,
+            },
+            example: "dmarc.mx",
+          },
+          {
+            name: "selectors",
+            in: "query",
+            required: false,
+            description:
+              "Comma-separated DKIM selectors to probe in addition to the built-in defaults.",
+            schema: { type: "string", pattern: "^[A-Za-z0-9._,-]+$" },
+            example: "google,selector1",
+          },
+          {
+            name: "format",
+            in: "query",
+            required: false,
+            description:
+              "Force `json` or `csv`. Omit to get the JSON response.",
+            schema: { type: "string", enum: ["json", "csv"] },
+          },
+        ],
+        responses: {
+          "200": {
+            description: "Scan completed",
+            headers: {
+              "X-Cache": {
+                description:
+                  "`HIT` when the response was served from the SSE cache.",
+                schema: { type: "string", enum: ["HIT"] },
+              },
+              "X-RateLimit-Limit": { schema: { type: "integer" } },
+              "X-RateLimit-Remaining": { schema: { type: "integer" } },
+              "X-RateLimit-Window": { schema: { type: "string" } },
+            },
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ScanResult" },
+              },
+              "text/csv": {
+                schema: {
+                  type: "string",
+                  description: "CSV export (UTF-8 BOM)",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Missing or invalid domain parameter",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Error" },
+              },
+            },
+          },
+          "429": {
+            description: "Rate limit exceeded (10 req/min per IP)",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Error" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/check/stream": {
+      get: {
+        summary: "Stream scan results as Server-Sent Events",
+        description:
+          "Emits a `protocol` event for each analyzer as it completes, then a `done` event with header/footer HTML fragments. Used by the web UI for progressive rendering.",
+        operationId: "scanDomainStream",
+        parameters: [
+          {
+            name: "domain",
+            in: "query",
+            required: true,
+            schema: { type: "string", pattern: "^[a-z0-9.-]+$" },
+          },
+          {
+            name: "selectors",
+            in: "query",
+            required: false,
+            schema: { type: "string" },
+          },
+        ],
+        responses: {
+          "200": {
+            description: "SSE stream",
+            content: {
+              "text/event-stream": {
+                schema: {
+                  type: "string",
+                  description:
+                    "Events: `protocol` (per-analyzer HTML fragment) and `done` (final header/footer HTML).",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/check": {
+      get: {
+        summary: "Human-facing scan endpoint (multi-format)",
+        description:
+          "Same scan as `/api/check` but content-negotiated. Defaults to HTML; returns JSON with `Accept: application/json`, CSV with `format=csv`, and markdown with `Accept: text/markdown`.",
+        operationId: "scanDomainNegotiated",
+        parameters: [
+          {
+            name: "domain",
+            in: "query",
+            required: true,
+            schema: { type: "string", pattern: "^[a-z0-9.-]+$" },
+          },
+          {
+            name: "selectors",
+            in: "query",
+            required: false,
+            schema: { type: "string" },
+          },
+          {
+            name: "format",
+            in: "query",
+            required: false,
+            schema: { type: "string", enum: ["json", "csv", "md"] },
+          },
+        ],
+        responses: {
+          "200": {
+            description: "Scan result in the negotiated format",
+            content: {
+              "text/html": { schema: { type: "string" } },
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ScanResult" },
+              },
+              "text/csv": { schema: { type: "string" } },
+              "text/markdown": { schema: { type: "string" } },
+            },
+          },
+        },
+      },
+    },
+    "/health": {
+      get: {
+        summary: "Liveness probe",
+        operationId: "health",
+        responses: {
+          "200": {
+            description: "Service healthy",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: ["status", "timestamp"],
+                  properties: {
+                    status: { type: "string", enum: ["ok"] },
+                    timestamp: { type: "string", format: "date-time" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/.well-known/api-catalog": {
+      get: {
+        summary: "RFC 9727 API catalog",
+        operationId: "apiCatalog",
+        responses: {
+          "200": {
+            description: "Linkset describing this API",
+            content: {
+              "application/linkset+json": {
+                schema: {
+                  type: "object",
+                  required: ["linkset"],
+                  properties: {
+                    linkset: { type: "array", items: { type: "object" } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      Status: statusEnum,
+      Validation: validation,
+      Error: {
+        type: "object",
+        required: ["error"],
+        properties: { error: { type: "string" } },
+      },
+      DmarcResult: {
+        type: "object",
+        required: ["status", "record", "tags", "validations"],
+        properties: {
+          status: { $ref: "#/components/schemas/Status" },
+          record: { type: ["string", "null"] },
+          tags: {
+            type: ["object", "null"],
+            additionalProperties: { type: "string" },
+          },
+          validations,
+        },
+      },
+      SpfIncludeNode: {
+        type: "object",
+        required: ["domain", "record", "mechanisms", "includes"],
+        properties: {
+          domain: { type: "string" },
+          record: { type: ["string", "null"] },
+          mechanisms: { type: "array", items: { type: "string" } },
+          includes: {
+            type: "array",
+            items: { $ref: "#/components/schemas/SpfIncludeNode" },
+          },
+        },
+      },
+      SpfResult: {
+        type: "object",
+        required: [
+          "status",
+          "record",
+          "lookups_used",
+          "lookup_limit",
+          "include_tree",
+          "validations",
+        ],
+        properties: {
+          status: { $ref: "#/components/schemas/Status" },
+          record: { type: ["string", "null"] },
+          lookups_used: { type: "integer" },
+          lookup_limit: { type: "integer" },
+          include_tree: {
+            oneOf: [
+              { $ref: "#/components/schemas/SpfIncludeNode" },
+              { type: "null" },
+            ],
+          },
+          validations,
+        },
+      },
+      DkimSelectorResult: {
+        type: "object",
+        required: ["found"],
+        properties: {
+          found: { type: "boolean" },
+          key_type: { type: "string" },
+          key_bits: { type: "integer" },
+          testing: { type: "boolean" },
+          revoked: { type: "boolean" },
+        },
+      },
+      DkimResult: {
+        type: "object",
+        required: ["status", "selectors", "validations"],
+        properties: {
+          status: { $ref: "#/components/schemas/Status" },
+          selectors: {
+            type: "object",
+            additionalProperties: {
+              $ref: "#/components/schemas/DkimSelectorResult",
+            },
+          },
+          validations,
+        },
+      },
+      BimiResult: {
+        type: "object",
+        required: ["status", "record", "tags", "validations"],
+        properties: {
+          status: { $ref: "#/components/schemas/Status" },
+          record: { type: ["string", "null"] },
+          tags: {
+            type: ["object", "null"],
+            additionalProperties: { type: "string" },
+          },
+          validations,
+        },
+      },
+      MtaStsPolicy: {
+        type: "object",
+        required: ["version", "mode", "mx", "max_age"],
+        properties: {
+          version: { type: "string" },
+          mode: { type: "string" },
+          mx: { type: "array", items: { type: "string" } },
+          max_age: { type: "integer" },
+        },
+      },
+      MtaStsResult: {
+        type: "object",
+        required: ["status", "dns_record", "policy", "validations"],
+        properties: {
+          status: { $ref: "#/components/schemas/Status" },
+          dns_record: { type: ["string", "null"] },
+          policy: {
+            oneOf: [
+              { $ref: "#/components/schemas/MtaStsPolicy" },
+              { type: "null" },
+            ],
+          },
+          validations,
+        },
+      },
+      EmailProvider: {
+        type: "object",
+        required: ["name", "category"],
+        properties: {
+          name: { type: "string" },
+          category: {
+            type: "string",
+            enum: ["security-gateway", "email-platform", "hosting"],
+          },
+        },
+      },
+      MxRecord: {
+        type: "object",
+        required: ["priority", "exchange"],
+        properties: {
+          priority: { type: "integer" },
+          exchange: { type: "string" },
+          provider: { $ref: "#/components/schemas/EmailProvider" },
+        },
+      },
+      MxResult: {
+        type: "object",
+        required: ["status", "records", "providers", "validations"],
+        properties: {
+          status: { $ref: "#/components/schemas/Status" },
+          records: {
+            type: "array",
+            items: { $ref: "#/components/schemas/MxRecord" },
+          },
+          providers: {
+            type: "array",
+            items: { $ref: "#/components/schemas/EmailProvider" },
+          },
+          validations,
+        },
+      },
+      ScanSummary: {
+        type: "object",
+        required: [
+          "mx_records",
+          "mx_providers",
+          "dmarc_policy",
+          "spf_result",
+          "spf_lookups",
+          "dkim_selectors_found",
+          "bimi_enabled",
+          "mta_sts_mode",
+        ],
+        properties: {
+          mx_records: { type: "integer" },
+          mx_providers: { type: "array", items: { type: "string" } },
+          dmarc_policy: { type: ["string", "null"] },
+          spf_result: { $ref: "#/components/schemas/Status" },
+          spf_lookups: { type: "string" },
+          dkim_selectors_found: { type: "integer" },
+          bimi_enabled: { type: "boolean" },
+          mta_sts_mode: { type: ["string", "null"] },
+        },
+      },
+      ScoringFactor: {
+        type: "object",
+        required: ["protocol", "label", "effect"],
+        properties: {
+          protocol: {
+            type: "string",
+            enum: ["dmarc", "spf", "dkim", "bimi", "mta_sts"],
+          },
+          label: { type: "string" },
+          effect: { type: "number" },
+        },
+      },
+      Recommendation: {
+        type: "object",
+        required: ["priority", "protocol", "title", "description", "impact"],
+        properties: {
+          priority: { type: "integer", enum: [1, 2, 3] },
+          protocol: {
+            type: "string",
+            enum: ["dmarc", "spf", "dkim", "bimi", "mta_sts"],
+          },
+          title: { type: "string" },
+          description: { type: "string" },
+          impact: { type: "string" },
+        },
+      },
+      GradeBreakdown: {
+        type: "object",
+        required: [
+          "grade",
+          "tier",
+          "tierReason",
+          "modifier",
+          "modifierLabel",
+          "factors",
+          "recommendations",
+          "protocolSummaries",
+        ],
+        properties: {
+          grade: { type: "string" },
+          tier: { type: "string" },
+          tierReason: { type: "string" },
+          modifier: { type: "number" },
+          modifierLabel: { type: "string" },
+          factors: {
+            type: "array",
+            items: { $ref: "#/components/schemas/ScoringFactor" },
+          },
+          recommendations: {
+            type: "array",
+            items: { $ref: "#/components/schemas/Recommendation" },
+          },
+          protocolSummaries: {
+            type: "object",
+            additionalProperties: {
+              type: "object",
+              required: ["status", "summary"],
+              properties: {
+                status: { $ref: "#/components/schemas/Status" },
+                summary: { type: "string" },
+              },
+            },
+          },
+        },
+      },
+      ScanResult: {
+        type: "object",
+        required: [
+          "domain",
+          "timestamp",
+          "grade",
+          "breakdown",
+          "summary",
+          "protocols",
+        ],
+        properties: {
+          domain: { type: "string" },
+          timestamp: { type: "string", format: "date-time" },
+          grade: { type: "string" },
+          breakdown: { $ref: "#/components/schemas/GradeBreakdown" },
+          summary: { $ref: "#/components/schemas/ScanSummary" },
+          protocols: {
+            type: "object",
+            required: ["mx", "dmarc", "spf", "dkim", "bimi", "mta_sts"],
+            properties: {
+              mx: { $ref: "#/components/schemas/MxResult" },
+              dmarc: { $ref: "#/components/schemas/DmarcResult" },
+              spf: { $ref: "#/components/schemas/SpfResult" },
+              dkim: { $ref: "#/components/schemas/DkimResult" },
+              bimi: { $ref: "#/components/schemas/BimiResult" },
+              mta_sts: { $ref: "#/components/schemas/MtaStsResult" },
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;
+
+export const OPENAPI_JSON = JSON.stringify(OPENAPI_DOCUMENT);

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ import type {
   ScanResult,
   SpfResult,
 } from "./analyzers/types.js";
+import { API_CATALOG_JSON } from "./api/catalog.js";
+import { OPENAPI_JSON } from "./api/openapi.js";
 import { getCachedScan, setCachedScan } from "./cache.js";
 import { generateCsv } from "./csv.js";
 import type { ProtocolId, ProtocolResult } from "./orchestrator.js";
@@ -26,6 +28,7 @@ import {
   webManifest,
 } from "./views/favicon.js";
 import {
+  renderApiDocs,
   renderBimiCard,
   renderDkimCard,
   renderDmarcCard,
@@ -49,6 +52,14 @@ import {
   renderLearnMtaSts,
   renderLearnSpf,
 } from "./views/learn.js";
+import {
+  renderApiDocsMarkdown,
+  renderErrorMarkdown,
+  renderLandingMarkdown,
+  renderLearnHubMarkdown,
+  renderReportMarkdown,
+  renderScoringRubricMarkdown,
+} from "./views/markdown.js";
 import { JS } from "./views/scripts.js";
 import { CSS } from "./views/styles.js";
 
@@ -88,9 +99,22 @@ app.use("*", async (c, next) => {
 const NOINDEX_CONTENT_TYPES = [
   "application/json",
   "application/manifest+json",
+  "application/linkset+json",
+  "application/openapi+json",
   "text/csv",
   "text/event-stream",
+  "text/markdown",
 ];
+
+// Link header (RFC 8288) pointing agents to discovery resources.
+// Attached to HTML responses only — JSON/CSV/SSE consumers are already
+// using the API directly.
+const AGENT_DISCOVERY_LINK_HEADER = [
+  '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"',
+  '</openapi.json>; rel="service-desc"; type="application/openapi+json"',
+  '</docs/api>; rel="service-doc"; type="text/html"',
+  '</health>; rel="status"',
+].join(", ");
 
 // Origins permitted to embed the HTML report in an iframe. Anything not listed
 // here (including subdomains) is blocked by the `frame-ancestors` directive
@@ -115,6 +139,9 @@ app.use("*", async (c, next) => {
       "Content-Security-Policy",
       `default-src 'none'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; manifest-src 'self'; form-action 'self'; base-uri 'none'; frame-ancestors ${frameAncestors}`,
     );
+    if (!c.res.headers.has("Link")) {
+      c.res.headers.set("Link", AGENT_DISCOVERY_LINK_HEADER);
+    }
     // Short edge cache so Cloudflare can absorb landing/scoring/report traffic
     // without hitting the Worker on every request. Browsers still revalidate.
     if (!c.res.headers.has("Cache-Control")) {
@@ -154,6 +181,29 @@ app.onError((err, c) => {
 });
 
 app.use("/api/*", cors());
+
+function markdownResponse(c: Context, body: string, status = 200) {
+  return c.body(body, status as 200, {
+    "Content-Type": "text/markdown; charset=utf-8",
+  });
+}
+
+// Returns true when the client explicitly asked for markdown (via `?format=md`
+// or an `Accept` header that lists `text/markdown` before `text/html`). HTML
+// stays the default for browsers that send wildcards like `*/*`.
+function wantsMarkdown(c: Context): boolean {
+  const format = c.req.query("format");
+  if (format === "md" || format === "markdown") return true;
+  const accept = c.req.header("Accept");
+  if (!accept) return false;
+  const types = accept.toLowerCase().split(",");
+  const mdIndex = types.findIndex((t) => t.trim().startsWith("text/markdown"));
+  if (mdIndex === -1) return false;
+  const htmlIndex = types.findIndex((t) => t.trim().startsWith("text/html"));
+  // Agents that send `Accept: text/markdown` (and nothing else, or markdown
+  // first) get markdown. Browsers that prefer HTML keep getting HTML.
+  return htmlIndex === -1 || mdIndex < htmlIndex;
+}
 
 function getClientIp(c: Context): string {
   const cfIp = c.req.header("CF-Connecting-IP");
@@ -485,6 +535,27 @@ app.get("/health", (c) => {
   return c.json({ status: "ok", timestamp: new Date().toISOString() });
 });
 
+// RFC 9727 API catalog — agents discover this via the Link header on HTML
+// pages or by fetching a well-known URI directly.
+app.get("/.well-known/api-catalog", (c) => {
+  return c.body(API_CATALOG_JSON, 200, {
+    "Content-Type": "application/linkset+json",
+    "Cache-Control": "public, max-age=3600",
+  });
+});
+
+app.get("/openapi.json", (c) => {
+  return c.body(OPENAPI_JSON, 200, {
+    "Content-Type": "application/openapi+json; charset=utf-8",
+    "Cache-Control": "public, max-age=3600",
+  });
+});
+
+app.get("/docs/api", (c) => {
+  if (wantsMarkdown(c)) return markdownResponse(c, renderApiDocsMarkdown());
+  return c.html(renderApiDocs());
+});
+
 // Crawl guidance for search engines. Block the API namespace (Google was
 // logging `/api/check?domain=dmarc.mx` as "Crawled - currently not indexed"
 // noise) and point to the sitemap.
@@ -536,14 +607,20 @@ ${urls}
 });
 
 app.get("/", (c) => {
+  if (wantsMarkdown(c)) return markdownResponse(c, renderLandingMarkdown());
   return c.html(renderLandingPage());
 });
 
 app.get("/scoring", (c) => {
+  if (wantsMarkdown(c))
+    return markdownResponse(c, renderScoringRubricMarkdown());
   return c.html(renderScoringRubric());
 });
 
-app.get("/learn", (c) => c.html(renderLearnHub()));
+app.get("/learn", (c) => {
+  if (wantsMarkdown(c)) return markdownResponse(c, renderLearnHubMarkdown());
+  return c.html(renderLearnHub());
+});
 app.get("/learn/dmarc", (c) => c.html(renderLearnDmarc()));
 app.get("/learn/spf", (c) => c.html(renderLearnSpf()));
 app.get("/learn/dkim", (c) => c.html(renderLearnDkim()));
@@ -629,6 +706,7 @@ app.get("/check", async (c) => {
   const wantsJson =
     format === "json" || c.req.header("Accept")?.includes("application/json");
   const wantsCsv = format === "csv";
+  const wantsMd = !wantsJson && !wantsCsv && wantsMarkdown(c);
 
   const domain = normalizeDomain(c.req.query("domain"));
   if (!domain) {
@@ -643,10 +721,42 @@ app.get("/check", async (c) => {
         "Content-Type": "text/csv; charset=utf-8",
       });
     }
+    if (wantsMd) {
+      return markdownResponse(
+        c,
+        renderErrorMarkdown("Missing or invalid domain parameter"),
+        400,
+      );
+    }
     return c.redirect("/", 302);
   }
 
   const selectors = parseSelectors(c.req.query("selectors"));
+
+  if (wantsMd) {
+    try {
+      Sentry.addBreadcrumb({
+        category: "scan.start",
+        message: domain,
+        data: { domain, selectors },
+        level: "info",
+      });
+      const cached = await getCachedScan(domain, selectors);
+      const result = cached ?? (await scan(domain, selectors));
+      tagScanResult(result);
+      if (!cached) {
+        const pendingCacheWrite = setCachedScan(domain, selectors, result);
+        if (pendingCacheWrite) {
+          c.executionCtx.waitUntil(pendingCacheWrite.catch(() => {}));
+        }
+      }
+      return markdownResponse(c, renderReportMarkdown(result));
+    } catch (err) {
+      Sentry.captureException(err);
+      const message = err instanceof Error ? err.message : "Internal error";
+      return markdownResponse(c, renderErrorMarkdown(message), 500);
+    }
+  }
 
   if (wantsJson) {
     try {

--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -664,3 +664,88 @@ export function renderError(message: string): string {
 </main>`,
   });
 }
+
+export function renderApiDocs(): string {
+  const body = `<main class="breakdown">
+  <div class="report-nav">
+    <a href="/">${generateCreature("sm")} Home</a>
+  </div>
+  <h1 class="rubric-title">dmarcheck API</h1>
+  <p class="rubric-intro">Public, unauthenticated HTTP API for grading a domain's email-security DNS posture. Rate limited to 10 requests per minute per IP.</p>
+
+  <div class="bd-card">
+    <div class="bd-card-title">Discovery</div>
+    <div class="bd-card-body">
+      <ul>
+        <li><a href="/.well-known/api-catalog"><code>/.well-known/api-catalog</code></a> — RFC 9727 linkset (<code>application/linkset+json</code>)</li>
+        <li><a href="/openapi.json"><code>/openapi.json</code></a> — OpenAPI 3.1 service description</li>
+        <li><a href="/health"><code>/health</code></a> — liveness probe</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="bd-card">
+    <div class="bd-card-title">GET /api/check</div>
+    <div class="bd-card-body">
+      <p>Scan a domain and return the graded result as JSON.</p>
+      <p><strong>Query params:</strong></p>
+      <ul>
+        <li><code>domain</code> <em>(required)</em> — <code>[a-z0-9.-]+</code></li>
+        <li><code>selectors</code> <em>(optional)</em> — comma-separated extra DKIM selectors</li>
+        <li><code>format</code> <em>(optional)</em> — <code>json</code> (default) or <code>csv</code></li>
+      </ul>
+      <p><strong>Example:</strong></p>
+      <pre><code>curl -H 'Accept: application/json' '${SITE_ORIGIN}/api/check?domain=dmarc.mx'</code></pre>
+    </div>
+  </div>
+
+  <div class="bd-card">
+    <div class="bd-card-title">GET /api/check/stream</div>
+    <div class="bd-card-body">
+      <p>Same scan via Server-Sent Events. Emits a <code>protocol</code> event per analyzer, then a <code>done</code> event with header/footer HTML fragments.</p>
+    </div>
+  </div>
+
+  <div class="bd-card">
+    <div class="bd-card-title">GET /check</div>
+    <div class="bd-card-body">
+      <p>Content-negotiated human endpoint.</p>
+      <ul>
+        <li>Default: HTML</li>
+        <li><code>Accept: application/json</code> → JSON (same shape as <code>/api/check</code>)</li>
+        <li><code>Accept: text/markdown</code> → markdown for agents</li>
+        <li><code>format=csv</code> → CSV download</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="bd-card">
+    <div class="bd-card-title">Response shape</div>
+    <div class="bd-card-body">
+      <p>See <code>ScanResult</code> in <a href="/openapi.json">openapi.json</a>. Top-level keys: <code>domain</code>, <code>timestamp</code>, <code>grade</code>, <code>breakdown</code>, <code>summary</code>, <code>protocols</code> (<code>mx</code>, <code>dmarc</code>, <code>spf</code>, <code>dkim</code>, <code>bimi</code>, <code>mta_sts</code>).</p>
+    </div>
+  </div>
+
+  <div class="bd-card">
+    <div class="bd-card-title">Errors</div>
+    <div class="bd-card-body">
+      <ul>
+        <li><code>400</code> — missing or invalid <code>domain</code> param</li>
+        <li><code>429</code> — rate limit exceeded</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="foss-callout">
+    <a href="https://github.com/schmug/dmarcheck" class="foss-link">Source on GitHub</a>
+  </div>
+</main>`;
+
+  return page({
+    title: "API — dmarcheck",
+    path: "/docs/api",
+    description:
+      "dmarcheck public HTTP API: endpoints, parameters, response shape, and discovery (OpenAPI 3.1, RFC 9727 catalog).",
+    body,
+  });
+}

--- a/src/views/markdown.ts
+++ b/src/views/markdown.ts
@@ -1,0 +1,267 @@
+import type { ScanResult, Validation } from "../analyzers/types.js";
+
+// Markdown renderings for agent consumers that send `Accept: text/markdown`.
+// Output is plain markdown with no HTML fragments — agents are expected to
+// feed this straight into an LLM or a text diff.
+
+const MD_SITE = "https://dmarc.mx";
+
+function bullet(items: string[]): string {
+  return items.length === 0 ? "" : items.map((s) => `- ${s}`).join("\n");
+}
+
+function validationLines(validations: Validation[]): string {
+  if (validations.length === 0) return "- _(no findings)_";
+  return validations.map((v) => `- **${v.status}** — ${v.message}`).join("\n");
+}
+
+export function renderLandingMarkdown(): string {
+  return `# dmarcheck — DNS Email Security Analyzer
+
+Free, open-source scanner that grades a domain's DMARC, SPF, DKIM, BIMI, and MTA-STS DNS posture.
+
+## Scan a domain
+
+\`\`\`
+curl -H 'Accept: application/json' '${MD_SITE}/api/check?domain=example.com'
+\`\`\`
+
+Or render this page as a human report: <${MD_SITE}/check?domain=example.com>.
+
+## API discovery
+
+- Catalog: <${MD_SITE}/.well-known/api-catalog> (\`application/linkset+json\`, RFC 9727)
+- OpenAPI 3.1: <${MD_SITE}/openapi.json>
+- Human docs: <${MD_SITE}/docs/api>
+- Health: <${MD_SITE}/health>
+
+## Resources
+
+- Scoring rubric: <${MD_SITE}/scoring>
+- Learn: <${MD_SITE}/learn> (DMARC, SPF, DKIM, BIMI, MTA-STS)
+- Source: <https://github.com/schmug/dmarcheck>
+
+Rate limited to 10 requests per minute per IP.
+`;
+}
+
+export function renderReportMarkdown(result: ScanResult): string {
+  const { domain, timestamp, grade, breakdown, summary, protocols } = result;
+
+  const recs = breakdown.recommendations
+    .sort((a, b) => a.priority - b.priority)
+    .map(
+      (r) =>
+        `- **P${r.priority} · ${r.protocol.toUpperCase()}** — ${r.title}. ${r.description} _(${r.impact})_`,
+    )
+    .join("\n");
+
+  const factors = breakdown.factors
+    .map(
+      (f) =>
+        `- ${f.protocol.toUpperCase()}: ${f.label} (${f.effect >= 0 ? "+" : ""}${f.effect})`,
+    )
+    .join("\n");
+
+  return `# ${domain} — Grade ${grade}
+
+_Scanned ${timestamp}_
+
+**Tier:** ${breakdown.tier} — ${breakdown.tierReason}
+**Modifier:** ${breakdown.modifierLabel} (${breakdown.modifier >= 0 ? "+" : ""}${breakdown.modifier})
+
+## Summary
+
+- MX records: ${summary.mx_records}${summary.mx_providers.length ? ` (${summary.mx_providers.join(", ")})` : ""}
+- DMARC policy: ${summary.dmarc_policy ?? "_none_"}
+- SPF: ${summary.spf_result} (${summary.spf_lookups})
+- DKIM selectors found: ${summary.dkim_selectors_found}
+- BIMI: ${summary.bimi_enabled ? "enabled" : "not configured"}
+- MTA-STS mode: ${summary.mta_sts_mode ?? "_none_"}
+
+## Recommendations
+
+${recs || "- _(no recommendations — nicely done)_"}
+
+## Scoring factors
+
+${factors || "- _(no factors)_"}
+
+## DMARC — ${protocols.dmarc.status}
+
+${protocols.dmarc.record ? `\`\`\`\n${protocols.dmarc.record}\n\`\`\`` : "_No DMARC record found._"}
+
+${validationLines(protocols.dmarc.validations)}
+
+## SPF — ${protocols.spf.status}
+
+${protocols.spf.record ? `\`\`\`\n${protocols.spf.record}\n\`\`\`` : "_No SPF record found._"}
+
+Lookups used: ${protocols.spf.lookups_used} / ${protocols.spf.lookup_limit}
+
+${validationLines(protocols.spf.validations)}
+
+## DKIM — ${protocols.dkim.status}
+
+${renderDkimSelectors(protocols.dkim.selectors)}
+
+${validationLines(protocols.dkim.validations)}
+
+## BIMI — ${protocols.bimi.status}
+
+${protocols.bimi.record ? `\`\`\`\n${protocols.bimi.record}\n\`\`\`` : "_No BIMI record found._"}
+
+${validationLines(protocols.bimi.validations)}
+
+## MTA-STS — ${protocols.mta_sts.status}
+
+${protocols.mta_sts.dns_record ? `\`\`\`\n${protocols.mta_sts.dns_record}\n\`\`\`` : "_No MTA-STS DNS record found._"}
+
+${protocols.mta_sts.policy ? `Policy: mode=${protocols.mta_sts.policy.mode}, max_age=${protocols.mta_sts.policy.max_age}, mx=[${protocols.mta_sts.policy.mx.join(", ")}]` : ""}
+
+${validationLines(protocols.mta_sts.validations)}
+
+## MX — ${protocols.mx.status}
+
+${bullet(protocols.mx.records.map((r) => `${r.priority} ${r.exchange}${r.provider ? ` _(${r.provider.name})_` : ""}`)) || "_No MX records found._"}
+
+${validationLines(protocols.mx.validations)}
+
+---
+
+JSON: <${MD_SITE}/api/check?domain=${encodeURIComponent(domain)}>
+`;
+}
+
+function renderDkimSelectors(
+  selectors: ScanResult["protocols"]["dkim"]["selectors"],
+): string {
+  const entries = Object.entries(selectors);
+  if (entries.length === 0) return "_No DKIM selectors probed._";
+  return entries
+    .map(([name, r]) => {
+      if (!r.found) return `- \`${name}\` — not found`;
+      const parts: string[] = [];
+      if (r.key_type) parts.push(r.key_type);
+      if (r.key_bits) parts.push(`${r.key_bits} bits`);
+      if (r.testing) parts.push("testing");
+      if (r.revoked) parts.push("revoked");
+      return `- \`${name}\` — ${parts.join(", ") || "found"}`;
+    })
+    .join("\n");
+}
+
+export function renderApiDocsMarkdown(): string {
+  return `# dmarcheck API
+
+Public, unauthenticated HTTP API for grading a domain's email-security DNS posture.
+
+**Base URL:** \`${MD_SITE}\`
+**Rate limit:** 10 requests per minute per IP (see \`X-RateLimit-*\` response headers).
+
+## Discovery
+
+- **Catalog** (RFC 9727): \`GET /.well-known/api-catalog\` → \`application/linkset+json\`
+- **OpenAPI 3.1**: \`GET /openapi.json\` → \`application/openapi+json\`
+- **Health**: \`GET /health\` → \`{ "status": "ok", "timestamp": "..." }\`
+
+## Endpoints
+
+### \`GET /api/check\`
+
+Scan a domain and return the graded result as JSON.
+
+Query params:
+
+- \`domain\` _(required)_ — \`[a-z0-9.-]+\`, e.g. \`example.com\`
+- \`selectors\` _(optional)_ — comma-separated extra DKIM selectors
+- \`format\` _(optional)_ — \`json\` (default) or \`csv\`
+
+Example:
+
+\`\`\`
+curl -H 'Accept: application/json' '${MD_SITE}/api/check?domain=dmarc.mx'
+\`\`\`
+
+### \`GET /api/check/stream\`
+
+Same scan but Server-Sent Events. Emits \`protocol\` events per analyzer, then a \`done\` event with header/footer HTML fragments.
+
+### \`GET /check\`
+
+Content-negotiated human endpoint.
+
+- Default: HTML
+- \`Accept: application/json\` → JSON (same shape as \`/api/check\`)
+- \`Accept: text/markdown\` → this rendering, for agents
+- \`format=csv\` → CSV download
+
+## Response shape
+
+See \`ScanResult\` in <${MD_SITE}/openapi.json>. Summary:
+
+\`\`\`
+{
+  "domain": "example.com",
+  "timestamp": "2026-04-17T12:00:00Z",
+  "grade": "A",
+  "breakdown": { "grade", "tier", "factors", "recommendations", ... },
+  "summary": { "dmarc_policy", "spf_result", "dkim_selectors_found", ... },
+  "protocols": {
+    "mx":      { "status", "records", "providers", "validations" },
+    "dmarc":   { "status", "record", "tags", "validations" },
+    "spf":     { "status", "record", "lookups_used", "include_tree", ... },
+    "dkim":    { "status", "selectors", "validations" },
+    "bimi":    { "status", "record", "tags", "validations" },
+    "mta_sts": { "status", "dns_record", "policy", "validations" }
+  }
+}
+\`\`\`
+
+## Errors
+
+- \`400\` — missing or invalid \`domain\` param
+- \`429\` — rate limit exceeded
+
+## Source
+
+<https://github.com/schmug/dmarcheck>
+`;
+}
+
+export function renderScoringRubricMarkdown(): string {
+  return `# dmarcheck scoring rubric
+
+The grade (S, A+, A, B, C, D, F) is computed from a tier + modifier model. Full logic: <https://github.com/schmug/dmarcheck/blob/main/src/shared/scoring.ts>.
+
+- **F** — domain has no DMARC record or DMARC \`p=none\`.
+- **D / C** — DMARC present but weak; SPF/DKIM issues.
+- **B** — DMARC enforced (quarantine/reject) with SPF + DKIM aligned.
+- **A / A+** — Full DMARC enforcement, SPF + DKIM correct, MTA-STS enforced.
+- **S** — All of the above plus BIMI with a valid VMC.
+
+Run a scan: \`${MD_SITE}/check?domain=example.com\` (add \`Accept: text/markdown\` for this format).
+`;
+}
+
+export function renderLearnHubMarkdown(): string {
+  return `# Learn — email security DNS records
+
+- [DMARC](${MD_SITE}/learn/dmarc) — policy layer on top of SPF + DKIM
+- [SPF](${MD_SITE}/learn/spf) — authorized sending IPs
+- [DKIM](${MD_SITE}/learn/dkim) — cryptographic signatures
+- [BIMI](${MD_SITE}/learn/bimi) — brand logos in inboxes
+- [MTA-STS](${MD_SITE}/learn/mta-sts) — TLS enforcement for inbound mail
+
+Run a scan: ${MD_SITE}/check?domain=example.com
+`;
+}
+
+export function renderErrorMarkdown(message: string): string {
+  return `# Error
+
+${message}
+
+Try again: <${MD_SITE}>
+`;
+}

--- a/src/views/scripts.ts
+++ b/src/views/scripts.ts
@@ -627,4 +627,33 @@ if (!window.__dmarcheckBound) {
     isActive = false;
   }
 })();
+
+/* WebMCP: expose the domain scan as a tool to in-browser agents.
+   No-op in browsers without navigator.modelContext — silently does nothing. */
+if (typeof navigator !== 'undefined' && navigator.modelContext && typeof navigator.modelContext.provideContext === 'function') {
+  try {
+    navigator.modelContext.provideContext({
+      tools: [{
+        name: 'scan_domain',
+        description: "Run a DNS email-security scan (DMARC, SPF, DKIM, BIMI, MTA-STS, MX) on a domain and return the graded JSON result.",
+        inputSchema: {
+          type: 'object',
+          properties: {
+            domain: { type: 'string', description: 'Domain to scan, e.g. example.com' },
+            selectors: { type: 'string', description: 'Optional comma-separated DKIM selectors' }
+          },
+          required: ['domain']
+        },
+        execute: async function(args) {
+          var url = new URL('/api/check', location.origin);
+          url.searchParams.set('domain', args.domain);
+          if (args.selectors) url.searchParams.set('selectors', args.selectors);
+          var r = await fetch(url.toString(), { headers: { Accept: 'application/json' } });
+          if (!r.ok) throw new Error('Scan failed: ' + r.status);
+          return await r.json();
+        }
+      }]
+    });
+  } catch (e) { /* ignore */ }
+}
 `;

--- a/test/agent-discovery.test.ts
+++ b/test/agent-discovery.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import app from "../src/index.js";
+import { _memoryStore } from "../src/rate-limit.js";
+
+vi.mock("../src/cache.js", () => ({
+  getCachedScan: vi.fn().mockResolvedValue(null),
+  setCachedScan: vi.fn(),
+}));
+
+vi.mock("../src/dns/client.js", () => ({
+  queryTxt: vi.fn().mockResolvedValue(null),
+  queryMx: vi.fn().mockResolvedValue(null),
+}));
+
+beforeEach(() => {
+  _memoryStore.clear();
+});
+
+describe("Link response header", () => {
+  it("advertises the four agent-discovery relations on the landing page", async () => {
+    const res = await app.request("/");
+    const link = res.headers.get("Link");
+    expect(link).toBeTruthy();
+    expect(link).toContain('rel="api-catalog"');
+    expect(link).toContain('rel="service-desc"');
+    expect(link).toContain('rel="service-doc"');
+    expect(link).toContain('rel="status"');
+    expect(link).toContain("</.well-known/api-catalog>");
+    expect(link).toContain("</openapi.json>");
+    expect(link).toContain("</docs/api>");
+    expect(link).toContain("</health>");
+  });
+
+  it("sets Link on scoring, learn, and docs pages too", async () => {
+    for (const path of ["/scoring", "/learn", "/docs/api"]) {
+      const res = await app.request(path);
+      expect(
+        res.headers.get("Link"),
+        `expected Link header on ${path}`,
+      ).toContain('rel="api-catalog"');
+    }
+  });
+
+  it("does not attach a Link header to JSON responses", async () => {
+    const res = await app.request("/health");
+    expect(res.headers.get("Link")).toBeNull();
+  });
+});
+
+describe("/.well-known/api-catalog", () => {
+  it("returns an RFC 9727 linkset with the expected anchor and relations", async () => {
+    const res = await app.request("/.well-known/api-catalog");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/linkset+json");
+    const body = (await res.json()) as {
+      linkset: Array<{
+        anchor: string;
+        "service-desc": Array<{ href: string; type: string }>;
+        "service-doc": Array<{ href: string; type: string }>;
+        status: Array<{ href: string }>;
+      }>;
+    };
+    expect(body.linkset).toHaveLength(1);
+    const [entry] = body.linkset;
+    expect(entry.anchor).toBe("https://dmarc.mx/api/check");
+    expect(entry["service-desc"][0].href).toBe("https://dmarc.mx/openapi.json");
+    expect(entry["service-desc"][0].type).toBe("application/openapi+json");
+    expect(entry["service-doc"][0].href).toBe("https://dmarc.mx/docs/api");
+    expect(entry.status[0].href).toBe("https://dmarc.mx/health");
+  });
+});
+
+describe("/openapi.json", () => {
+  it("returns an OpenAPI 3.1 document covering the public endpoints", async () => {
+    const res = await app.request("/openapi.json");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe(
+      "application/openapi+json; charset=utf-8",
+    );
+    const doc = (await res.json()) as {
+      openapi: string;
+      paths: Record<string, unknown>;
+      components: { schemas: Record<string, unknown> };
+    };
+    expect(doc.openapi).toBe("3.1.0");
+    for (const path of [
+      "/api/check",
+      "/api/check/stream",
+      "/check",
+      "/health",
+      "/.well-known/api-catalog",
+    ]) {
+      expect(doc.paths[path], `expected OpenAPI path ${path}`).toBeDefined();
+    }
+    expect(doc.components.schemas.ScanResult).toBeDefined();
+    expect(doc.components.schemas.DmarcResult).toBeDefined();
+  });
+});
+
+describe("/docs/api", () => {
+  it("renders the HTML API docs page by default", async () => {
+    const res = await app.request("/docs/api");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/html");
+    const body = await res.text();
+    expect(body).toContain("dmarcheck API");
+    expect(body).toContain("/openapi.json");
+  });
+
+  it("returns markdown when Accept: text/markdown is sent", async () => {
+    const res = await app.request("/docs/api", {
+      headers: { Accept: "text/markdown" },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe(
+      "text/markdown; charset=utf-8",
+    );
+    const body = await res.text();
+    expect(body).toContain("# dmarcheck API");
+  });
+});
+
+describe("markdown content negotiation", () => {
+  it("returns markdown for the landing page when requested", async () => {
+    const res = await app.request("/", {
+      headers: { Accept: "text/markdown" },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe(
+      "text/markdown; charset=utf-8",
+    );
+    const body = await res.text();
+    expect(body).toContain("# dmarcheck");
+  });
+
+  it("honors ?format=md on the scoring page", async () => {
+    const res = await app.request("/scoring?format=md");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe(
+      "text/markdown; charset=utf-8",
+    );
+    expect(await res.text()).toContain("# dmarcheck scoring rubric");
+  });
+
+  it("keeps HTML as the default when Accept lists HTML first", async () => {
+    const res = await app.request("/", {
+      headers: { Accept: "text/html,application/xhtml+xml" },
+    });
+    expect(res.headers.get("Content-Type")).toContain("text/html");
+  });
+
+  it("returns a 400 markdown error when /check has no domain and Accept: text/markdown", async () => {
+    const res = await app.request("/check", {
+      headers: { Accept: "text/markdown" },
+    });
+    expect(res.status).toBe(400);
+    expect(res.headers.get("Content-Type")).toBe(
+      "text/markdown; charset=utf-8",
+    );
+    expect(await res.text()).toContain("# Error");
+  });
+
+  it("noindexes markdown responses", async () => {
+    const res = await app.request("/", {
+      headers: { Accept: "text/markdown" },
+    });
+    expect(res.headers.get("X-Robots-Tag")).toBe("noindex");
+  });
+});
+
+describe("WebMCP tool registration", () => {
+  it("inlines the scan_domain tool definition in the client bundle", async () => {
+    // Fetch the hashed JS asset. Follow the CSS_PATH/JS_PATH constants through
+    // the landing page response so the test is resilient to content-hash
+    // changes.
+    const landing = await app.request("/");
+    const html = await landing.text();
+    const match = html.match(/src="(\/assets\/scripts-[^"]+\.js)"/);
+    expect(match).toBeTruthy();
+    const jsPath = match?.[1];
+    expect(jsPath).toBeTruthy();
+    const js = await (await app.request(jsPath as string)).text();
+    expect(js).toContain("navigator.modelContext");
+    expect(js).toContain("scan_domain");
+    expect(js).toContain("/api/check");
+  });
+});


### PR DESCRIPTION
## Summary

Exposes the public scan API to AI agents via standard discovery mechanisms, addressing the isitagentready.com audit findings.

- **Link response headers (RFC 8288)** on every HTML page, advertising `api-catalog`, `service-desc`, `service-doc`, and `status` relations.
- **`/.well-known/api-catalog`** — RFC 9727 linkset (`application/linkset+json`) anchored at `/api/check`.
- **`/openapi.json`** — OpenAPI 3.1 document covering `/api/check`, `/api/check/stream`, `/check`, `/health`, and the catalog. 19 schemas mirror `src/analyzers/types.ts`.
- **`/docs/api`** — Human-readable API reference page.
- **Markdown for agents** — `Accept: text/markdown` (or `?format=md`) on `/`, `/check`, `/scoring`, `/learn`, and `/docs/api` returns a markdown rendering with `Content-Type: text/markdown; charset=utf-8`. Noindexed.
- **WebMCP** — Client JS registers a `scan_domain` tool via `navigator.modelContext.provideContext()` when that API exists; silent no-op otherwise.

## Out of scope

OAuth/OIDC discovery and protected resource metadata (dmarcheck has no auth), MCP server card (separate project), agent-skills discovery index (draft RFC, low urgency).

## Test plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` — 338/338 pass, including 12 new tests in `test/agent-discovery.test.ts`
- [x] Dev server smoke test: `Link` header present on `/`, catalog + OpenAPI + markdown report all return expected content
- [ ] Post-deploy: re-run isitagentready.com and confirm Link / catalog / markdown / WebMCP checks flip to passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)