### PR TITLE
⚡ Bolt: Replace Object.entries() with for...in loops in middleware

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -192,8 +192,11 @@ app.use("/check", async (c, next) => {
 
   const headers = rateLimitHeaders(remaining);
   await next();
-  for (const [key, value] of Object.entries(headers)) {
-    c.res.headers.set(key, value);
+  // ⚡ Bolt Optimization: Use for...in instead of Object.entries() on hot paths.
+  // Avoids allocating an array of key-value tuples for headers on every request,
+  // reducing GC pressure for high-traffic middleware.
+  for (const key in headers) {
+    c.res.headers.set(key, headers[key]);
   }
 });
 
@@ -216,8 +219,8 @@ app.use("/check/score", async (c, next) => {
 
   const headers = rateLimitHeaders(remaining);
   await next();
-  for (const [key, value] of Object.entries(headers)) {
-    c.res.headers.set(key, value);
+  for (const key in headers) {
+    c.res.headers.set(key, headers[key]);
   }
 });
 
@@ -238,8 +241,8 @@ app.use("/api/check", async (c, next) => {
 
   const headers = rateLimitHeaders(remaining);
   await next();
-  for (const [key, value] of Object.entries(headers)) {
-    c.res.headers.set(key, value);
+  for (const key in headers) {
+    c.res.headers.set(key, headers[key]);
   }
 });
 
@@ -263,8 +266,8 @@ app.use("/api/check/stream", async (c, next) => {
 
   const headers = rateLimitHeaders(remaining);
   await next();
-  for (const [key, value] of Object.entries(headers)) {
-    c.res.headers.set(key, value);
+  for (const key in headers) {
+    c.res.headers.set(key, headers[key]);
   }
 });
 


### PR DESCRIPTION
💡 **What**: Replaced `Object.entries()` with `for...in` loops when iterating over `headers` in the 4 instances of rate-limit middleware within `src/index.ts`. Added a comment explaining the performance rationale.

🎯 **Why**: `Object.entries()` inherently allocates a new array, and an inner array tuple for every `[key, value]` pair on the object. In the context of a Hono middleware that gets executed on every request (a "hot path"), these continuous temporary object allocations unnecessarily increase memory usage and add pressure to the Garbage Collector. Using a simple `for...in` loop reads directly from the object's properties, bypassing the array allocations.

📊 **Impact**: Reduces GC pressure and memory allocation overhead per-request, yielding small but continuous latency improvements for the high-throughput endpoints.

🔬 **Measurement**: Verified using `pnpm lint` and `pnpm test` that functionality is fully preserved. All tests pass successfully.

---
*PR created automatically by Jules for task [17038004316882502398](https://jules.google.com/task/17038004316882502398) started by @schmug*