### PR TITLE
🎨 Palette: Improve mobile UX for domain and selector inputs

### DIFF
--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -134,7 +134,7 @@ export function renderLandingPage(): string {
       <h1 class="tagline">DNS email security analyzer &mdash; DMARC, SPF, DKIM, BIMI &amp; MTA-STS</h1>
       <form action="/check" method="GET">
         <div class="search-box">
-          <input type="text" name="domain" placeholder="Enter a domain (e.g., google.com)" aria-label="Enter a domain" autofocus required>
+          <input type="text" name="domain" placeholder="Enter a domain (e.g., google.com)" aria-label="Enter a domain" autocapitalize="none" autocorrect="off" spellcheck="false" autofocus required>
           <button type="submit">Scan</button>
         </div>
         <details class="advanced-options">
@@ -144,6 +144,9 @@ export function renderLandingPage(): string {
             <input type="text" id="selectors" name="selectors"
                    placeholder="e.g. myselector, custom2"
                    autocomplete="off"
+                   autocapitalize="none"
+                   autocorrect="off"
+                   spellcheck="false"
                    aria-describedby="selectors-help" />
             <small id="selectors-help">Comma-separated. These are checked in addition to the 38 common selectors.</small>
           </div>

--- a/src/views/learn.ts
+++ b/src/views/learn.ts
@@ -123,7 +123,7 @@ function learnCta(placeholder: string): string {
     <div class="bd-card-body">
       <form action="/check" method="GET" class="learn-cta-form">
         <div class="search-box">
-          <input type="text" name="domain" placeholder="${esc(placeholder)}" aria-label="Enter a domain" required>
+          <input type="text" name="domain" placeholder="${esc(placeholder)}" aria-label="Enter a domain" autocapitalize="none" autocorrect="off" spellcheck="false" required>
           <button type="submit">Scan</button>
         </div>
       </form>


### PR DESCRIPTION
### 💡 What
Added `autocapitalize="none"`, `autocorrect="off"`, and `spellcheck="false"` to the domain and DKIM selector inputs across the application (in the main landing page, the advanced options, and the learning center call-to-actions).

### 🎯 Why
Domains and DKIM selectors are highly technical strings. When a user tries to type "example.com" or "google._domainkey" on a mobile device, OS-level autocorrect and auto-capitalization can mistakenly alter their input, causing frustration and forcing them to re-type or dismiss autocorrect suggestions multiple times. These attributes instruct the device's keyboard to leave the user's input alone, creating a smoother, more reliable text entry experience.

### 📸 Before/After
*(Visual change is in the behavior of the mobile keyboard, the inputs themselves remain unchanged visually)*

### ♿ Accessibility
This fundamentally improves the usability of the primary user input fields, particularly for mobile users, ensuring they can input technical queries effortlessly without combating OS-level text correction algorithms.

---
*PR created automatically by Jules for task [10008900596974642337](https://jules.google.com/task/10008900596974642337) started by @schmug*