### PR TITLE
Add Claude Code automations for analyzer + security guardrails

### DIFF
--- a/.claude/agents/analyzer-reviewer.md
+++ b/.claude/agents/analyzer-reviewer.md
@@ -1,0 +1,96 @@
+---
+name: analyzer-reviewer
+description: Review new or modified protocol analyzers in src/analyzers/ for conformance to dmarcheck's analyzer contract (status taxonomy, null-on-NXDOMAIN, Promise.allSettled compatibility, scoring integration, test coverage). Invoke on any change touching src/analyzers/**, src/orchestrator.ts, src/shared/scoring.ts, or their tests — before commit or PR.
+tools: Read, Grep, Glob, Bash
+model: inherit
+---
+
+You review protocol analyzers in the dmarcheck codebase (DNS email-security analyzer: DMARC/SPF/DKIM/BIMI/MTA-STS). All analyzers follow a rigid shape — your job is to catch drift early.
+
+## Scope
+
+You are invoked on changes to:
+- `src/analyzers/*.ts` (analyzer modules)
+- `src/analyzers/types.ts` (shared result types)
+- `src/orchestrator.ts` (wiring)
+- `src/shared/scoring.ts` (grade integration)
+- `test/*.test.ts` (corresponding tests)
+
+If the diff touches nothing in these paths, exit early and say so.
+
+## Discovery
+
+1. Run `git diff --stat origin/main...HEAD` (or `git diff --stat` if the branch hasn't been pushed) to identify changed files.
+2. `Read` each changed analyzer and its test file in full.
+3. Skim `src/analyzers/spf.ts` and `src/analyzers/dmarc.ts` as reference shape if unfamiliar.
+
+## Checklist
+
+For each analyzer module, verify:
+
+### Contract
+- Exports a single async function: `analyzeFoo(domain: string, ...): Promise<FooResult>`.
+- Return type is declared in `src/analyzers/types.ts` and extends the analyzer result pattern (`status`, a record field, `validations: Validation[]`).
+- `status` is one of `"pass" | "warn" | "fail" | "info"` (see `Status` in types.ts). Informational-only analyzers (MX) use `"info"`; scored analyzers use pass/warn/fail.
+- `status` is derived from validations at the end: fail if any `fail`, else warn if any `warn`, else pass. The SPF pattern in `src/analyzers/spf.ts:92-94` is canonical.
+
+### DNS error handling
+- DNS lookups go through `src/dns/client.ts` helpers (`queryTxt`, `queryMx`, `queryA`, etc.) — never raw `node:dns` imports.
+- NXDOMAIN / NODATA returns `null`, not an exception. Analyzer must handle `null` as "record not found" and emit a `fail` validation, not throw.
+- If the analyzer fetches over HTTP (like MTA-STS), network errors must be caught and converted to a `fail` validation.
+
+### Concurrency safety
+- Analyzer must be safe to run inside `Promise.allSettled` — no shared mutable state at module scope, no reliance on other analyzers' results being already resolved.
+- If it needs another analyzer's output (e.g. BIMI needs DMARC's policy), verify the orchestrator chains them via `.then()` — see `src/orchestrator.ts:95-100`.
+
+### Orchestrator wiring
+- New analyzer is imported in `src/orchestrator.ts`.
+- Called in both `scan()` and `scanStreaming()`.
+- In `scanStreaming`, a `.then()` handler calls `onResult(protocolId, result)` AND adds a `Sentry.addBreadcrumb` with category `"analyzer.complete"`.
+- Added to the `ProtocolId` union and `ProtocolResult` union at the top of orchestrator.ts.
+- Added to the `protocols` object passed to `buildScanResult`.
+
+### Scoring integration
+- If scored: result type is added to the `Protocols` interface in `src/shared/scoring.ts`.
+- Protocol summary added to `buildProtocolSummaries` with the exact protocol key used elsewhere (e.g. `mta_sts`, not `mtaSts`).
+- If the analyzer affects grade tiers, `resolveScoring` is updated — verify the tier logic still matches CLAUDE.md's description ("F if no DMARC or p=none").
+- `PROTO_LABELS` in `src/views/components.ts:304-310` includes the new protocol key.
+
+### Tests
+- A `test/<name>.test.ts` file exists.
+- Uses `vi.mock("../src/dns/client.js", ...)` with `vi.resetAllMocks()` in `beforeEach` — see `test/mta-sts.test.ts:3-16`.
+- Covers at least: no-record case, happy path, one malformed-input case.
+- Does NOT hit the real network — mock `fetch` with `vi.spyOn(globalThis, "fetch")` if the analyzer fetches.
+
+### Security
+- Any user-supplied input (domain, selector) must already have been validated upstream — do not re-interpolate raw input into shell commands, URLs, or HTML.
+- If the analyzer issues `fetch()`, verify `redirect:` mode is explicit. For MTA-STS specifically, it MUST be `"manual"` (see `CLAUDE.md` §Security — this regressed twice).
+
+## Output format
+
+Structured, high-signal. Group by severity:
+
+```
+## Analyzer review — <analyzer name>
+
+### Blocking (must fix)
+- <file:line> — <specific issue and why>
+
+### Warnings (should fix)
+- <file:line> — <specific issue>
+
+### Observations
+- <non-blocking notes>
+
+### Verified
+- <list of checklist items that passed>
+```
+
+If nothing is wrong, say "No issues found" and list the verified checklist items.
+
+## Rules
+
+- Always cite `file:line` (not just file name).
+- Do not suggest fixes beyond the analyzer contract — a human reviewer handles style/performance.
+- If you find a Blocking issue, state it as a fact, not a suggestion. Example: "Blocking: analyzer throws on NXDOMAIN (src/analyzers/foo.ts:42) — contract requires null-return."
+- Skip cosmetic feedback; Biome handles formatting.

--- a/.claude/agents/security-hardening-reviewer.md
+++ b/.claude/agents/security-hardening-reviewer.md
@@ -1,0 +1,84 @@
+---
+name: security-hardening-reviewer
+description: Audit dmarcheck code changes against the project's documented security invariants (input validation regexes, HTML escaping, GitHub Actions pinning and runners, MTA-STS redirect mode). Invoke on any PR or staged diff before merging, especially when changes touch src/index.ts, src/views/, .github/workflows/, or src/analyzers/mta-sts.ts.
+tools: Read, Grep, Glob, Bash
+model: inherit
+---
+
+You audit dmarcheck (public Cloudflare Worker) for regressions against its documented security invariants. The invariants live in `CLAUDE.md` §Security and are non-negotiable — several have regressed via PR before.
+
+## Scope
+
+Run on the current diff. Focus your attention on:
+- `src/index.ts` — input validation (`normalizeDomain`, rate limiting)
+- `src/api/catalog.ts` — selector parsing (`parseSelectors`)
+- `src/views/**` — HTML generation (no raw user input in inline `<script>`)
+- `src/analyzers/mta-sts.ts` — redirect mode
+- `.github/workflows/*.yml` — runners, action pinning, permissions
+- Any new `fetch()` call anywhere in `src/`
+
+## Discovery
+
+1. Run `git diff --stat origin/main...HEAD` (or `git diff --stat` if no remote).
+2. `Read` each changed file in the scope above, in full.
+3. `Read` `CLAUDE.md` §Security for the authoritative invariant list.
+
+## Invariants to verify
+
+### 1. Input validation (src/index.ts, src/api/catalog.ts)
+- `normalizeDomain` must restrict user-supplied domains to `[a-z0-9.-]`. Any relaxation is a blocking issue.
+- `parseSelectors` must restrict DKIM selectors to `[A-Za-z0-9._-]`.
+- Neither regex should be bypassed via a new code path.
+
+### 2. HTML output (src/views/**)
+- User input MUST pass through `esc()` (`src/views/components.ts:28`) before HTML interpolation.
+- Raw user input MUST NOT appear inside inline `<script>` blocks. The approved pattern is `data-*` attributes populated via `esc()`, read by the bundled client script. If you see a new `<script>${...}</script>` containing interpolated user input, that is a blocking issue.
+- `data-*` attribute values must still be escaped.
+
+### 3. MTA-STS fetch (src/analyzers/mta-sts.ts)
+- The policy fetch MUST use `redirect: "manual"`. Not `"error"`, not `"follow"`, not omitted.
+- This regressed via PRs #58 and #92 — call it out as a blocking issue with explicit reference.
+- The guard `resp.type === "opaqueredirect"` or `!resp.ok` must still reject redirected responses.
+
+### 4. GitHub Actions (.github/workflows/**)
+- No job uses `runs-on: self-hosted` or a self-hosted runner label. Blocking.
+- Every `uses:` is pinned to a full 40-character commit SHA with a `# v<version>` trailing comment. Tag-only refs (`@v4`) are blocking.
+- Every workflow file declares a top-level `permissions:` block. Missing = blocking.
+- Job-level `permissions:` only elevates where necessary (e.g. `release.yml` needs `contents: write` for tag push).
+
+### 5. New network calls (anywhere in src/)
+- Any new `fetch(...)` must specify `redirect:` explicitly and not allow unbounded following of cross-origin redirects.
+- No new calls to `eval` or dynamic function constructors (treat string-to-code conversion as blocking).
+- No secrets, tokens, API keys, or env values committed in code.
+
+### 6. Dependencies (package.json, package-lock.json)
+- If package.json added a new dep, flag it for human review (license, maintenance, size).
+- If `@emnapi/*` deps are removed, that is a blocking issue — see `CLAUDE.md` memory about PR #111 and macOS lockfile drift.
+
+## Output format
+
+```
+## Security review
+
+### Blocking (must fix before merge)
+- <file:line> — <invariant violated> — <reference to CLAUDE.md or prior PR>
+
+### High-priority warnings
+- <file:line> — <what's suspicious and why>
+
+### Verified
+- <list of invariants explicitly checked and passing>
+
+### Not applicable
+- <list of invariants not relevant to this diff>
+```
+
+If no issues, say "No blocking issues found" and enumerate what you verified.
+
+## Rules
+
+- Cite `file:line` for every finding.
+- Prefer false positives to false negatives — surface anything suspicious, but mark confidence.
+- Don't review style, tests, or refactoring — Biome and CI handle those.
+- If the diff doesn't touch your scope, say so in one line and exit.
+- Never mark something Verified unless you actually Read the relevant code in this run.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,6 +23,26 @@
             "statusMessage": "Running tests & typecheck..."
           }
         ]
+      },
+      {
+        "matcher": "Bash(npm run deploy*)|Bash(wrangler deploy*)|Bash(npx wrangler deploy*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo 'Blocked: deploys run via Cloudflare Git integration on push to main. Running wrangler deploy manually causes intermittent stale deploys. See CLAUDE.md §Commands.' >&2; exit 2",
+            "statusMessage": "Blocking manual deploy..."
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r 'if ((.tool_input.file_path // \"\") | test(\"src/analyzers/mta-sts\\\\.ts$\")) then (.tool_input.new_string // .tool_input.content // \"\") else \"\" end' | grep -qE 'redirect:[[:space:]]*\"(error|follow)\"' && { echo 'Blocked: MTA-STS fetch must use redirect: \"manual\" (RFC 8461 §3.3). This regressed twice via PRs #58 and #92 — see CLAUDE.md §Security.' >&2; exit 2; } || exit 0",
+            "statusMessage": "Checking MTA-STS redirect mode..."
+          }
+        ]
       }
     ]
   }

--- a/.claude/skills/dmarcus-mood-check/SKILL.md
+++ b/.claude/skills/dmarcus-mood-check/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: dmarcus-mood-check
+description: Invariants and conventions for DMarcus, the dmarcheck mascot (the @ creature with three legs). Use when editing src/views/components.ts, src/views/styles.ts, src/views/scripts.ts, or any view that renders the creature — to ensure sizes, moods, party-hat rules, grade-to-mood mapping, and the reduced-motion contract stay consistent.
+user-invocable: false
+---
+
+# DMarcus mood + rendering invariants
+
+DMarcus is the dmarcheck mascot: an orange `@` character with googly eyes and three legs. He appears in the landing page, report header, loading state, error page, nav, footer, and as an idle easter egg. Any change to his rendering must preserve the invariants below.
+
+## Where he lives
+
+- **Render helper:** `generateCreature(size, mood?, partyHat?)` in `src/views/components.ts`.
+- **Mood mapping:** `gradeToMood(grade)` in the same file.
+- **Styles + animation:** `src/views/styles.ts` (selectors: `.creature`, `.creature-eyes`, `.creature-legs`, `.creature-partying`, etc.).
+- **Easter-egg behavior:** `src/views/scripts.ts` (idle walk/eat, 60s trigger, panic on interaction).
+
+## Invariants
+
+### Sizes
+Exactly three: `lg` | `md` | `sm`. Used as:
+- `lg` — landing page logo
+- `md` — grade reactions in the report header, footer
+- `sm` — nav links
+
+Do NOT introduce `xl`, `xs`, or numeric sizes. If a new context needs a size variant, map it to the closest existing size.
+
+### Moods
+Exactly five: `celebrating` | `content` | `worried` | `scared` | `panicked`.
+Mood is ONLY passed when rendering a grade-reaction creature (in the report). Landing, nav, and footer creatures have no mood class.
+
+### Grade → mood mapping (must match `gradeToMood`)
+- `S` → `celebrating` (perfect grade, easter egg)
+- `A+` / `A` / `A-` → `celebrating`
+- `B+` / `B` / `B-` → `content`
+- `C+` / `C` / `C-` → `worried`
+- `D+` / `D` / `D-` → `scared`
+- `F` → `panicked`
+
+Only the first character (A/B/C/D/F) matters except for `S`.
+
+### Party hat
+- `partyHat = true` ONLY for the `S` grade (perfect, with the `dmarc.mx` TXT easter egg triggered in orchestrator).
+- Party hat enables the `creature-partying` animation class (dance).
+- Never ship party hat for any A-tier grade, even `A+`. The distinction is intentional.
+
+### Accessibility
+- Creature HTML includes `aria-hidden="true"` — DMarcus is decorative. His meaning is conveyed by the grade text elsewhere.
+- If you add text near the creature, ensure the textual grade/status is still the authoritative signal for screen readers.
+
+### Reduced motion (easter egg)
+- The idle creature-walk-around-eating-the-page easter egg in `src/views/scripts.ts` MUST respect `prefers-reduced-motion: reduce`. Check with `window.matchMedia("(prefers-reduced-motion: reduce)")` before starting the animation; disable or significantly reduce movement if set.
+- The 60-second idle trigger and the panic-on-interaction behavior should also be suppressed under reduced motion.
+- Party-hat dance animation should ideally also gate on reduced-motion, but at minimum the idle easter egg must.
+
+### Name
+The mascot's name is **DMarcus** — not "the creature", "@-character", "the mascot", etc. Use the name in user-facing strings (loading text, footer "Guarded by DMarcus", error page, aria-labels where a human name helps).
+
+The name is a pun on DMARC. Do not rename.
+
+### Color
+Orange accent `#f97316` — pulled from the existing theme tokens, not hardcoded. Light/dark theme variants are already handled in `src/views/styles.ts`; new creature-specific styling should use CSS variables, not literal hex.
+
+## Before committing changes
+
+When your change touches the creature:
+- Read `src/views/components.ts` (`generateCreature`, `gradeToMood`) to confirm you haven't drifted from the helper.
+- Grep for `creature-` class selectors to make sure any new class you added is styled in `src/views/styles.ts`.
+- If you added a new mood or size: update this skill file to match.
+
+## When NOT to apply
+
+- Editing non-view code (analyzers, scoring, DNS) — DMarcus invariants don't apply.
+- Pure text copy changes in views that don't render the creature.
+- Changes to non-creature UI elements (forms, tables, cards) — those have their own conventions in `CLAUDE.md` §Conventions.

--- a/.claude/skills/new-analyzer/SKILL.md
+++ b/.claude/skills/new-analyzer/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: new-analyzer
+description: Scaffold a new protocol analyzer for dmarcheck. Creates the analyzer module, types, orchestrator wiring, scoring hook-in, HTML component, and a test file — all matching the existing shape of src/analyzers/spf.ts and test/spf.test.ts. Use when adding support for a new DNS/email-security protocol (e.g. ARC, TLS-RPT, DANE).
+---
+
+# Scaffolding a new protocol analyzer
+
+Adding a protocol analyzer to dmarcheck touches six places in a predictable pattern. This skill walks through them in order. Skip nothing — the orchestrator, scoring, and HTML report all assume the same contract.
+
+## Prerequisites
+
+Ask the user for:
+1. **Protocol name** — short lowercase identifier (e.g. `arc`, `tls_rpt`, `dane`). Use snake_case if multi-word.
+2. **Human label** — for UI (e.g. "ARC", "TLS-RPT").
+3. **Informational or scored?** — informational protocols (like MX) use `status: "info"` and don't feed the grade. Scored protocols can affect the grade tier in `src/shared/scoring.ts`.
+4. **Data source** — TXT lookup, fetched policy, MX chain, etc.
+
+If unclear, ask before generating anything.
+
+## Reference implementations
+
+Before writing, Read these as templates:
+- Pure DNS-lookup analyzer: `src/analyzers/dmarc.ts` + `test/analyzers.test.ts`
+- DNS + HTTP fetch: `src/analyzers/mta-sts.ts` + `test/mta-sts.test.ts`
+- Informational (no grade impact): `src/analyzers/mx.ts` + `test/mx.test.ts`
+- Result types: `src/analyzers/types.ts`
+- Orchestrator pattern: `src/orchestrator.ts`
+- Scoring integration: `src/shared/scoring.ts`
+
+## Steps
+
+### 1. Add the result type
+
+Edit `src/analyzers/types.ts`. Add:
+
+```ts
+export interface FooResult {
+  status: Status;
+  record: string | null;
+  // ...protocol-specific fields...
+  validations: Validation[];
+}
+```
+
+Then add `foo: FooResult` to `ScanResult.protocols`.
+
+### 2. Create the analyzer module
+
+Create `src/analyzers/foo.ts`:
+
+```ts
+import { queryTxt } from "../dns/client.js";
+import type { FooResult, Validation } from "./types.js";
+
+export async function analyzeFoo(domain: string): Promise<FooResult> {
+  const validations: Validation[] = [];
+
+  const txt = await queryTxt(`_foo.${domain}`);
+  if (!txt) {
+    return {
+      status: "fail",
+      record: null,
+      validations: [{ status: "fail", message: "No _foo record found" }],
+    };
+  }
+
+  const record = txt.entries.find((e) => e.startsWith("v=FOO1"));
+  if (!record) {
+    return {
+      status: "fail",
+      record: null,
+      validations: [{ status: "fail", message: "No v=FOO1 record" }],
+    };
+  }
+
+  validations.push({ status: "pass", message: "Foo record found" });
+  // ...protocol-specific validations...
+
+  const hasFailure = validations.some((v) => v.status === "fail");
+  const hasWarn = validations.some((v) => v.status === "warn");
+  const status = hasFailure ? "fail" : hasWarn ? "warn" : "pass";
+
+  return { status, record, validations };
+}
+```
+
+**Critical contract rules** (the `analyzer-reviewer` subagent will enforce these):
+- DNS errors (NXDOMAIN/NODATA) come back from `queryTxt` etc. as `null`. Return a `fail` validation — never throw.
+- If the analyzer uses `fetch()`, wrap in try/catch and convert errors to `fail` validations. Always specify `redirect:` explicitly. For any policy fetch, `redirect: "manual"` is the safe default.
+- Derive the final `status` from validations using the pattern above.
+- The function must be safe to run inside `Promise.allSettled` — no module-scope mutable state.
+
+### 3. Wire into the orchestrator
+
+Edit `src/orchestrator.ts`:
+
+1. Import: `import { analyzeFoo } from "./analyzers/foo.js";`
+2. Add `"foo"` to `ProtocolId` union and `FooResult` to `ProtocolResult` union.
+3. In `scan()`:
+   ```ts
+   const fooPromise = analyzeFoo(domain);
+   ```
+   Add it to the `Promise.all([...])` array and destructure the result.
+4. In `scanStreaming()`, do the same AND add:
+   ```ts
+   fooPromise.then((r) => {
+     Sentry.addBreadcrumb({
+       category: "analyzer.complete",
+       message: `foo: ${r.status}`,
+       data: { protocol: "foo", status: r.status },
+       level: "info",
+     });
+     onResult("foo", r);
+   });
+   ```
+5. Pass `foo: fooResult` into `buildScanResult`.
+
+### 4. Wire into scoring (skip if informational-only)
+
+Edit `src/shared/scoring.ts`:
+
+1. Add `foo: FooResult` to the `Protocols` interface and to the `ScoringFactor["protocol"]` / `Recommendation["protocol"]` unions.
+2. Add a `buildProtocolSummaries` entry:
+   ```ts
+   foo: {
+     status: foo.status,
+     summary: foo.record ? "Configured" : "Not configured",
+   },
+   ```
+3. If the protocol affects tier: update `resolveScoring`. If it only contributes a ±1 modifier: add a `fooFactors(...)` helper and call it from the relevant tier branches.
+4. If it warrants a recommendation: extend `generateRecommendations` with appropriate `priority`, `title`, `description`, `impact`.
+
+### 5. Register the HTML label and card
+
+Edit `src/views/components.ts`:
+
+1. Add `foo: "FOO"` (or human label) to `PROTO_LABELS`.
+2. If the report needs a custom body (tag grid, MX-style table, SPF-tree-style visualization), add a helper here; otherwise the default `protocolCard` will render validations via `validationList`.
+
+Edit `src/views/html.ts` (or wherever protocol cards are rendered — search for a sibling protocol like `dkim` to find the exact location).
+
+### 6. Test
+
+Create `test/foo.test.ts` modeled on `test/mta-sts.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/dns/client.js", () => ({
+  queryTxt: vi.fn(),
+}));
+
+import { analyzeFoo } from "../src/analyzers/foo.js";
+import { queryTxt } from "../src/dns/client.js";
+
+const mockQueryTxt = vi.mocked(queryTxt);
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.restoreAllMocks();
+});
+
+describe("analyzeFoo", () => {
+  it("returns fail when no record", async () => {
+    mockQueryTxt.mockResolvedValue(null);
+    const result = await analyzeFoo("example.com");
+    expect(result.status).toBe("fail");
+    expect(result.record).toBeNull();
+  });
+
+  it("returns pass for a valid record", async () => {
+    mockQueryTxt.mockResolvedValue({
+      entries: ["v=FOO1; ..."],
+    });
+    const result = await analyzeFoo("example.com");
+    expect(result.status).toBe("pass");
+  });
+
+  // Add one malformed-input case and any protocol-specific edge cases.
+});
+```
+
+### 7. Verify
+
+Run:
+```
+npm test
+npm run lint
+npm run typecheck
+```
+
+If any of these fail, fix before committing. The pre-commit hook will re-run them anyway.
+
+### 8. Update docs
+
+- Add the new analyzer to `CLAUDE.md` §Architecture (analyzers list).
+- If user-facing: add a brief explanation to `README.md` and the `/learn` markdown page.
+
+## When you're done
+
+Invoke the `analyzer-reviewer` subagent on the diff — it checks the analyzer contract and catches drift.

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "sentry": {
+      "type": "http",
+      "url": "https://mcp.sentry.dev/mcp"
+    },
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds six Claude Code automations tailored to dmarcheck's documented regression patterns and analyzer contract. Read-only analysis pass recommended these; this PR implements all of them.

- **Hooks** (`.claude/settings.json`):
  - Blocks `npm run deploy` / `wrangler deploy` / `npx wrangler deploy` — CLAUDE.md explicitly warns manual deploys collide with the Git integration auto-deploy.
  - Blocks `Edit|Write` on `src/analyzers/mta-sts.ts` that changes `redirect:` away from `"manual"`. This invariant regressed twice via PRs #58 and #92; a hook catches a third attempt before it lands.
- **Subagents** (`.claude/agents/`):
  - `analyzer-reviewer` — enforces the analyzer contract (status taxonomy, null-on-NXDOMAIN, `Promise.allSettled` safety, orchestrator wiring, scoring integration, test pattern).
  - `security-hardening-reviewer` — audits CLAUDE.md §Security invariants (input validation regexes, HTML escaping, runner/permissions/SHA pinning in workflows, MTA-STS redirect mode, `@emnapi/*` lockfile pin).
- **Skills** (`.claude/skills/`):
  - `new-analyzer` — six-step scaffold walkthrough for adding a protocol (module → types → orchestrator → scoring → views → test).
  - `dmarcus-mood-check` — Claude-only (`user-invocable: false`) knowledge of the mascot's invariants (sizes, moods, grade→mood map, party-hat S-only rule, reduced-motion contract).
- **`.mcp.json`** — team-shared config adding Sentry (hosted remote, OAuth on first use) and context7 (live docs lookup). Cloudflare MCP stays in the user's global config.

Skips things already in place: Biome PostToolUse format, pre-commit test+typecheck hook, globally-configured Cloudflare MCP.

## Test plan

- [x] `npm run lint` — clean (41 files)
- [x] `npm test` — 338/338 passing
- [x] `npm run typecheck` — clean
- [x] `.claude/settings.json` validates as JSON (`jq .`)
- [x] `.mcp.json` validates as JSON
- [x] MTA-STS redirect-mode hook smoke-tested against safe edit, unsafe edit (`redirect: "error"`), and unrelated-file edit
- [ ] After merge: run `/agents` to confirm both subagents appear; run `/new-analyzer` to confirm the skill is invocable; verify `.mcp.json` servers connect (`claude mcp list`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)