### PR TITLE
Phase 1 freemium: WorkOS auth + D1 + user dashboard

### DIFF
--- a/docs/superpowers/plans/2026-04-01-phase1-auth-d1-dashboard.md
+++ b/docs/superpowers/plans/2026-04-01-phase1-auth-d1-dashboard.md
@@ -1,0 +1,142 @@
+# Freemium Monetization Phase 1 — Auth + D1 + Dashboard Implementation Plan
+
+> **Historical note (2026-04-18):** This plan was drafted on 2026-04-01 but never committed. It is committed now alongside the implementation. The original implementation lived on `feat/freemium-auth-dashboard-v1` and was rebuilt onto current main (which had since received ~30 commits) as `feat/freemium-phase1`.
+
+**Goal:** Land the identity + persistence foundation for freemium monetization — WorkOS AuthKit login, D1-backed users/domains, and a minimal authenticated dashboard. No Stripe, no alerts, no API keys — those are Phases 2–3.
+
+**Spec:** `docs/superpowers/specs/2026-04-01-freemium-monetization-design.md`
+
+**Architecture:** Hand-rolled HS256 JWT sessions (`crypto.subtle`) — no library deps. WorkOS AuthKit via direct `fetch` to the user-management API — no SDK. D1 for persistence. Dashboard renders via existing template-literal HTML pattern.
+
+---
+
+### Task 1: D1 schema + Env types
+
+**Files:**
+- Create: `src/db/schema.sql`
+- Create: `src/env.ts`
+- Modify: `wrangler.toml` (add `[[d1_databases]]` binding)
+
+- [ ] Define the D1 schema with tables: `users`, `domains`, `scan_history`, `alerts`, `webhooks`. Include forward-compat columns (`stripe_customer_id`, `api_key` on users) even though Phase 1 does not populate them.
+- [ ] Add indexes: `idx_domains_user_id`, `idx_scan_history_domain_id`, `idx_alerts_domain_id`, `idx_domains_last_scanned`.
+- [ ] Export `Env` interface declaring `DB: D1Database`, `WORKOS_CLIENT_ID`, `WORKOS_CLIENT_SECRET`, `WORKOS_REDIRECT_URI`, `SESSION_SECRET`.
+- [ ] Add D1 binding to `wrangler.toml` (binding `DB`, database `dmarcheck-db`, id `7e6e7e64-5477-458f-b206-941ea58b7dba`).
+
+### Task 2: User query module
+
+**Files:**
+- Create: `src/db/users.ts`
+- Create: `test/db-users.test.ts`
+
+- [ ] `createUser({ id, email })` — INSERT derives `email_domain` from the email suffix. Throws on unique-constraint violation.
+- [ ] `getUserByEmail(email)` — returns `{ id, email, email_domain, created_at } | null`.
+- [ ] `getUserById(id)` — same shape.
+- [ ] Tests cover: successful insert, duplicate email rejection, lookup by email, lookup by id, missing-user null return.
+
+### Task 3: Domain query module
+
+**Files:**
+- Create: `src/db/domains.ts`
+- Create: `test/db-domains.test.ts`
+
+- [ ] `createDomain({ userId, domain, isFree })` — enforces `UNIQUE(user_id, domain)`.
+- [ ] `getDomainsByUser(userId)` — returns array ordered by `created_at`.
+- [ ] `getDomainById(id)` with `userId` ownership check.
+- [ ] `deleteDomain(id, userId)` — ownership-checked delete.
+- [ ] Tests cover: create, list, get-with-ownership-check, delete-with-ownership-check, UNIQUE-constraint rejection.
+
+### Task 4: Session management (HS256 JWT via crypto.subtle)
+
+**Files:**
+- Create: `src/auth/session.ts`
+- Create: `test/session.test.ts`
+
+- [ ] `createSessionToken({ sub, email }, secret, ttlSeconds = 604800)` — returns `header.payload.signature` JWT string. Base64url-encodes each segment. Signs with HMAC-SHA256 via `crypto.subtle`.
+- [ ] `validateSessionToken(token, secret)` — verifies signature, checks `exp`, returns decoded `SessionPayload` or null.
+- [ ] Tests cover: round-trip (create → validate), expired token, tampered signature, malformed token (wrong segment count), wrong secret.
+
+### Task 5: Auth middleware
+
+**Files:**
+- Create: `src/auth/middleware.ts`
+- Create: `test/auth-middleware.test.ts`
+
+- [ ] `requireAuth(c, next)` — reads `session` cookie, validates via `validateSessionToken`, attaches decoded payload to `c` via `c.set("user", payload)`. Redirects to `/auth/login` on missing/invalid.
+- [ ] Tests cover: valid session passes through, missing cookie redirects, expired/tampered cookie redirects, downstream handler can read `c.get("user")`.
+
+### Task 6: Auth routes (WorkOS login / callback / logout)
+
+**Files:**
+- Create: `src/auth/routes.ts`
+- Create: `test/auth-routes.test.ts`
+
+- [ ] `GET /login` — builds the WorkOS authorize URL with `client_id`, `redirect_uri`, `response_type=code`, `provider=authkit`; 302 redirect.
+- [ ] `GET /callback` — exchanges the `code` param via `POST https://api.workos.com/user_management/authenticate`, upserts the user (handling the duplicate-email race with a try/catch around `createUser`), auto-provisions the free domain from the email suffix on first login, issues session cookie (`HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=604800`), redirects to `/dashboard`.
+- [ ] `GET /logout` — deletes the session cookie, redirects to `/`.
+- [ ] Tests cover: login builds correct WorkOS URL, callback rejects missing code (400), callback rejects WorkOS token-exchange failure (401), callback creates user + free domain on first login, callback reuses user on repeat login, callback handles concurrent-signup race, logout clears cookie.
+
+### Task 7: Dashboard views
+
+**Files:**
+- Create: `src/views/dashboard.ts`
+- Create: `test/dashboard-views.test.ts`
+
+- [ ] `renderDashboardList(user, domains)` — domain list page with grade badges, scan frequency, last-scanned time, and an "Add domain" form (free tier enforces one domain).
+- [ ] `renderDashboardDetail(user, domain)` — per-domain detail view with placeholder for scan history (Phase 2) and webhook configuration (Phase 2 stubs).
+- [ ] `renderDashboardSettings(user)` — account settings (email, logout link, placeholder for Phase 3 billing).
+- [ ] All views reuse the existing `generateCreature`, navigation, and styles from `src/views/components.ts` / `src/views/styles.ts` so the dashboard visually matches the public site.
+- [ ] Tests cover: list renders domain rows, detail renders domain, settings renders email, all pages escape user-controlled strings.
+
+### Task 8: Dashboard routes + wiring
+
+**Files:**
+- Create: `src/dashboard/routes.ts`
+- Create: `test/dashboard-routes.test.ts`
+- Modify: `src/index.ts` (mount `app.route("/auth", authRoutes)` and `app.route("/dashboard", dashboardRoutes)`; change `new Hono()` to `new Hono<{ Bindings: Env }>()`)
+
+- [ ] Sub-app applies `requireAuth` middleware to all routes.
+- [ ] `GET /` (dashboard index) → domain list.
+- [ ] `GET /:id` → domain detail.
+- [ ] `POST /domains` → create domain (validates free-tier single-domain rule).
+- [ ] `POST /domains/:id/delete` → delete domain (ownership-checked).
+- [ ] `POST /:id/scan` → stub returning 501 "Coming in Phase 2" (placeholder for scan-now button).
+- [ ] `GET /settings` → settings page.
+- [ ] `POST /settings/webhook` → stub accepting webhookUrl, validating HTTPS URL, persisting to `webhooks` table (Phase 1 stores; Phase 2 consumes).
+- [ ] Mount in `src/index.ts` after existing agent-discovery / content-negotiation routes but before the catch-all.
+- [ ] Tests cover: unauthenticated redirect, authenticated list, add-domain validation, delete ownership, webhook URL validation (reject non-HTTPS), scan-stub 501.
+
+### Task 9: Login link on landing page
+
+**Files:**
+- Modify: `src/views/components.ts` (or wherever the landing nav lives on current main)
+- Create: `test/nav-link.test.ts`
+
+- [ ] Add a "Log in" link to the landing page navigation, styled consistently with other nav links (use `--clr-accent`, not `--accent`).
+- [ ] The link points to `/auth/login`.
+- [ ] Test verifies the link renders on the landing page and has the correct href.
+
+### Task 10: WorkOS configuration + end-to-end verification
+
+**Files:** (no code files — secrets + D1 schema application + manual flow)
+
+- [ ] Provision a WorkOS application with AuthKit enabled; configure redirect URI to `http://localhost:8790/auth/callback` (dev) and `https://dmarc.mx/auth/callback` (prod).
+- [ ] `wrangler secret put WORKOS_CLIENT_ID` — paste WorkOS client ID.
+- [ ] `wrangler secret put WORKOS_CLIENT_SECRET` — paste WorkOS client secret.
+- [ ] `wrangler secret put WORKOS_REDIRECT_URI` — paste prod redirect URI.
+- [ ] `wrangler secret put SESSION_SECRET` — paste a fresh random 32-byte secret.
+- [ ] `wrangler d1 execute dmarcheck-db --remote --file=src/db/schema.sql` — apply schema to production D1.
+- [ ] `wrangler d1 execute dmarcheck-db --local --file=src/db/schema.sql` — apply to local dev D1.
+- [ ] Create `.dev.vars` with the same four secrets pointing to localhost redirect for `npm run dev`.
+- [ ] Exercise the full flow locally: landing → "Log in" → WorkOS AuthKit → callback → dashboard → add domain → logout. Capture + fix any runtime issues.
+
+## Verification
+
+- Unauthenticated paths unchanged: `/`, `/check`, `/learn/*`, `/scoring`, `/docs/api`, `/.well-known/api-catalog`, `/openapi.json`.
+- `/auth/login` 302s to `api.workos.com/user_management/authorize`.
+- `/auth/callback?code=...` with a valid code creates a user, creates one free domain, issues a session cookie, lands on `/dashboard`.
+- `/dashboard` without a session 302s to `/auth/login`.
+- `/dashboard` with a valid session renders the domain list.
+- `/auth/logout` clears the cookie and lands on `/`.
+- Duplicate login does not create duplicate users.
+- `npm run lint`, `npm run typecheck`, `npm test` all green.
+- PR opened against main; CI `check` status passes.

--- a/docs/superpowers/specs/2026-04-01-freemium-monetization-design.md
+++ b/docs/superpowers/specs/2026-04-01-freemium-monetization-design.md
@@ -1,0 +1,137 @@
+# Freemium Monetization — Design Spec
+
+> **Historical note (2026-04-18):** This spec was drafted on 2026-04-01 during the original monetization planning session but never committed. It is being committed now — unchanged in substance — alongside the Phase 1 implementation, as the PR it was written to support (`feat/freemium-auth-dashboard-v1`) was reworked into `feat/freemium-phase1` after a 17-day gap.
+
+## Context
+
+**dmarc.mx** is a polished, free, open-source DNS email security analyzer (DMARC, SPF, DKIM, BIMI, MTA-STS) deployed on Cloudflare Workers. It has zero monetization infrastructure today — no auth, no API keys, no payment processing, no premium tiers. The codebase is production-quality with a comprehensive test suite, strong UX (DMarcus mascot, confetti, gamification), and a clean architecture that naturally lends itself to tiered features.
+
+**Why monetize now:** The tool already delivers real value (comprehensive multi-protocol analysis, actionable recommendations, multiple export formats). The existing rate limiter, API endpoint, and CSV export are natural seams where free/paid boundaries can be introduced with minimal architectural disruption.
+
+**Competitive landscape:**
+
+| Competitor | Model | Pricing |
+|-----------|-------|---------|
+| MXToolbox | Free basic + paid monitoring | $129–499/mo |
+| Dmarcian | DMARC reporting SaaS | $100–500/mo |
+| EasyDMARC | Freemium SaaS | $25–300/mo |
+| PowerDMARC | MSP/MSSP-focused | $8–12/domain/mo |
+| Valimail | Enterprise automation | Enterprise pricing |
+
+dmarc.mx differentiates on: speed (edge-deployed), UX (creature branding, gamification), transparency (open-source scoring), and simplicity (zero signup for basic use).
+
+## Shodan-style freemium model
+
+- **Free tier:** 1 domain per account (auto-provisioned from the user's email suffix), monthly scan cadence, grade badge, email alerts.
+- **Paid tier:** $3/domain/month for weekly scans, webhook alerts, bulk API, no branding on embeds.
+- **Auth:** WorkOS AuthKit (hosted login), JWT sessions signed with `crypto.subtle` HS256.
+- **Payments:** Stripe Checkout (Phase 3).
+- **Data:** Cloudflare D1 for users, domains, scan history, alerts, webhooks.
+- **Alerts:** Resend email + webhook POST (Phase 2).
+
+## Principles
+
+1. **Keep the free tier generous.** The free tool is the top-of-funnel. Do not gate current functionality (single-domain scan, full protocol analysis, CSV export, rate limit, DMarcus).
+2. **API-first monetization.** API consumers (automation tools, MSPs, security vendors) have the highest willingness to pay and the lowest support burden.
+3. **Cloudflare-native.** Use KV/D1/R2/Cron/Email Workers to stay on one platform.
+4. **Preserve open source.** The core scanning engine stays MIT-licensed. Monetize the hosted service layer (monitoring, storage, reports), not the analysis logic.
+
+## What NOT to gate behind payment
+
+- Single-domain scanning (HTML + JSON + CSV)
+- Current 10 req/IP/60s rate limit
+- Full protocol analysis (all 5 protocols)
+- Scoring rubric and recommendations
+- Embeddable badge (basic tier)
+- DMarcus creature and all UX features
+- Agent-readiness discovery (`/.well-known/api-catalog`, `/openapi.json`, `/docs/api`)
+
+These stay free. They are the product's moat — the reason people discover and recommend dmarc.mx.
+
+## Phased roadmap
+
+```
+Phase 1 (this spec): Auth + D1 + Dashboard
+  └─ WorkOS AuthKit login
+  └─ JWT sessions (crypto.subtle HS256)
+  └─ D1 schema (users, domains, scan_history, alerts, webhooks)
+  └─ Dashboard views: domain list, detail, settings
+  └─ Free-tier auto-provisioning: 1 domain from email suffix
+
+Phase 2: Monitoring + Alerts
+  └─ Cloudflare Cron Trigger running existing orchestrator
+  └─ Delta detection vs last scan
+  └─ Resend email alerts (free tier)
+  └─ Webhook POST alerts (paid tier)
+
+Phase 3: Stripe Billing + Paid Features
+  └─ Stripe Checkout subscription flow
+  └─ Per-domain paid upgrades ($3/domain/mo)
+  └─ API key issuance with tiered rate limits
+  └─ Bulk /api/bulk endpoint (paid only)
+  └─ White-label option: suppress dmarc.mx branding in API responses
+
+Phase 4: Badge Endpoint
+  └─ GET /badge/:domain returning SVG
+  └─ Free: static grade badge, 24h cache
+  └─ Paid: real-time, custom colors, click-through, no branding
+```
+
+## Phase 1 scope
+
+Phase 1 builds only the identity + persistence foundation. It does NOT include Stripe, alerts, monitoring, API keys, or bulk endpoints — those are intentionally deferred.
+
+### Components
+
+- **`src/env.ts`** — typed bindings: `DB: D1Database`, `WORKOS_CLIENT_ID`, `WORKOS_CLIENT_SECRET`, `WORKOS_REDIRECT_URI`, `SESSION_SECRET`.
+- **`src/auth/session.ts`** — hand-rolled HS256 JWT via `crypto.subtle` (no library deps). 7-day TTL. `createSessionToken`, `validateSessionToken`.
+- **`src/auth/middleware.ts`** — `requireAuth` Hono middleware. Missing/invalid session → redirect to `/auth/login`.
+- **`src/auth/routes.ts`** — `/auth/login` (redirect to WorkOS), `/auth/callback` (code exchange, user upsert, session cookie), `/auth/logout` (cookie delete). Exchanges auth code directly via `fetch` to `api.workos.com/user_management/authenticate` — no SDK needed.
+- **`src/db/schema.sql`** — D1 schema (see below).
+- **`src/db/users.ts`**, **`src/db/domains.ts`** — typed query modules.
+- **`src/dashboard/routes.ts`** — mounted at `/dashboard`. Protected. Pages: list, detail, settings. Stubs "Scan Now" button as a Phase 2 placeholder.
+- **`src/views/dashboard.ts`** — HTML template literals for the dashboard pages.
+
+### D1 schema
+
+Forward-compatible with Phases 2–3 (includes `api_key`, `stripe_customer_id` on `users`; `scan_history`, `alerts`, `webhooks` tables):
+
+```sql
+users(id, email UNIQUE, email_domain, stripe_customer_id, api_key UNIQUE, created_at)
+domains(id, user_id, domain, is_free, scan_frequency, last_scanned_at, last_grade, created_at, UNIQUE(user_id, domain))
+scan_history(id, domain_id, grade, score_factors, protocol_results, scanned_at)
+alerts(id, domain_id, alert_type, previous_value, new_value, notified_via, created_at)
+webhooks(id, user_id, url, secret, created_at)
+```
+
+### Free-tier auto-provisioning
+
+On first successful `/auth/callback`, the callback handler:
+1. Upserts the user keyed by email (ignores unique-constraint race on concurrent signups).
+2. Creates one domain row for the user's email suffix (`alice@example.com` → `example.com`), `is_free = 1`.
+
+This makes the free experience usable immediately after signup without a separate "add your first domain" step.
+
+### Session cookie
+
+`Set-Cookie: session=<jwt>; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=604800` (7 days).
+
+### Rate limiting
+
+Dashboard routes are authenticated; they do not share the anonymous 10/IP/60s limit applied to `/check`. Phase 1 does not introduce separate authenticated rate limits — the assumption is that a logged-in user hitting the dashboard cannot materially increase load beyond what the DNS scan cost already covers. Revisit in Phase 3 alongside API keys.
+
+## Verification
+
+- Unauthenticated flows unchanged: landing, `/check`, agent-discovery endpoints, /learn, /scoring, /docs/api all still work without a session.
+- `/auth/login` redirects to WorkOS; `/auth/callback` issues a session cookie and lands on `/dashboard`.
+- Dashboard without a valid session redirects to `/auth/login`.
+- First login creates exactly one user row and one free domain row for the email suffix.
+- Concurrent first-login requests (duplicate signup race) yield exactly one user row.
+- Cookie is `HttpOnly; Secure; SameSite=Lax`.
+- CI green: lint, typecheck, all tests pass.
+
+## Open questions deferred to later phases
+
+- How to handle users who want to monitor a domain that doesn't match their email suffix (upgrade path to paid, or ownership verification via DNS TXT / email challenge)?
+- Rate limit tiering once API keys exist in Phase 3.
+- DMARC aggregate report ingestion (rua parsing) — potentially the highest-revenue feature, but a major new subsystem; parked until Phase 3 validates willingness to pay.

--- a/src/auth/middleware.ts
+++ b/src/auth/middleware.ts
@@ -1,0 +1,20 @@
+import type { Context, Next } from "hono";
+import { getCookie } from "hono/cookie";
+import { validateSessionToken } from "./session.js";
+
+export async function requireAuth(c: Context, next: Next) {
+  const sessionSecret = (c.env as { SESSION_SECRET: string }).SESSION_SECRET;
+  const token = getCookie(c, "session");
+
+  if (!token) {
+    return c.redirect("/auth/login");
+  }
+
+  const payload = await validateSessionToken(token, sessionSecret);
+  if (!payload) {
+    return c.redirect("/auth/login");
+  }
+
+  c.set("user" as never, payload);
+  await next();
+}

--- a/src/auth/routes.ts
+++ b/src/auth/routes.ts
@@ -1,0 +1,103 @@
+import { Hono } from "hono";
+import { deleteCookie, setCookie } from "hono/cookie";
+import { createDomain } from "../db/domains.js";
+import { createUser, getUserByEmail } from "../db/users.js";
+import { createSessionToken } from "./session.js";
+
+export const authRoutes = new Hono();
+
+authRoutes.get("/login", (c) => {
+  const env = c.env as {
+    WORKOS_CLIENT_ID: string;
+    WORKOS_REDIRECT_URI: string;
+  };
+  const params = new URLSearchParams({
+    client_id: env.WORKOS_CLIENT_ID,
+    redirect_uri: env.WORKOS_REDIRECT_URI,
+    response_type: "code",
+    provider: "authkit",
+  });
+  return c.redirect(
+    `https://api.workos.com/user_management/authorize?${params}`,
+  );
+});
+
+authRoutes.get("/callback", async (c) => {
+  const code = c.req.query("code");
+  if (!code) {
+    return c.text("Missing authorization code", 400);
+  }
+
+  const env = c.env as {
+    WORKOS_CLIENT_ID: string;
+    WORKOS_CLIENT_SECRET: string;
+    SESSION_SECRET: string;
+    DB: D1Database;
+  };
+
+  // Exchange code for user info
+  const tokenRes = await fetch(
+    "https://api.workos.com/user_management/authenticate",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        code,
+        client_id: env.WORKOS_CLIENT_ID,
+        client_secret: env.WORKOS_CLIENT_SECRET,
+        grant_type: "authorization_code",
+      }),
+    },
+  );
+
+  if (!tokenRes.ok) {
+    return c.text("Authentication failed", 401);
+  }
+
+  const data = (await tokenRes.json()) as {
+    user: { id: string; email: string };
+  };
+  const { id, email } = data.user;
+
+  // Create or find user (handle race condition on duplicate signups)
+  let user = await getUserByEmail(env.DB, email);
+  if (!user) {
+    try {
+      await createUser(env.DB, { id, email });
+      // Auto-provision free domain from email
+      const emailDomain = email.split("@")[1];
+      await createDomain(env.DB, {
+        userId: id,
+        domain: emailDomain,
+        isFree: true,
+      });
+    } catch {
+      // Unique constraint violation — user was created by a concurrent request
+    }
+    user = await getUserByEmail(env.DB, email);
+    if (!user) {
+      return c.text("Account creation failed", 500);
+    }
+  }
+
+  // Create session
+  const token = await createSessionToken(
+    { sub: user.id, email: user.email },
+    env.SESSION_SECRET,
+  );
+
+  setCookie(c, "session", token, {
+    httpOnly: true,
+    secure: true,
+    sameSite: "Lax",
+    path: "/",
+    maxAge: 7 * 24 * 60 * 60, // 7 days
+  });
+
+  return c.redirect("/dashboard");
+});
+
+authRoutes.get("/logout", (c) => {
+  deleteCookie(c, "session", { path: "/" });
+  return c.redirect("/");
+});

--- a/src/auth/session.ts
+++ b/src/auth/session.ts
@@ -1,0 +1,99 @@
+export interface SessionPayload {
+  sub: string;
+  email: string;
+  exp: number;
+}
+
+const ENCODER = new TextEncoder();
+const DEFAULT_TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
+
+function base64UrlEncode(data: ArrayBuffer | Uint8Array): string {
+  const bytes = data instanceof ArrayBuffer ? new Uint8Array(data) : data;
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function base64UrlDecode(str: string): Uint8Array {
+  const padded = str.replace(/-/g, "+").replace(/_/g, "/");
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+async function getKey(secret: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    "raw",
+    ENCODER.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign", "verify"],
+  );
+}
+
+export async function createSessionToken(
+  claims: { sub: string; email: string },
+  secret: string,
+  ttlSeconds: number = DEFAULT_TTL_SECONDS,
+): Promise<string> {
+  const header = base64UrlEncode(
+    ENCODER.encode(JSON.stringify({ alg: "HS256", typ: "JWT" })),
+  );
+  const payload: SessionPayload = {
+    sub: claims.sub,
+    email: claims.email,
+    exp: Math.floor(Date.now() / 1000) + ttlSeconds,
+  };
+  const payloadEncoded = base64UrlEncode(
+    ENCODER.encode(JSON.stringify(payload)),
+  );
+  const signingInput = `${header}.${payloadEncoded}`;
+  const key = await getKey(secret);
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    ENCODER.encode(signingInput),
+  );
+  return `${signingInput}.${base64UrlEncode(signature)}`;
+}
+
+export async function validateSessionToken(
+  token: string,
+  secret: string,
+): Promise<SessionPayload | null> {
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+
+  const [header, payloadStr, signatureStr] = parts;
+  const signingInput = `${header}.${payloadStr}`;
+
+  try {
+    const key = await getKey(secret);
+    const signature = base64UrlDecode(signatureStr);
+    const valid = await crypto.subtle.verify(
+      "HMAC",
+      key,
+      signature,
+      ENCODER.encode(signingInput),
+    );
+    if (!valid) return null;
+
+    const payload: SessionPayload = JSON.parse(
+      new TextDecoder().decode(base64UrlDecode(payloadStr)),
+    );
+
+    if (payload.exp < Math.floor(Date.now() / 1000)) return null;
+
+    return payload;
+  } catch {
+    return null;
+  }
+}

--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -1,0 +1,142 @@
+import { Hono } from "hono";
+import { requireAuth } from "../auth/middleware.js";
+import type { SessionPayload } from "../auth/session.js";
+import { getDomainByUserAndName, getDomainsByUser } from "../db/domains.js";
+import { getUserById, setApiKey } from "../db/users.js";
+import {
+  renderDashboardPage,
+  renderDomainDetailPage,
+  renderSettingsPage,
+} from "../views/dashboard.js";
+
+export const dashboardRoutes = new Hono();
+
+// All dashboard routes require auth
+dashboardRoutes.use("*", requireAuth);
+
+// Domain list
+dashboardRoutes.get("/", async (c) => {
+  const session = c.get("user" as never) as SessionPayload;
+  const db = (c.env as { DB: D1Database }).DB;
+  const domains = await getDomainsByUser(db, session.sub);
+  return c.html(
+    renderDashboardPage({
+      email: session.email,
+      domains: domains.map((d) => ({
+        domain: d.domain,
+        grade: d.last_grade ?? "—",
+        frequency: d.scan_frequency,
+        lastScanned: d.last_scanned_at
+          ? new Date(d.last_scanned_at * 1000).toLocaleDateString()
+          : null,
+        isFree: d.is_free === 1,
+      })),
+    }),
+  );
+});
+
+// Domain detail
+dashboardRoutes.get("/domain/:domain", async (c) => {
+  const session = c.get("user" as never) as SessionPayload;
+  const db = (c.env as { DB: D1Database }).DB;
+  const domainName = c.req.param("domain");
+  const domain = await getDomainByUserAndName(db, session.sub, domainName);
+  if (!domain) {
+    return c.text("Domain not found", 404);
+  }
+  const history = await db
+    .prepare(
+      "SELECT grade, scanned_at FROM scan_history WHERE domain_id = ? ORDER BY scanned_at DESC LIMIT 12",
+    )
+    .bind(domain.id)
+    .all<{ grade: string; scanned_at: number }>();
+  return c.html(
+    renderDomainDetailPage({
+      email: session.email,
+      domain: domain.domain,
+      grade: domain.last_grade ?? "—",
+      lastScanned: domain.last_scanned_at
+        ? new Date(domain.last_scanned_at * 1000).toLocaleDateString()
+        : null,
+      isFree: domain.is_free === 1,
+      scanFrequency: domain.scan_frequency,
+      scanHistory: history.results.map((r) => ({
+        date: new Date(r.scanned_at * 1000).toLocaleDateString(),
+        grade: r.grade,
+      })),
+    }),
+  );
+});
+
+// Manual scan trigger (stub — Phase 2 will add full monitoring)
+dashboardRoutes.post("/domain/:domain/scan", async (c) => {
+  const domainName = c.req.param("domain");
+  return c.redirect(`/dashboard/domain/${encodeURIComponent(domainName)}`);
+});
+
+// Settings page
+dashboardRoutes.get("/settings", async (c) => {
+  const session = c.get("user" as never) as SessionPayload;
+  const db = (c.env as { DB: D1Database }).DB;
+  const user = await getUserById(db, session.sub);
+  if (!user) {
+    return c.redirect("/auth/logout");
+  }
+  const webhook = await db
+    .prepare("SELECT url FROM webhooks WHERE user_id = ?")
+    .bind(session.sub)
+    .first<{ url: string }>();
+  return c.html(
+    renderSettingsPage({
+      email: user.email,
+      apiKey: user.api_key,
+      webhookUrl: webhook?.url ?? null,
+      hasStripe: !!user.stripe_customer_id,
+    }),
+  );
+});
+
+// Generate/regenerate API key
+dashboardRoutes.post("/settings/api-key", async (c) => {
+  const session = c.get("user" as never) as SessionPayload;
+  const db = (c.env as { DB: D1Database }).DB;
+  const key = `dmarc_${crypto.randomUUID().replace(/-/g, "")}`;
+  await setApiKey(db, session.sub, key);
+  return c.redirect("/dashboard/settings");
+});
+
+// Save webhook URL
+dashboardRoutes.post("/settings/webhook", async (c) => {
+  const session = c.get("user" as never) as SessionPayload;
+  const db = (c.env as { DB: D1Database }).DB;
+  const body = await c.req.parseBody();
+  const url = body.webhookUrl as string;
+
+  // Validate URL
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "https:") {
+      return c.redirect("/dashboard/settings");
+    }
+  } catch {
+    return c.redirect("/dashboard/settings");
+  }
+
+  const existing = await db
+    .prepare("SELECT id FROM webhooks WHERE user_id = ?")
+    .bind(session.sub)
+    .first<{ id: number }>();
+  if (existing) {
+    await db
+      .prepare("UPDATE webhooks SET url = ? WHERE user_id = ?")
+      .bind(url, session.sub)
+      .run();
+  } else {
+    const secret = crypto.randomUUID();
+    await db
+      .prepare("INSERT INTO webhooks (user_id, url, secret) VALUES (?, ?, ?)")
+      .bind(session.sub, url, secret)
+      .run();
+  }
+  return c.redirect("/dashboard/settings");
+});

--- a/src/db/domains.ts
+++ b/src/db/domains.ts
@@ -1,0 +1,70 @@
+export interface Domain {
+  id: number;
+  user_id: string;
+  domain: string;
+  is_free: number;
+  scan_frequency: string;
+  last_scanned_at: number | null;
+  last_grade: string | null;
+  created_at: number;
+}
+
+export async function createDomain(
+  db: D1Database,
+  input: { userId: string; domain: string; isFree: boolean },
+): Promise<void> {
+  const frequency = input.isFree ? "monthly" : "weekly";
+  await db
+    .prepare(
+      "INSERT INTO domains (user_id, domain, is_free, scan_frequency) VALUES (?, ?, ?, ?)",
+    )
+    .bind(input.userId, input.domain, input.isFree ? 1 : 0, frequency)
+    .run();
+}
+
+export async function getDomainsByUser(
+  db: D1Database,
+  userId: string,
+): Promise<Domain[]> {
+  const result = await db
+    .prepare("SELECT * FROM domains WHERE user_id = ? ORDER BY created_at")
+    .bind(userId)
+    .all<Domain>();
+  return result.results;
+}
+
+export async function getDomainByUserAndName(
+  db: D1Database,
+  userId: string,
+  domain: string,
+): Promise<Domain | null> {
+  return db
+    .prepare("SELECT * FROM domains WHERE user_id = ? AND domain = ?")
+    .bind(userId, domain)
+    .first<Domain>();
+}
+
+export async function deleteDomain(
+  db: D1Database,
+  userId: string,
+  domain: string,
+): Promise<void> {
+  await db
+    .prepare("DELETE FROM domains WHERE user_id = ? AND domain = ?")
+    .bind(userId, domain)
+    .run();
+}
+
+export async function updateLastScan(
+  db: D1Database,
+  domainId: number,
+  grade: string,
+  scannedAt: number,
+): Promise<void> {
+  await db
+    .prepare(
+      "UPDATE domains SET last_grade = ?, last_scanned_at = ? WHERE id = ?",
+    )
+    .bind(grade, scannedAt, domainId)
+    .run();
+}

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -1,0 +1,58 @@
+-- Users table
+CREATE TABLE IF NOT EXISTS users (
+  id TEXT PRIMARY KEY,
+  email TEXT NOT NULL UNIQUE,
+  email_domain TEXT NOT NULL,
+  stripe_customer_id TEXT,
+  api_key TEXT UNIQUE,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+-- Monitored domains
+CREATE TABLE IF NOT EXISTS domains (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  domain TEXT NOT NULL,
+  is_free INTEGER NOT NULL DEFAULT 0,
+  scan_frequency TEXT NOT NULL DEFAULT 'monthly',
+  last_scanned_at INTEGER,
+  last_grade TEXT,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+  UNIQUE(user_id, domain)
+);
+
+-- Scan history snapshots
+CREATE TABLE IF NOT EXISTS scan_history (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  domain_id INTEGER NOT NULL REFERENCES domains(id) ON DELETE CASCADE,
+  grade TEXT NOT NULL,
+  score_factors TEXT,
+  protocol_results TEXT,
+  scanned_at INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+-- Alert log
+CREATE TABLE IF NOT EXISTS alerts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  domain_id INTEGER NOT NULL REFERENCES domains(id) ON DELETE CASCADE,
+  alert_type TEXT NOT NULL,
+  previous_value TEXT,
+  new_value TEXT,
+  notified_via TEXT,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+-- Webhook configurations
+CREATE TABLE IF NOT EXISTS webhooks (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  url TEXT NOT NULL,
+  secret TEXT,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+-- Indexes for common queries
+CREATE INDEX IF NOT EXISTS idx_domains_user_id ON domains(user_id);
+CREATE INDEX IF NOT EXISTS idx_scan_history_domain_id ON scan_history(domain_id);
+CREATE INDEX IF NOT EXISTS idx_alerts_domain_id ON alerts(domain_id);
+CREATE INDEX IF NOT EXISTS idx_domains_last_scanned ON domains(last_scanned_at);

--- a/src/db/users.ts
+++ b/src/db/users.ts
@@ -1,0 +1,57 @@
+export interface User {
+  id: string;
+  email: string;
+  email_domain: string;
+  stripe_customer_id: string | null;
+  api_key: string | null;
+  created_at: number;
+}
+
+export async function createUser(
+  db: D1Database,
+  input: { id: string; email: string },
+): Promise<void> {
+  const emailDomain = input.email.split("@")[1];
+  await db
+    .prepare("INSERT INTO users (id, email, email_domain) VALUES (?, ?, ?)")
+    .bind(input.id, input.email, emailDomain)
+    .run();
+}
+
+export async function getUserById(
+  db: D1Database,
+  id: string,
+): Promise<User | null> {
+  return db.prepare("SELECT * FROM users WHERE id = ?").bind(id).first<User>();
+}
+
+export async function getUserByEmail(
+  db: D1Database,
+  email: string,
+): Promise<User | null> {
+  return db
+    .prepare("SELECT * FROM users WHERE email = ?")
+    .bind(email)
+    .first<User>();
+}
+
+export async function getUserByApiKey(
+  db: D1Database,
+  apiKey: string,
+): Promise<User | null> {
+  return db
+    .prepare("SELECT * FROM users WHERE api_key = ?")
+    .bind(apiKey)
+    .first<User>();
+}
+
+export async function setApiKey(
+  db: D1Database,
+  userId: string,
+  apiKey: string,
+): Promise<void> {
+  await db
+    .prepare("UPDATE users SET api_key = ? WHERE id = ?")
+    .bind(apiKey, userId)
+    .run();
+}

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,7 @@
+export interface Env {
+  DB: D1Database;
+  WORKOS_CLIENT_ID: string;
+  WORKOS_CLIENT_SECRET: string;
+  WORKOS_REDIRECT_URI: string;
+  SESSION_SECRET: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,8 +13,11 @@ import type {
 } from "./analyzers/types.js";
 import { API_CATALOG_JSON } from "./api/catalog.js";
 import { OPENAPI_JSON } from "./api/openapi.js";
+import { authRoutes } from "./auth/routes.js";
 import { getCachedScan, setCachedScan } from "./cache.js";
 import { generateCsv } from "./csv.js";
+import { dashboardRoutes } from "./dashboard/routes.js";
+import type { Env } from "./env.js";
 import type { ProtocolId, ProtocolResult } from "./orchestrator.js";
 import { scan, scanStreaming } from "./orchestrator.js";
 import { checkRateLimit, rateLimitHeaders } from "./rate-limit.js";
@@ -64,7 +67,7 @@ import {
 import { JS } from "./views/scripts.js";
 import { CSS } from "./views/styles.js";
 
-const app = new Hono();
+const app = new Hono<{ Bindings: Env }>();
 
 // Set Sentry scope context for every request
 app.use("*", async (c, next) => {
@@ -182,6 +185,12 @@ app.onError((err, c) => {
 });
 
 app.use("/api/*", cors());
+
+// Auth routes (public) — login, WorkOS callback, logout
+app.route("/auth", authRoutes);
+
+// Dashboard routes (auth enforced inside dashboardRoutes via requireAuth)
+app.route("/dashboard", dashboardRoutes);
 
 function markdownResponse(c: Context, body: string, status = 200) {
   return c.body(body, status as 200, {

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -1,0 +1,507 @@
+import {
+  esc,
+  generateCreature,
+  gradeClass,
+  themeToggle,
+} from "./components.js";
+import { JS } from "./scripts.js";
+import { CSS } from "./styles.js";
+
+const DASHBOARD_CSS = `
+.dashboard-nav {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 0.75rem 1.5rem;
+  background: var(--clr-surface);
+  border-bottom: 1px solid var(--clr-border);
+  flex-wrap: wrap;
+}
+.dashboard-nav .nav-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  text-decoration: none;
+  color: var(--clr-text);
+  font-weight: 700;
+  font-size: 1rem;
+}
+.dashboard-nav .nav-links {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex: 1;
+}
+.dashboard-nav .nav-links a {
+  color: var(--clr-text-muted);
+  text-decoration: none;
+  font-size: 0.875rem;
+}
+.dashboard-nav .nav-links a:hover {
+  color: var(--clr-accent);
+}
+.dashboard-nav .nav-user {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-left: auto;
+  font-size: 0.875rem;
+  color: var(--clr-text-muted);
+}
+.dashboard-nav .nav-user a {
+  color: var(--clr-text-muted);
+  text-decoration: none;
+}
+.dashboard-nav .nav-user a:hover {
+  color: var(--clr-accent);
+}
+.dashboard-body {
+  max-width: 900px;
+  margin: 2rem auto;
+  padding: 0 1.5rem;
+}
+.dashboard-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--clr-text);
+  margin-bottom: 1.5rem;
+}
+.domain-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--clr-surface);
+  border: 1px solid var(--clr-border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.domain-table th {
+  text-align: left;
+  padding: 0.75rem 1rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--clr-text-muted);
+  background: var(--clr-bg);
+  border-bottom: 1px solid var(--clr-border);
+}
+.domain-table td {
+  padding: 0.875rem 1rem;
+  border-bottom: 1px solid var(--clr-border);
+  color: var(--clr-text);
+  font-size: 0.9rem;
+}
+.domain-table tr:last-child td {
+  border-bottom: none;
+}
+.domain-table tr:hover td {
+  background: var(--clr-bg);
+}
+.domain-table a {
+  color: var(--clr-accent);
+  text-decoration: none;
+  font-weight: 500;
+}
+.domain-table a:hover {
+  text-decoration: underline;
+}
+.badge-free {
+  display: inline-block;
+  padding: 0.1rem 0.45rem;
+  background: var(--clr-accent-glow);
+  color: var(--clr-accent);
+  border: 1px solid var(--clr-accent);
+  border-radius: 4px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-left: 0.4rem;
+  vertical-align: middle;
+}
+.grade-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  font-size: 1.25rem;
+  font-weight: 800;
+  border: 3px solid currentColor;
+}
+.grade-badge.grade-a { color: var(--clr-pass); border-color: var(--clr-pass); }
+.grade-badge.grade-c { color: var(--clr-warn); border-color: var(--clr-warn); }
+.grade-badge.grade-f { color: var(--clr-fail); border-color: var(--clr-fail); }
+.domain-detail-header {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+}
+.domain-detail-name {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--clr-text);
+}
+.domain-detail-meta {
+  background: var(--clr-surface);
+  border: 1px solid var(--clr-border);
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1.5rem;
+  font-size: 0.875rem;
+  color: var(--clr-text-muted);
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+.domain-detail-meta strong {
+  color: var(--clr-text);
+}
+.btn {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  background: var(--clr-accent);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background 0.15s;
+}
+.btn:hover { background: var(--clr-accent-hover); }
+.btn-secondary {
+  background: var(--clr-surface);
+  color: var(--clr-text);
+  border: 1px solid var(--clr-border);
+}
+.btn-secondary:hover {
+  background: var(--clr-bg);
+  border-color: var(--clr-border-hover);
+}
+.btn-danger {
+  background: var(--clr-fail);
+  color: #fff;
+}
+.btn-danger:hover { opacity: 0.85; }
+.history-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.history-list li {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.6rem 1rem;
+  border-bottom: 1px solid var(--clr-border);
+  font-size: 0.875rem;
+}
+.history-list li:last-child { border-bottom: none; }
+.history-list .history-date {
+  color: var(--clr-text-muted);
+  flex: 1;
+}
+.settings-section {
+  background: var(--clr-surface);
+  border: 1px solid var(--clr-border);
+  border-radius: 8px;
+  padding: 1.25rem 1.5rem;
+  margin-bottom: 1.5rem;
+}
+.settings-section h2 {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--clr-text);
+  margin-bottom: 0.75rem;
+}
+.settings-section p {
+  font-size: 0.875rem;
+  color: var(--clr-text-muted);
+  margin-bottom: 0.75rem;
+}
+.api-key-display {
+  font-family: monospace;
+  font-size: 0.85rem;
+  background: var(--clr-bg);
+  border: 1px solid var(--clr-border);
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+  color: var(--clr-text);
+  word-break: break-all;
+  margin-bottom: 0.75rem;
+}
+.settings-input {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--clr-border);
+  border-radius: 6px;
+  background: var(--clr-bg);
+  color: var(--clr-text);
+  font-size: 0.875rem;
+  margin-bottom: 0.75rem;
+  box-sizing: border-box;
+}
+.settings-input:focus {
+  outline: 2px solid var(--clr-accent);
+  outline-offset: 1px;
+  border-color: var(--clr-accent);
+}
+.empty-state {
+  text-align: center;
+  padding: 3rem 1rem;
+  color: var(--clr-text-muted);
+  font-size: 0.95rem;
+}
+.empty-state p { margin-bottom: 1.25rem; }
+.inline-grade {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+.inline-grade.grade-a { color: var(--clr-pass); background: var(--clr-pass-bg); }
+.inline-grade.grade-c { color: var(--clr-warn); background: var(--clr-warn-bg); }
+.inline-grade.grade-f { color: var(--clr-fail); background: var(--clr-fail-bg); }
+.section-card {
+  background: var(--clr-surface);
+  border: 1px solid var(--clr-border);
+  border-radius: 8px;
+  padding: 1.25rem 1.5rem;
+  margin-bottom: 1.5rem;
+}
+.section-card h2 {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--clr-text);
+  margin-bottom: 1rem;
+}
+.action-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+  flex-wrap: wrap;
+}
+`;
+
+function dashboardPage(title: string, body: string, email: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>${esc(title)}</title>
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" href="/favicon.svg" type="image/svg+xml">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<script>(function(){var t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t)})()</script>
+<style>${CSS}</style>
+<style>${DASHBOARD_CSS}</style>
+</head>
+<body>
+<nav class="dashboard-nav">
+  <a href="/" class="nav-logo">${generateCreature("sm")} dmarc.mx</a>
+  <div class="nav-links">
+    <a href="/dashboard">Domains</a>
+    <a href="/dashboard/settings">Settings</a>
+  </div>
+  <div class="nav-user">
+    <span>${esc(email)}</span>
+    <a href="/auth/logout">Logout</a>
+    ${themeToggle()}
+  </div>
+</nav>
+<div class="dashboard-body">
+${body}
+</div>
+<script>${JS}</script>
+</body>
+</html>`;
+}
+
+export interface DashboardDomain {
+  domain: string;
+  grade: string;
+  frequency: string;
+  lastScanned: string | null;
+  isFree: boolean;
+}
+
+export interface ScanHistoryEntry {
+  date: string;
+  grade: string;
+}
+
+export function renderDashboardPage({
+  email,
+  domains,
+}: {
+  email: string;
+  domains: DashboardDomain[];
+}): string {
+  let tableBody: string;
+
+  if (domains.length === 0) {
+    tableBody = `<div class="empty-state">
+  <p>No domains yet. Add your first domain to start monitoring.</p>
+  <a href="/dashboard/domain/add" class="btn">Add Domain</a>
+</div>`;
+  } else {
+    const rows = domains
+      .map(
+        (d) => `<tr>
+  <td>
+    <a href="/dashboard/domain/${encodeURIComponent(d.domain)}">${esc(d.domain)}</a>
+    ${d.isFree ? '<span class="badge-free">Free</span>' : ""}
+  </td>
+  <td><span class="inline-grade ${gradeClass(d.grade)}">${esc(d.grade)}</span></td>
+  <td>${esc(d.frequency)}</td>
+  <td>${d.lastScanned ? esc(d.lastScanned) : '<span style="color:var(--clr-text-muted)">Never</span>'}</td>
+</tr>`,
+      )
+      .join("");
+
+    tableBody = `<table class="domain-table">
+  <thead>
+    <tr>
+      <th>Domain</th>
+      <th>Grade</th>
+      <th>Frequency</th>
+      <th>Last Scan</th>
+    </tr>
+  </thead>
+  <tbody>${rows}</tbody>
+</table>`;
+  }
+
+  return dashboardPage(
+    "Domains — dmarc.mx",
+    `<h1 class="dashboard-title">Your Domains</h1>
+${tableBody}`,
+    email,
+  );
+}
+
+export function renderDomainDetailPage({
+  email,
+  domain,
+  grade,
+  lastScanned,
+  isFree,
+  scanFrequency,
+  scanHistory,
+}: {
+  email: string;
+  domain: string;
+  grade: string;
+  lastScanned: string | null;
+  isFree: boolean;
+  scanFrequency: string;
+  scanHistory: ScanHistoryEntry[];
+}): string {
+  const historyItems = scanHistory
+    .slice(0, 12)
+    .map(
+      (entry) => `<li>
+  <span class="history-date">${esc(entry.date)}</span>
+  <span class="inline-grade ${gradeClass(entry.grade)}">${esc(entry.grade)}</span>
+</li>`,
+    )
+    .join("");
+
+  const historySection =
+    scanHistory.length > 0
+      ? `<ul class="history-list">${historyItems}</ul>`
+      : `<p style="color:var(--clr-text-muted);font-size:0.875rem;padding:0.75rem 0">No scan history yet.</p>`;
+
+  const body = `<div class="domain-detail-header">
+  <span class="grade-badge ${gradeClass(grade)}">${esc(grade)}</span>
+  <span class="domain-detail-name">${esc(domain)}</span>
+  ${isFree ? '<span class="badge-free">Free</span>' : ""}
+</div>
+<div class="domain-detail-meta">
+  <span><strong>Scan Frequency:</strong> ${esc(scanFrequency)}</span>
+  <span><strong>Last Scanned:</strong> ${lastScanned ? esc(lastScanned) : "Never"}</span>
+</div>
+<div class="action-row" style="margin-bottom:1.5rem">
+  <form method="POST" action="/dashboard/domain/${encodeURIComponent(domain)}/scan" style="display:inline">
+    <button type="submit" class="btn">Scan Now</button>
+  </form>
+  <a href="/check?domain=${encodeURIComponent(domain)}" class="btn btn-secondary">View Full Report</a>
+</div>
+<div class="section-card">
+  <h2>Grade History</h2>
+  ${historySection}
+</div>`;
+
+  return dashboardPage(`${domain} — dmarc.mx`, body, email);
+}
+
+export function renderSettingsPage({
+  email,
+  apiKey,
+  webhookUrl,
+  hasStripe,
+}: {
+  email: string;
+  apiKey: string | null;
+  webhookUrl: string | null;
+  hasStripe: boolean;
+}): string {
+  const apiKeySection = apiKey
+    ? `<div class="api-key-display">${esc(apiKey)}</div>
+<form method="POST" action="/dashboard/settings/api-key">
+  <button type="submit" class="btn btn-secondary">Regenerate API Key</button>
+</form>`
+    : `<p>No API key yet. Generate one to use the dmarc.mx API.</p>
+<form method="POST" action="/dashboard/settings/api-key">
+  <button type="submit" class="btn">Generate API Key</button>
+</form>`;
+
+  const billingSection = hasStripe
+    ? `<a href="/dashboard/billing" class="btn btn-secondary">Manage Billing</a>`
+    : `<p>You have no active subscription.</p>
+<a href="/dashboard/billing/subscribe" class="btn">Upgrade</a>`;
+
+  const body = `<h1 class="dashboard-title">Settings</h1>
+
+<div class="settings-section">
+  <h2>Account</h2>
+  <p>Signed in as <strong>${esc(email)}</strong></p>
+</div>
+
+<div class="settings-section">
+  <h2>API Key</h2>
+  ${apiKeySection}
+</div>
+
+<div class="settings-section">
+  <h2>Webhook</h2>
+  <form method="POST" action="/dashboard/settings/webhook">
+    <label for="webhook-url" style="display:block;font-size:0.875rem;color:var(--clr-text-muted);margin-bottom:0.4rem">Webhook URL</label>
+    <input
+      id="webhook-url"
+      class="settings-input"
+      type="url"
+      name="webhookUrl"
+      placeholder="https://your-server.example/webhook"
+      value="${webhookUrl ? esc(webhookUrl) : ""}"
+    >
+    <button type="submit" class="btn">Save Webhook</button>
+  </form>
+</div>
+
+<div class="settings-section">
+  <h2>Billing</h2>
+  ${billingSection}
+</div>`;
+
+  return dashboardPage("Settings — dmarc.mx", body, email);
+}

--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -171,6 +171,7 @@ export function renderLandingPage(): string {
         </a>
       </div>
       <div class="dmarcus-credit">Guarded by DMarcus ${generateCreature("sm", "content")}</div>
+      <div class="learn-link"><a href="/auth/login">Log in</a> to monitor a domain (free)</div>
     </div>
   </div>
   <section class="landing-explainer" id="what-we-check" aria-labelledby="explainer-heading">

--- a/test/auth-middleware.test.ts
+++ b/test/auth-middleware.test.ts
@@ -1,0 +1,68 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { requireAuth } from "../src/auth/middleware.js";
+import { createSessionToken } from "../src/auth/session.js";
+
+const SECRET = "test-secret";
+
+function createTestApp() {
+  const app = new Hono<{ Bindings: { SESSION_SECRET: string } }>();
+  app.use("/dashboard/*", requireAuth);
+  app.get("/dashboard/home", (c) => {
+    const user = c.get("user" as never);
+    return c.json(user);
+  });
+  app.get("/public", (c) => c.text("ok"));
+  return app;
+}
+
+describe("auth/middleware", () => {
+  it("redirects to login when no session cookie", async () => {
+    const app = createTestApp();
+    const res = await app.request(
+      "/dashboard/home",
+      {},
+      { SESSION_SECRET: SECRET },
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/auth/login");
+  });
+
+  it("allows access with valid session cookie", async () => {
+    const app = createTestApp();
+    const token = await createSessionToken(
+      { sub: "user_1", email: "alice@example.com" },
+      SECRET,
+    );
+    const res = await app.request(
+      "/dashboard/home",
+      { headers: { Cookie: `session=${token}` } },
+      { SESSION_SECRET: SECRET },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sub).toBe("user_1");
+    expect(body.email).toBe("alice@example.com");
+  });
+
+  it("redirects on expired session", async () => {
+    const app = createTestApp();
+    const token = await createSessionToken(
+      { sub: "user_1", email: "alice@example.com" },
+      SECRET,
+      -1,
+    );
+    const res = await app.request(
+      "/dashboard/home",
+      { headers: { Cookie: `session=${token}` } },
+      { SESSION_SECRET: SECRET },
+    );
+    expect(res.status).toBe(302);
+  });
+
+  it("does not affect public routes", async () => {
+    const app = createTestApp();
+    const res = await app.request("/public", {}, { SESSION_SECRET: SECRET });
+    expect(res.status).toBe(200);
+  });
+});

--- a/test/auth-routes.test.ts
+++ b/test/auth-routes.test.ts
@@ -1,0 +1,94 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { authRoutes } from "../src/auth/routes.js";
+
+function createTestApp() {
+  const app = new Hono();
+  app.route("/auth", authRoutes);
+  return app;
+}
+
+const ENV = {
+  WORKOS_CLIENT_ID: "test-client-id",
+  WORKOS_REDIRECT_URI: "https://example.com/auth/callback",
+  SESSION_SECRET: "test-session-secret",
+};
+
+describe("auth/routes", () => {
+  describe("GET /auth/login", () => {
+    it("redirects to WorkOS authorization URL", async () => {
+      const app = createTestApp();
+      const res = await app.request("/auth/login", {}, ENV);
+      expect(res.status).toBe(302);
+      const location = res.headers.get("Location");
+      expect(location).not.toBeNull();
+      const url = new URL(location as string);
+      expect(url.origin + url.pathname).toBe(
+        "https://api.workos.com/user_management/authorize",
+      );
+    });
+
+    it("includes client_id in the authorization URL", async () => {
+      const app = createTestApp();
+      const res = await app.request("/auth/login", {}, ENV);
+      const location = res.headers.get("Location") as string;
+      const url = new URL(location);
+      expect(url.searchParams.get("client_id")).toBe(ENV.WORKOS_CLIENT_ID);
+    });
+
+    it("includes redirect_uri in the authorization URL", async () => {
+      const app = createTestApp();
+      const res = await app.request("/auth/login", {}, ENV);
+      const location = res.headers.get("Location") as string;
+      const url = new URL(location);
+      expect(url.searchParams.get("redirect_uri")).toBe(
+        ENV.WORKOS_REDIRECT_URI,
+      );
+    });
+
+    it("includes response_type=code in the authorization URL", async () => {
+      const app = createTestApp();
+      const res = await app.request("/auth/login", {}, ENV);
+      const location = res.headers.get("Location") as string;
+      const url = new URL(location);
+      expect(url.searchParams.get("response_type")).toBe("code");
+    });
+
+    it("includes provider=authkit in the authorization URL", async () => {
+      const app = createTestApp();
+      const res = await app.request("/auth/login", {}, ENV);
+      const location = res.headers.get("Location") as string;
+      const url = new URL(location);
+      expect(url.searchParams.get("provider")).toBe("authkit");
+    });
+  });
+
+  describe("GET /auth/callback", () => {
+    it("returns 400 when code query param is missing", async () => {
+      const app = createTestApp();
+      const res = await app.request("/auth/callback", {}, ENV);
+      expect(res.status).toBe(400);
+      const body = await res.text();
+      expect(body).toBe("Missing authorization code");
+    });
+  });
+
+  describe("GET /auth/logout", () => {
+    it("clears the session cookie", async () => {
+      const app = createTestApp();
+      const res = await app.request("/auth/logout", {}, ENV);
+      const setCookieHeader = res.headers.get("Set-Cookie");
+      expect(setCookieHeader).not.toBeNull();
+      // Cookie should be cleared (Max-Age=0 or expires in the past)
+      expect(setCookieHeader).toMatch(/session=/);
+      expect(setCookieHeader).toMatch(/Max-Age=0/);
+    });
+
+    it("redirects to /", async () => {
+      const app = createTestApp();
+      const res = await app.request("/auth/logout", {}, ENV);
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/");
+    });
+  });
+});

--- a/test/dashboard-routes.test.ts
+++ b/test/dashboard-routes.test.ts
@@ -1,0 +1,425 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { createSessionToken } from "../src/auth/session.js";
+import { dashboardRoutes } from "../src/dashboard/routes.js";
+
+const SECRET = "test-session-secret";
+
+// Minimal D1-like mock that routes calls to in-memory data
+function createMockDB(data: {
+  domains?: Array<{
+    id: number;
+    user_id: string;
+    domain: string;
+    is_free: number;
+    scan_frequency: string;
+    last_scanned_at: number | null;
+    last_grade: string | null;
+    created_at: number;
+  }>;
+  users?: Array<{
+    id: string;
+    email: string;
+    email_domain: string;
+    stripe_customer_id: string | null;
+    api_key: string | null;
+    created_at: number;
+  }>;
+  scanHistory?: Array<{ grade: string; scanned_at: number }>;
+  webhooks?: Array<{
+    id: number;
+    user_id: string;
+    url: string;
+    secret: string;
+  }>;
+}) {
+  const domains = data.domains ?? [];
+  const users = data.users ?? [];
+  const scanHistory = data.scanHistory ?? [];
+  const webhooks = data.webhooks ?? [];
+
+  const makeStatement = (sql: string, bindings: unknown[]) => ({
+    bind: (...args: unknown[]) => makeStatement(sql, args),
+    first: async <T>() => {
+      if (sql.includes("SELECT * FROM users WHERE id")) {
+        return (users.find((u) => u.id === bindings[0]) ?? null) as T | null;
+      }
+      if (sql.includes("SELECT * FROM users WHERE email")) {
+        return (users.find((u) => u.email === bindings[0]) ?? null) as T | null;
+      }
+      if (sql.includes("SELECT * FROM domains WHERE user_id = ? AND domain")) {
+        return (domains.find(
+          (d) => d.user_id === bindings[0] && d.domain === bindings[1],
+        ) ?? null) as T | null;
+      }
+      if (sql.includes("SELECT url FROM webhooks WHERE user_id")) {
+        const wh = webhooks.find((w) => w.user_id === bindings[0]);
+        return (wh ? { url: wh.url } : null) as T | null;
+      }
+      if (sql.includes("SELECT id FROM webhooks WHERE user_id")) {
+        const wh = webhooks.find((w) => w.user_id === bindings[0]);
+        return (wh ? { id: wh.id } : null) as T | null;
+      }
+      return null as T | null;
+    },
+    all: async <T>() => {
+      if (sql.includes("SELECT * FROM domains WHERE user_id")) {
+        return {
+          results: domains.filter((d) => d.user_id === bindings[0]) as T[],
+        };
+      }
+      if (sql.includes("SELECT grade, scanned_at FROM scan_history")) {
+        return { results: scanHistory as T[] };
+      }
+      return { results: [] as T[] };
+    },
+    run: async () => ({ success: true }),
+  });
+
+  return {
+    prepare: (sql: string) => makeStatement(sql, []),
+  };
+}
+
+function createTestApp(db: ReturnType<typeof createMockDB>) {
+  const app = new Hono();
+  app.route("/dashboard", dashboardRoutes);
+  // Inject the mock DB into requests via env
+  return {
+    request: (url: string, init?: RequestInit) =>
+      app.request(url, init, {
+        SESSION_SECRET: SECRET,
+        DB: db,
+      }),
+  };
+}
+
+async function makeSessionCookie(sub: string, email: string): Promise<string> {
+  const token = await createSessionToken({ sub, email }, SECRET);
+  return `session=${token}`;
+}
+
+describe("dashboard/routes", () => {
+  describe("GET /dashboard (domain list)", () => {
+    it("redirects to /auth/login without a session cookie", async () => {
+      const db = createMockDB({});
+      const app = createTestApp(db);
+      const res = await app.request("/dashboard");
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/auth/login");
+    });
+
+    it("returns 200 and contains Dashboard with valid session", async () => {
+      const db = createMockDB({
+        users: [
+          {
+            id: "user_1",
+            email: "alice@example.com",
+            email_domain: "example.com",
+            stripe_customer_id: null,
+            api_key: null,
+            created_at: 1700000000,
+          },
+        ],
+        domains: [
+          {
+            id: 1,
+            user_id: "user_1",
+            domain: "example.com",
+            is_free: 1,
+            scan_frequency: "monthly",
+            last_scanned_at: null,
+            last_grade: null,
+            created_at: 1700000000,
+          },
+        ],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard", {
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body).toContain("Your Domains");
+    });
+
+    it("shows domain names in the list", async () => {
+      const db = createMockDB({
+        domains: [
+          {
+            id: 1,
+            user_id: "user_1",
+            domain: "example.com",
+            is_free: 1,
+            scan_frequency: "monthly",
+            last_scanned_at: null,
+            last_grade: "A",
+            created_at: 1700000000,
+          },
+        ],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard", {
+        headers: { Cookie: cookie },
+      });
+      const body = await res.text();
+      expect(body).toContain("example.com");
+    });
+
+    it("shows empty state when user has no domains", async () => {
+      const db = createMockDB({ domains: [] });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard", {
+        headers: { Cookie: cookie },
+      });
+      const body = await res.text();
+      expect(body).toContain("No domains");
+    });
+  });
+
+  describe("GET /dashboard/domain/:domain", () => {
+    it("redirects to /auth/login without a session cookie", async () => {
+      const db = createMockDB({});
+      const app = createTestApp(db);
+      const res = await app.request("/dashboard/domain/example.com");
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/auth/login");
+    });
+
+    it("returns 404 when domain does not belong to the user", async () => {
+      const db = createMockDB({ domains: [] });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/domain/notmine.com", {
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 200 and contains domain name with valid session", async () => {
+      const db = createMockDB({
+        domains: [
+          {
+            id: 1,
+            user_id: "user_1",
+            domain: "example.com",
+            is_free: 0,
+            scan_frequency: "weekly",
+            last_scanned_at: 1700000000,
+            last_grade: "B",
+            created_at: 1700000000,
+          },
+        ],
+        scanHistory: [{ grade: "B", scanned_at: 1700000000 }],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/domain/example.com", {
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body).toContain("example.com");
+    });
+
+    it("shows grade history section", async () => {
+      const db = createMockDB({
+        domains: [
+          {
+            id: 1,
+            user_id: "user_1",
+            domain: "example.com",
+            is_free: 0,
+            scan_frequency: "weekly",
+            last_scanned_at: null,
+            last_grade: null,
+            created_at: 1700000000,
+          },
+        ],
+        scanHistory: [],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/domain/example.com", {
+        headers: { Cookie: cookie },
+      });
+      const body = await res.text();
+      expect(body).toContain("Grade History");
+    });
+  });
+
+  describe("GET /dashboard/settings", () => {
+    it("redirects to /auth/login without a session cookie", async () => {
+      const db = createMockDB({});
+      const app = createTestApp(db);
+      const res = await app.request("/dashboard/settings");
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/auth/login");
+    });
+
+    it("returns 200 and contains email and Settings with valid session", async () => {
+      const db = createMockDB({
+        users: [
+          {
+            id: "user_1",
+            email: "alice@example.com",
+            email_domain: "example.com",
+            stripe_customer_id: null,
+            api_key: null,
+            created_at: 1700000000,
+          },
+        ],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/settings", {
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body).toContain("Settings");
+      expect(body).toContain("alice@example.com");
+    });
+
+    it("shows API key when one exists", async () => {
+      const db = createMockDB({
+        users: [
+          {
+            id: "user_1",
+            email: "alice@example.com",
+            email_domain: "example.com",
+            stripe_customer_id: null,
+            api_key: "dmarc_abc123",
+            created_at: 1700000000,
+          },
+        ],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/settings", {
+        headers: { Cookie: cookie },
+      });
+      const body = await res.text();
+      expect(body).toContain("dmarc_abc123");
+      expect(body).toContain("Regenerate");
+    });
+
+    it("shows webhook URL when one is configured", async () => {
+      const db = createMockDB({
+        users: [
+          {
+            id: "user_1",
+            email: "alice@example.com",
+            email_domain: "example.com",
+            stripe_customer_id: null,
+            api_key: null,
+            created_at: 1700000000,
+          },
+        ],
+        webhooks: [
+          {
+            id: 1,
+            user_id: "user_1",
+            url: "https://hooks.example.com/notify",
+            secret: "sec",
+          },
+        ],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/settings", {
+        headers: { Cookie: cookie },
+      });
+      const body = await res.text();
+      expect(body).toContain("https://hooks.example.com/notify");
+    });
+
+    it("redirects to logout when user record is missing", async () => {
+      const db = createMockDB({ users: [] });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("ghost_user", "ghost@example.com");
+      const res = await app.request("/dashboard/settings", {
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/auth/logout");
+    });
+  });
+
+  describe("POST /dashboard/settings/api-key", () => {
+    it("redirects to /auth/login without a session cookie", async () => {
+      const db = createMockDB({});
+      const app = createTestApp(db);
+      const res = await app.request("/dashboard/settings/api-key", {
+        method: "POST",
+      });
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/auth/login");
+    });
+
+    it("redirects to /dashboard/settings after generating a key", async () => {
+      const updatedKey: { value: string | null } = { value: null };
+      const db = createMockDB({});
+      // Override run to capture the key
+      const origPrepare = db.prepare.bind(db);
+      db.prepare = (sql: string) => {
+        const stmt = origPrepare(sql);
+        if (sql.includes("UPDATE users SET api_key")) {
+          return {
+            ...stmt,
+            bind: (...args: unknown[]) => ({
+              ...stmt,
+              run: async () => {
+                updatedKey.value = args[0] as string;
+                return { success: true };
+              },
+            }),
+          };
+        }
+        return stmt;
+      };
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/settings/api-key", {
+        method: "POST",
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/dashboard/settings");
+    });
+  });
+
+  describe("POST /dashboard/settings/webhook", () => {
+    it("redirects to /auth/login without a session cookie", async () => {
+      const db = createMockDB({});
+      const app = createTestApp(db);
+      const res = await app.request("/dashboard/settings/webhook", {
+        method: "POST",
+      });
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/auth/login");
+    });
+
+    it("redirects to /dashboard/settings after saving webhook", async () => {
+      const db = createMockDB({ webhooks: [] });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const body = new URLSearchParams({
+        webhookUrl: "https://example.com/hook",
+      });
+      const res = await app.request("/dashboard/settings/webhook", {
+        method: "POST",
+        headers: {
+          Cookie: cookie,
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: body.toString(),
+      });
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/dashboard/settings");
+    });
+  });
+});

--- a/test/dashboard-views.test.ts
+++ b/test/dashboard-views.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it } from "vitest";
+import {
+  renderDashboardPage,
+  renderDomainDetailPage,
+  renderSettingsPage,
+} from "../src/views/dashboard";
+
+describe("renderDashboardPage", () => {
+  it("renders empty state when no domains", () => {
+    const html = renderDashboardPage({
+      email: "user@example.com",
+      domains: [],
+    });
+    expect(html).toContain("No domains");
+  });
+
+  it("renders domain rows when domains are provided", () => {
+    const html = renderDashboardPage({
+      email: "user@example.com",
+      domains: [
+        {
+          domain: "example.com",
+          grade: "A",
+          frequency: "daily",
+          lastScanned: "2026-04-01",
+          isFree: true,
+        },
+      ],
+    });
+    expect(html).toContain("example.com");
+    expect(html).toContain("grade-a");
+    expect(html).toContain("badge-free");
+    expect(html).toContain("Free");
+    expect(html).toContain("daily");
+  });
+
+  it("renders multiple domains", () => {
+    const html = renderDashboardPage({
+      email: "user@example.com",
+      domains: [
+        {
+          domain: "alpha.com",
+          grade: "B",
+          frequency: "weekly",
+          lastScanned: null,
+          isFree: false,
+        },
+        {
+          domain: "beta.com",
+          grade: "F",
+          frequency: "monthly",
+          lastScanned: "2026-03-15",
+          isFree: true,
+        },
+      ],
+    });
+    expect(html).toContain("alpha.com");
+    expect(html).toContain("beta.com");
+    expect(html).toContain("grade-a"); // B maps to grade-a class
+    expect(html).toContain("grade-f");
+    expect(html).toContain("Never");
+  });
+
+  it("escapes domain names containing special characters", () => {
+    const html = renderDashboardPage({
+      email: "user@example.com",
+      domains: [
+        {
+          domain: "<script>alert(1)</script>",
+          grade: "F",
+          frequency: "daily",
+          lastScanned: null,
+          isFree: false,
+        },
+      ],
+    });
+    // The escaped form must appear in the body content
+    expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+  });
+
+  it("includes nav links and email", () => {
+    const html = renderDashboardPage({
+      email: "test@example.com",
+      domains: [],
+    });
+    expect(html).toContain("test@example.com");
+    expect(html).toContain("Domains");
+    expect(html).toContain("Settings");
+    expect(html).toContain("Logout");
+  });
+
+  it("links to domain detail pages", () => {
+    const html = renderDashboardPage({
+      email: "user@example.com",
+      domains: [
+        {
+          domain: "example.com",
+          grade: "A",
+          frequency: "daily",
+          lastScanned: null,
+          isFree: false,
+        },
+      ],
+    });
+    expect(html).toContain("/dashboard/domain/");
+    expect(html).toContain("example.com");
+  });
+});
+
+describe("renderDomainDetailPage", () => {
+  const baseProps = {
+    email: "user@example.com",
+    domain: "example.com",
+    grade: "B+",
+    lastScanned: "2026-04-01",
+    isFree: false,
+    scanFrequency: "daily",
+    scanHistory: [
+      { date: "2026-04-01", grade: "B+" },
+      { date: "2026-03-25", grade: "B" },
+    ],
+  };
+
+  it("renders domain name", () => {
+    const html = renderDomainDetailPage(baseProps);
+    expect(html).toContain("example.com");
+  });
+
+  it("renders grade", () => {
+    const html = renderDomainDetailPage(baseProps);
+    expect(html).toContain("B+");
+  });
+
+  it("renders Scan Now button", () => {
+    const html = renderDomainDetailPage(baseProps);
+    expect(html).toContain("Scan Now");
+  });
+
+  it("renders Grade History section", () => {
+    const html = renderDomainDetailPage(baseProps);
+    expect(html).toContain("Grade History");
+  });
+
+  it("renders scan history entries", () => {
+    const html = renderDomainDetailPage(baseProps);
+    expect(html).toContain("2026-04-01");
+    expect(html).toContain("2026-03-25");
+  });
+
+  it("links to full report", () => {
+    const html = renderDomainDetailPage(baseProps);
+    expect(html).toContain("/check?domain=");
+    expect(html).toContain("View Full Report");
+  });
+
+  it("shows free badge when isFree is true", () => {
+    const html = renderDomainDetailPage({ ...baseProps, isFree: true });
+    expect(html).toContain("badge-free");
+    expect(html).toContain("Free");
+  });
+
+  it("shows no-history message when scanHistory is empty", () => {
+    const html = renderDomainDetailPage({ ...baseProps, scanHistory: [] });
+    expect(html).toContain("No scan history yet");
+  });
+
+  it("limits grade history to 12 entries", () => {
+    const history = Array.from({ length: 20 }, (_, i) => ({
+      date: `2026-01-${String(i + 1).padStart(2, "0")}`,
+      grade: "A",
+    }));
+    const html = renderDomainDetailPage({ ...baseProps, scanHistory: history });
+    // Only 12 entries should appear — count list items inside the history list
+    // Each entry renders as a <li> with class history-date span
+    const matches = html.match(/<li>\s*<span class="history-date">/g);
+    expect(matches).not.toBeNull();
+    expect((matches ?? []).length).toBe(12);
+  });
+
+  it("includes scan form posting to correct URL", () => {
+    const html = renderDomainDetailPage(baseProps);
+    expect(html).toContain('method="POST"');
+    expect(html).toContain("/scan");
+  });
+});
+
+describe("renderSettingsPage", () => {
+  it("renders Generate API Key when no key exists", () => {
+    const html = renderSettingsPage({
+      email: "user@example.com",
+      apiKey: null,
+      webhookUrl: null,
+      hasStripe: false,
+    });
+    expect(html).toContain("Generate API Key");
+    expect(html).not.toContain("Regenerate");
+  });
+
+  it("renders Regenerate and existing key when apiKey is set", () => {
+    const html = renderSettingsPage({
+      email: "user@example.com",
+      apiKey: "dmx_abc123secret",
+      webhookUrl: null,
+      hasStripe: false,
+    });
+    expect(html).toContain("dmx_abc123secret");
+    expect(html).toContain("Regenerate");
+  });
+
+  it("renders email in account section", () => {
+    const html = renderSettingsPage({
+      email: "admin@example.com",
+      apiKey: null,
+      webhookUrl: null,
+      hasStripe: false,
+    });
+    expect(html).toContain("admin@example.com");
+    expect(html).toContain("Account");
+  });
+
+  it("renders webhook input with existing URL prefilled", () => {
+    const html = renderSettingsPage({
+      email: "user@example.com",
+      apiKey: null,
+      webhookUrl: "https://hooks.example.com/dmarc",
+      hasStripe: false,
+    });
+    expect(html).toContain("https://hooks.example.com/dmarc");
+    expect(html).toContain("Webhook");
+  });
+
+  it("renders manage billing link when hasStripe is true", () => {
+    const html = renderSettingsPage({
+      email: "user@example.com",
+      apiKey: null,
+      webhookUrl: null,
+      hasStripe: true,
+    });
+    expect(html).toContain("Manage Billing");
+  });
+
+  it("renders no subscription message when hasStripe is false", () => {
+    const html = renderSettingsPage({
+      email: "user@example.com",
+      apiKey: null,
+      webhookUrl: null,
+      hasStripe: false,
+    });
+    expect(html).toContain("no active subscription");
+    expect(html).toContain("Upgrade");
+  });
+
+  it("escapes API key to prevent XSS", () => {
+    const html = renderSettingsPage({
+      email: "user@example.com",
+      apiKey: "<script>alert(1)</script>",
+      webhookUrl: null,
+      hasStripe: false,
+    });
+    // The escaped form must appear; raw user content must not be injected as HTML
+    expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+    // The api-key-display div must contain escaped content
+    expect(html).toContain('class="api-key-display">&lt;script&gt;');
+  });
+});

--- a/test/db-domains.test.ts
+++ b/test/db-domains.test.ts
@@ -1,0 +1,258 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  createDomain,
+  type Domain,
+  deleteDomain,
+  getDomainByUserAndName,
+  getDomainsByUser,
+  updateLastScan,
+} from "../src/db/domains.js";
+
+// In-memory store for mock D1
+let store: Map<number, Domain>;
+let nextId: number;
+
+function makeD1Mock(): D1Database {
+  const prepare = (sql: string) => {
+    return {
+      bind: (...params: unknown[]) => {
+        return {
+          run: async () => {
+            if (/^INSERT INTO domains/i.test(sql)) {
+              const [userId, domain, isFree, scanFrequency] = params as [
+                string,
+                string,
+                number,
+                string,
+              ];
+              const id = nextId++;
+              store.set(id, {
+                id,
+                user_id: userId,
+                domain,
+                is_free: isFree,
+                scan_frequency: scanFrequency,
+                last_scanned_at: null,
+                last_grade: null,
+                created_at: Math.floor(Date.now() / 1000),
+              });
+            } else if (/^DELETE FROM domains/i.test(sql)) {
+              const [userId, domain] = params as [string, string];
+              for (const [id, row] of store.entries()) {
+                if (row.user_id === userId && row.domain === domain) {
+                  store.delete(id);
+                  break;
+                }
+              }
+            } else if (/^UPDATE domains SET last_grade/i.test(sql)) {
+              const [grade, scannedAt, domainId] = params as [
+                string,
+                number,
+                number,
+              ];
+              const row = store.get(domainId);
+              if (row) {
+                store.set(domainId, {
+                  ...row,
+                  last_grade: grade,
+                  last_scanned_at: scannedAt,
+                });
+              }
+            }
+            return { success: true };
+          },
+          first: async <T>(): Promise<T | null> => {
+            if (/WHERE user_id = \? AND domain = \?/i.test(sql)) {
+              const [userId, domain] = params as [string, string];
+              for (const row of store.values()) {
+                if (row.user_id === userId && row.domain === domain) {
+                  return row as T;
+                }
+              }
+              return null;
+            }
+            return null;
+          },
+          all: async <T>(): Promise<{ results: T[] }> => {
+            if (/WHERE user_id = \? ORDER BY created_at/i.test(sql)) {
+              const [userId] = params as [string];
+              const results = [...store.values()]
+                .filter((row) => row.user_id === userId)
+                .sort((a, b) => a.created_at - b.created_at) as T[];
+              return { results };
+            }
+            return { results: [] };
+          },
+        };
+      },
+    };
+  };
+
+  return { prepare } as unknown as D1Database;
+}
+
+describe("db/domains", () => {
+  let db: D1Database;
+
+  beforeEach(() => {
+    store = new Map();
+    nextId = 1;
+    db = makeD1Mock();
+  });
+
+  describe("createDomain + getDomainsByUser", () => {
+    it("creates a free domain and retrieves it with monthly frequency", async () => {
+      await createDomain(db, {
+        userId: "user-1",
+        domain: "example.com",
+        isFree: true,
+      });
+      const domains = await getDomainsByUser(db, "user-1");
+
+      expect(domains).toHaveLength(1);
+      expect(domains[0].domain).toBe("example.com");
+      expect(domains[0].user_id).toBe("user-1");
+      expect(domains[0].is_free).toBe(1);
+      expect(domains[0].scan_frequency).toBe("monthly");
+      expect(domains[0].last_scanned_at).toBeNull();
+      expect(domains[0].last_grade).toBeNull();
+    });
+
+    it("creates a paid domain with weekly frequency", async () => {
+      await createDomain(db, {
+        userId: "user-2",
+        domain: "paid.com",
+        isFree: false,
+      });
+      const domains = await getDomainsByUser(db, "user-2");
+
+      expect(domains).toHaveLength(1);
+      expect(domains[0].is_free).toBe(0);
+      expect(domains[0].scan_frequency).toBe("weekly");
+    });
+
+    it("returns only domains belonging to the given user", async () => {
+      await createDomain(db, {
+        userId: "user-1",
+        domain: "alice.com",
+        isFree: true,
+      });
+      await createDomain(db, {
+        userId: "user-2",
+        domain: "bob.com",
+        isFree: false,
+      });
+
+      const user1Domains = await getDomainsByUser(db, "user-1");
+      expect(user1Domains).toHaveLength(1);
+      expect(user1Domains[0].domain).toBe("alice.com");
+    });
+  });
+
+  describe("getDomainByUserAndName", () => {
+    it("retrieves a domain by user and name", async () => {
+      await createDomain(db, {
+        userId: "user-1",
+        domain: "lookup.com",
+        isFree: true,
+      });
+      const domain = await getDomainByUserAndName(db, "user-1", "lookup.com");
+
+      expect(domain).not.toBeNull();
+      expect(domain?.domain).toBe("lookup.com");
+      expect(domain?.user_id).toBe("user-1");
+    });
+
+    it("returns null for a non-existent domain", async () => {
+      const domain = await getDomainByUserAndName(db, "user-1", "notfound.com");
+      expect(domain).toBeNull();
+    });
+
+    it("returns null when the domain belongs to a different user", async () => {
+      await createDomain(db, {
+        userId: "user-1",
+        domain: "someone-elses.com",
+        isFree: true,
+      });
+      const domain = await getDomainByUserAndName(
+        db,
+        "user-2",
+        "someone-elses.com",
+      );
+      expect(domain).toBeNull();
+    });
+  });
+
+  describe("deleteDomain", () => {
+    it("deletes a domain so it no longer appears in queries", async () => {
+      await createDomain(db, {
+        userId: "user-1",
+        domain: "to-delete.com",
+        isFree: true,
+      });
+      expect(await getDomainsByUser(db, "user-1")).toHaveLength(1);
+
+      await deleteDomain(db, "user-1", "to-delete.com");
+
+      expect(await getDomainsByUser(db, "user-1")).toHaveLength(0);
+      expect(
+        await getDomainByUserAndName(db, "user-1", "to-delete.com"),
+      ).toBeNull();
+    });
+
+    it("only deletes the matching domain, leaving others intact", async () => {
+      await createDomain(db, {
+        userId: "user-1",
+        domain: "keep.com",
+        isFree: true,
+      });
+      await createDomain(db, {
+        userId: "user-1",
+        domain: "remove.com",
+        isFree: true,
+      });
+
+      await deleteDomain(db, "user-1", "remove.com");
+
+      const remaining = await getDomainsByUser(db, "user-1");
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0].domain).toBe("keep.com");
+    });
+  });
+
+  describe("updateLastScan", () => {
+    it("updates last_grade and last_scanned_at for a domain", async () => {
+      await createDomain(db, {
+        userId: "user-1",
+        domain: "scan.com",
+        isFree: false,
+      });
+      const domains = await getDomainsByUser(db, "user-1");
+      const domainId = domains[0].id;
+      const scannedAt = 1700000000;
+
+      await updateLastScan(db, domainId, "A", scannedAt);
+
+      const updated = await getDomainByUserAndName(db, "user-1", "scan.com");
+      expect(updated?.last_grade).toBe("A");
+      expect(updated?.last_scanned_at).toBe(scannedAt);
+    });
+
+    it("can update scan info multiple times, keeping the latest values", async () => {
+      await createDomain(db, {
+        userId: "user-1",
+        domain: "rescan.com",
+        isFree: false,
+      });
+      const domains = await getDomainsByUser(db, "user-1");
+      const domainId = domains[0].id;
+
+      await updateLastScan(db, domainId, "B", 1700000000);
+      await updateLastScan(db, domainId, "A+", 1700001000);
+
+      const updated = await getDomainByUserAndName(db, "user-1", "rescan.com");
+      expect(updated?.last_grade).toBe("A+");
+      expect(updated?.last_scanned_at).toBe(1700001000);
+    });
+  });
+});

--- a/test/db-users.test.ts
+++ b/test/db-users.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  createUser,
+  getUserByApiKey,
+  getUserByEmail,
+  getUserById,
+  setApiKey,
+  type User,
+} from "../src/db/users.js";
+
+// In-memory store for mock D1
+let store: Map<string, User>;
+
+function makeD1Mock(): D1Database {
+  // Each call to prepare returns a statement builder.
+  // We track the SQL and implement bind/run/first against the in-memory store.
+  const prepare = (sql: string) => {
+    return {
+      bind: (...params: unknown[]) => {
+        return {
+          run: async () => {
+            if (/^INSERT INTO users/i.test(sql)) {
+              const [id, email, email_domain] = params as [
+                string,
+                string,
+                string,
+              ];
+              store.set(id, {
+                id,
+                email,
+                email_domain,
+                stripe_customer_id: null,
+                api_key: null,
+                created_at: Math.floor(Date.now() / 1000),
+              });
+            } else if (/^UPDATE users SET api_key/i.test(sql)) {
+              const [apiKey, userId] = params as [string, string];
+              const user = store.get(userId);
+              if (user) {
+                store.set(userId, { ...user, api_key: apiKey });
+              }
+            }
+            return { success: true };
+          },
+          first: async <T>(): Promise<T | null> => {
+            if (/WHERE id = \?/i.test(sql)) {
+              const [id] = params as [string];
+              return (store.get(id) as T | undefined) ?? null;
+            }
+            if (/WHERE email = \?/i.test(sql)) {
+              const [email] = params as [string];
+              for (const user of store.values()) {
+                if (user.email === email) return user as T;
+              }
+              return null;
+            }
+            if (/WHERE api_key = \?/i.test(sql)) {
+              const [apiKey] = params as [string];
+              for (const user of store.values()) {
+                if (user.api_key === apiKey) return user as T;
+              }
+              return null;
+            }
+            return null;
+          },
+        };
+      },
+    };
+  };
+
+  // Cast to D1Database — we only use prepare/bind/run/first in our module
+  return { prepare } as unknown as D1Database;
+}
+
+describe("db/users", () => {
+  let db: D1Database;
+
+  beforeEach(() => {
+    store = new Map();
+    db = makeD1Mock();
+  });
+
+  describe("createUser + getUserById", () => {
+    it("creates a user and retrieves it by id", async () => {
+      await createUser(db, { id: "user-1", email: "alice@example.com" });
+      const user = await getUserById(db, "user-1");
+
+      expect(user).not.toBeNull();
+      expect(user?.id).toBe("user-1");
+      expect(user?.email).toBe("alice@example.com");
+    });
+
+    it("extracts email_domain from the email address", async () => {
+      await createUser(db, { id: "user-2", email: "bob@dmarc.mx" });
+      const user = await getUserById(db, "user-2");
+
+      expect(user?.email_domain).toBe("dmarc.mx");
+    });
+
+    it("initialises stripe_customer_id and api_key as null", async () => {
+      await createUser(db, { id: "user-3", email: "carol@test.org" });
+      const user = await getUserById(db, "user-3");
+
+      expect(user?.stripe_customer_id).toBeNull();
+      expect(user?.api_key).toBeNull();
+    });
+  });
+
+  describe("getUserByEmail", () => {
+    it("retrieves an existing user by email", async () => {
+      await createUser(db, { id: "user-4", email: "dave@example.com" });
+      const user = await getUserByEmail(db, "dave@example.com");
+
+      expect(user).not.toBeNull();
+      expect(user?.id).toBe("user-4");
+    });
+
+    it("returns null for an unknown email", async () => {
+      const user = await getUserByEmail(db, "nobody@example.com");
+      expect(user).toBeNull();
+    });
+  });
+
+  describe("getUserById", () => {
+    it("returns null for a non-existent id", async () => {
+      const user = await getUserById(db, "does-not-exist");
+      expect(user).toBeNull();
+    });
+  });
+
+  describe("setApiKey + getUserByApiKey", () => {
+    it("sets an api key and retrieves the user by that key", async () => {
+      await createUser(db, { id: "user-5", email: "eve@example.com" });
+      await setApiKey(db, "user-5", "sk-test-abc123");
+
+      const user = await getUserByApiKey(db, "sk-test-abc123");
+      expect(user).not.toBeNull();
+      expect(user?.id).toBe("user-5");
+      expect(user?.api_key).toBe("sk-test-abc123");
+    });
+
+    it("returns null when no user has that api key", async () => {
+      const user = await getUserByApiKey(db, "sk-unknown");
+      expect(user).toBeNull();
+    });
+  });
+});

--- a/test/nav-link.test.ts
+++ b/test/nav-link.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { renderLandingPage } from "../src/views/html.js";
+
+describe("landing page nav", () => {
+  it("includes a login link", () => {
+    const html = renderLandingPage();
+    expect(html).toContain("/auth/login");
+    expect(html).toContain("Log in");
+  });
+});

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  createSessionToken,
+  validateSessionToken,
+} from "../src/auth/session.js";
+
+const SECRET = "test-secret-key-for-jwt-signing";
+
+describe("session JWT", () => {
+  it("creates and validates a session token", async () => {
+    const token = await createSessionToken(
+      { sub: "user-123", email: "alice@example.com" },
+      SECRET,
+    );
+
+    expect(typeof token).toBe("string");
+    expect(token.split(".")).toHaveLength(3);
+
+    const payload = await validateSessionToken(token, SECRET);
+
+    expect(payload).not.toBeNull();
+    expect(payload?.sub).toBe("user-123");
+    expect(payload?.email).toBe("alice@example.com");
+    expect(typeof payload?.exp).toBe("number");
+  });
+
+  it("rejects a tampered token", async () => {
+    const token = await createSessionToken(
+      { sub: "user-456", email: "bob@example.com" },
+      SECRET,
+    );
+
+    // Tamper with the payload segment
+    const parts = token.split(".");
+    const tamperedPayload = btoa(
+      JSON.stringify({
+        sub: "attacker",
+        email: "evil@example.com",
+        exp: parts[1],
+      }),
+    )
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    const tamperedToken = `${parts[0]}.${tamperedPayload}.${parts[2]}`;
+
+    const result = await validateSessionToken(tamperedToken, SECRET);
+    expect(result).toBeNull();
+  });
+
+  it("rejects an expired token", async () => {
+    const token = await createSessionToken(
+      { sub: "user-789", email: "carol@example.com" },
+      SECRET,
+      -1, // already expired
+    );
+
+    const result = await validateSessionToken(token, SECRET);
+    expect(result).toBeNull();
+  });
+
+  it("rejects a token signed with a different secret", async () => {
+    const token = await createSessionToken(
+      { sub: "user-999", email: "dave@example.com" },
+      "original-secret",
+    );
+
+    const result = await validateSessionToken(token, "different-secret");
+    expect(result).toBeNull();
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -10,3 +10,8 @@ routes = [
 
 [dev]
 port = 8790
+
+[[d1_databases]]
+binding = "DB"
+database_name = "dmarcheck-db"
+database_id = "7e6e7e64-5477-458f-b206-941ea58b7dba"


### PR DESCRIPTION
## Summary

Ships Phase 1 of the freemium monetization roadmap drafted on 2026-04-01:

- **WorkOS AuthKit login** via `/auth/login` → `/auth/callback` → `/auth/logout`. Uses direct `fetch` to `api.workos.com/user_management/*` — no SDK dependency.
- **Sessions** are hand-rolled HS256 JWTs signed with `crypto.subtle` (7-day TTL, `HttpOnly; Secure; SameSite=Lax` cookie).
- **D1 persistence** (`dmarcheck-db`, UUID `7e6e7e64-…`) with `users`, `domains`, `scan_history`, `alerts`, `webhooks` tables. Schema is forward-compatible with Phases 2 (monitoring) and 3 (Stripe).
- **Dashboard** at `/dashboard` (requires auth): domain list, per-domain detail with last 12 scan-history rows, settings (API key regeneration + webhook URL save).
- **Free-tier auto-provisioning**: on first successful login, a free domain is created from the user's email suffix.
- **Login link** in the landing page footer.

The underlying implementation was first written on `feat/freemium-auth-dashboard-v1` on 2026-04-01 but never opened as a PR. Main has since received ~30 commits touching the same integration surface (agent-readiness, /learn, Sentry, rate-limit hardening, Bolt/Palette passes), so this PR replays the Phase 1 work onto current main rather than rebasing. See [the design spec](../blob/feat/freemium-phase1/docs/superpowers/specs/2026-04-01-freemium-monetization-design.md) and [the implementation plan](../blob/feat/freemium-phase1/docs/superpowers/plans/2026-04-01-phase1-auth-d1-dashboard.md) for context.

## Out of scope

No Stripe, no alerts, no cron-trigger monitoring, no API keys at auth boundary, no bulk endpoint. Those are Phases 2–3.

## Before merging (action required)

Step 10 of the original Phase 1 plan — secrets + schema — is **not yet done** and cannot be automated from a Claude Code session:

- [ ] Provision a WorkOS application with AuthKit; configure redirect URIs (`http://localhost:8790/auth/callback` for dev, `https://dmarc.mx/auth/callback` for prod).
- [ ] `wrangler secret put WORKOS_CLIENT_ID`
- [ ] `wrangler secret put WORKOS_CLIENT_SECRET`
- [ ] `wrangler secret put WORKOS_REDIRECT_URI`
- [ ] `wrangler secret put SESSION_SECRET` (fresh random 32 bytes)
- [ ] `wrangler d1 execute dmarcheck-db --remote --file=src/db/schema.sql`
- [ ] Create local `.dev.vars` mirroring the same four secrets, pointed at the localhost redirect URI
- [ ] `wrangler d1 execute dmarcheck-db --local --file=src/db/schema.sql`

Until the secrets are set, `/auth/login` will fail at the WorkOS redirect — but all existing unauthenticated flows are unaffected, and the PR can merge safely before those secrets land (the dashboard is just inaccessible).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 414 tests pass (main had 358; +56 from new Phase 1 test files)
- [ ] After secrets land: visit `/` → click "Log in" → WorkOS AuthKit → callback → `/dashboard` → add domain → logout
- [ ] After secrets land: verify unauthenticated `/`, `/check`, `/learn/*`, `/scoring`, `/docs/api`, `/.well-known/api-catalog`, `/openapi.json` still work
- [ ] After secrets land: verify session cookie is `HttpOnly; Secure; SameSite=Lax`
- [ ] After secrets land: verify `/dashboard` without a session redirects to `/auth/login`