### PR TITLE
Phase 2a: persist scans + wire dashboard "Scan Now"

### DIFF
--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -2,7 +2,9 @@ import { Hono } from "hono";
 import { requireAuth } from "../auth/middleware.js";
 import type { SessionPayload } from "../auth/session.js";
 import { getDomainByUserAndName, getDomainsByUser } from "../db/domains.js";
+import { recordScan } from "../db/scans.js";
 import { getUserById, setApiKey } from "../db/users.js";
+import { scan } from "../orchestrator.js";
 import {
   renderDashboardPage,
   renderDomainDetailPage,
@@ -68,10 +70,28 @@ dashboardRoutes.get("/domain/:domain", async (c) => {
   );
 });
 
-// Manual scan trigger (stub — Phase 2 will add full monitoring)
+// Manual scan trigger — runs the orchestrator for a user-owned domain and
+// persists the result to scan_history + domains.last_*. Rate-limiting comes
+// from the session cookie gating this path (plus D1 write volume per user).
 dashboardRoutes.post("/domain/:domain/scan", async (c) => {
+  const session = c.get("user" as never) as SessionPayload;
+  const db = (c.env as { DB: D1Database }).DB;
   const domainName = c.req.param("domain");
-  return c.redirect(`/dashboard/domain/${encodeURIComponent(domainName)}`);
+
+  const owned = await getDomainByUserAndName(db, session.sub, domainName);
+  if (!owned) {
+    return c.text("Domain not found", 404);
+  }
+
+  const result = await scan(owned.domain);
+  await recordScan(db, {
+    domainId: owned.id,
+    grade: result.grade,
+    scoreFactors: result.breakdown.factors,
+    protocolResults: result.protocols,
+  });
+
+  return c.redirect(`/dashboard/domain/${encodeURIComponent(domainName)}`, 303);
 });
 
 // Settings page

--- a/src/db/scans.ts
+++ b/src/db/scans.ts
@@ -1,0 +1,62 @@
+export interface ScanHistoryRow {
+  id: number;
+  domain_id: number;
+  grade: string;
+  score_factors: string | null;
+  protocol_results: string | null;
+  scanned_at: number;
+}
+
+export interface RecordScanInput {
+  domainId: number;
+  grade: string;
+  scoreFactors: unknown;
+  protocolResults: unknown;
+  scannedAt?: number;
+}
+
+// Writes one scan_history row and updates the owning domain's last_grade /
+// last_scanned_at in a single D1 batch. Batch is atomic at the D1 layer, so
+// the history row and the domain summary stay in sync even if the request is
+// cancelled mid-flight.
+export async function recordScan(
+  db: D1Database,
+  input: RecordScanInput,
+): Promise<void> {
+  const scannedAt = input.scannedAt ?? Math.floor(Date.now() / 1000);
+  const scoreFactorsJson = JSON.stringify(input.scoreFactors ?? null);
+  const protocolResultsJson = JSON.stringify(input.protocolResults ?? null);
+
+  await db.batch([
+    db
+      .prepare(
+        "INSERT INTO scan_history (domain_id, grade, score_factors, protocol_results, scanned_at) VALUES (?, ?, ?, ?, ?)",
+      )
+      .bind(
+        input.domainId,
+        input.grade,
+        scoreFactorsJson,
+        protocolResultsJson,
+        scannedAt,
+      ),
+    db
+      .prepare(
+        "UPDATE domains SET last_grade = ?, last_scanned_at = ? WHERE id = ?",
+      )
+      .bind(input.grade, scannedAt, input.domainId),
+  ]);
+}
+
+export async function getScanHistory(
+  db: D1Database,
+  domainId: number,
+  limit = 12,
+): Promise<ScanHistoryRow[]> {
+  const result = await db
+    .prepare(
+      "SELECT * FROM scan_history WHERE domain_id = ? ORDER BY scanned_at DESC LIMIT ?",
+    )
+    .bind(domainId, limit)
+    .all<ScanHistoryRow>();
+  return result.results;
+}

--- a/test/dashboard-routes.test.ts
+++ b/test/dashboard-routes.test.ts
@@ -1,7 +1,38 @@
 import { Hono } from "hono";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createSessionToken } from "../src/auth/session.js";
 import { dashboardRoutes } from "../src/dashboard/routes.js";
+
+vi.mock("../src/orchestrator.js", () => ({
+  scan: vi.fn(async (domain: string) => ({
+    domain,
+    timestamp: "2026-04-19T00:00:00.000Z",
+    grade: "B",
+    breakdown: {
+      grade: "B",
+      tier: "B",
+      tierReason: "test",
+      modifier: 0,
+      modifierLabel: "",
+      factors: [{ name: "dmarc", status: "pass", weight: 1 }],
+      recommendations: [],
+      protocolSummaries: {},
+    },
+    summary: {
+      mx_records: 0,
+      mx_providers: [],
+      dmarc_policy: "none",
+    },
+    protocols: {
+      mx: { status: "info" },
+      dmarc: { status: "pass" },
+      spf: { status: "pass" },
+      dkim: { status: "pass" },
+      bimi: { status: "pass" },
+      mta_sts: { status: "pass" },
+    },
+  })),
+}));
 
 const SECRET = "test-session-secret";
 
@@ -32,11 +63,13 @@ function createMockDB(data: {
     url: string;
     secret: string;
   }>;
+  writes?: Array<{ sql: string; bindings: unknown[] }>;
 }) {
   const domains = data.domains ?? [];
   const users = data.users ?? [];
   const scanHistory = data.scanHistory ?? [];
   const webhooks = data.webhooks ?? [];
+  const writes = data.writes;
 
   const makeStatement = (sql: string, bindings: unknown[]) => ({
     bind: (...args: unknown[]) => makeStatement(sql, args),
@@ -73,11 +106,23 @@ function createMockDB(data: {
       }
       return { results: [] as T[] };
     },
-    run: async () => ({ success: true }),
+    run: async () => {
+      writes?.push({ sql, bindings });
+      return { success: true };
+    },
   });
 
   return {
     prepare: (sql: string) => makeStatement(sql, []),
+    batch: async (
+      stmts: Array<{ run: () => Promise<{ success: boolean }> }>,
+    ) => {
+      const out = [];
+      for (const stmt of stmts) {
+        out.push(await stmt.run());
+      }
+      return out;
+    },
   };
 }
 
@@ -389,6 +434,71 @@ describe("dashboard/routes", () => {
       });
       expect(res.status).toBe(302);
       expect(res.headers.get("Location")).toBe("/dashboard/settings");
+    });
+  });
+
+  describe("POST /dashboard/domain/:domain/scan", () => {
+    it("redirects to /auth/login without a session cookie", async () => {
+      const db = createMockDB({});
+      const app = createTestApp(db);
+      const res = await app.request("/dashboard/domain/example.com/scan", {
+        method: "POST",
+      });
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/auth/login");
+    });
+
+    it("returns 404 when domain does not belong to the user", async () => {
+      const db = createMockDB({ domains: [] });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/domain/notmine.com/scan", {
+        method: "POST",
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("runs the scan, persists history, and 303-redirects to the detail page", async () => {
+      const writes: Array<{ sql: string; bindings: unknown[] }> = [];
+      const db = createMockDB({
+        domains: [
+          {
+            id: 7,
+            user_id: "user_1",
+            domain: "example.com",
+            is_free: 1,
+            scan_frequency: "monthly",
+            last_scanned_at: null,
+            last_grade: null,
+            created_at: 1700000000,
+          },
+        ],
+        writes,
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+
+      const res = await app.request("/dashboard/domain/example.com/scan", {
+        method: "POST",
+        headers: { Cookie: cookie },
+      });
+
+      expect(res.status).toBe(303);
+      expect(res.headers.get("Location")).toBe("/dashboard/domain/example.com");
+
+      const insertSql = writes.find((w) =>
+        w.sql.includes("INSERT INTO scan_history"),
+      );
+      expect(insertSql).toBeDefined();
+      expect(insertSql?.bindings[0]).toBe(7); // domain_id
+      expect(insertSql?.bindings[1]).toBe("B"); // grade
+
+      const updateSql = writes.find((w) =>
+        w.sql.includes("UPDATE domains SET last_grade"),
+      );
+      expect(updateSql).toBeDefined();
+      expect(updateSql?.bindings[0]).toBe("B");
     });
   });
 

--- a/test/db-scans.test.ts
+++ b/test/db-scans.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  getScanHistory,
+  recordScan,
+  type ScanHistoryRow,
+} from "../src/db/scans.js";
+
+interface DomainRow {
+  id: number;
+  last_grade: string | null;
+  last_scanned_at: number | null;
+}
+
+let scanStore: Map<number, ScanHistoryRow>;
+let domainStore: Map<number, DomainRow>;
+let nextScanId: number;
+
+function makeD1Mock(): D1Database {
+  const prepare = (sql: string) => {
+    return {
+      bind: (...params: unknown[]) => ({
+        sql,
+        params,
+        run: async () => {
+          if (/^INSERT INTO scan_history/i.test(sql)) {
+            const [domainId, grade, scoreFactors, protocolResults, scannedAt] =
+              params as [number, string, string, string, number];
+            const id = nextScanId++;
+            scanStore.set(id, {
+              id,
+              domain_id: domainId,
+              grade,
+              score_factors: scoreFactors,
+              protocol_results: protocolResults,
+              scanned_at: scannedAt,
+            });
+          } else if (/^UPDATE domains SET last_grade/i.test(sql)) {
+            const [grade, scannedAt, domainId] = params as [
+              string,
+              number,
+              number,
+            ];
+            const row = domainStore.get(domainId);
+            if (row) {
+              domainStore.set(domainId, {
+                ...row,
+                last_grade: grade,
+                last_scanned_at: scannedAt,
+              });
+            }
+          }
+          return { success: true };
+        },
+        all: async <T>(): Promise<{ results: T[] }> => {
+          if (/FROM scan_history WHERE domain_id = \?/i.test(sql)) {
+            const [domainId, limit] = params as [number, number];
+            const results = [...scanStore.values()]
+              .filter((r) => r.domain_id === domainId)
+              .sort((a, b) => b.scanned_at - a.scanned_at)
+              .slice(0, limit) as T[];
+            return { results };
+          }
+          return { results: [] };
+        },
+      }),
+    };
+  };
+
+  return {
+    prepare,
+    batch: async (
+      stmts: Array<{ run: () => Promise<{ success: boolean }> }>,
+    ) => {
+      const out = [];
+      for (const stmt of stmts) {
+        out.push(await stmt.run());
+      }
+      return out;
+    },
+  } as unknown as D1Database;
+}
+
+describe("db/scans", () => {
+  let db: D1Database;
+
+  beforeEach(() => {
+    scanStore = new Map();
+    domainStore = new Map([
+      [42, { id: 42, last_grade: null, last_scanned_at: null }],
+    ]);
+    nextScanId = 1;
+    db = makeD1Mock();
+  });
+
+  describe("recordScan", () => {
+    it("inserts history row and updates domain summary in one batch", async () => {
+      await recordScan(db, {
+        domainId: 42,
+        grade: "B",
+        scoreFactors: { dmarc: "pass", spf: "warn" },
+        protocolResults: { dmarc: { status: "pass" } },
+        scannedAt: 1_700_000_000,
+      });
+
+      expect(scanStore.size).toBe(1);
+      const row = [...scanStore.values()][0];
+      expect(row.domain_id).toBe(42);
+      expect(row.grade).toBe("B");
+      expect(row.score_factors).toBe(
+        JSON.stringify({ dmarc: "pass", spf: "warn" }),
+      );
+      expect(row.protocol_results).toBe(
+        JSON.stringify({ dmarc: { status: "pass" } }),
+      );
+      expect(row.scanned_at).toBe(1_700_000_000);
+
+      const domain = domainStore.get(42);
+      expect(domain?.last_grade).toBe("B");
+      expect(domain?.last_scanned_at).toBe(1_700_000_000);
+    });
+
+    it("defaults scannedAt to current unix time when omitted", async () => {
+      const before = Math.floor(Date.now() / 1000);
+      await recordScan(db, {
+        domainId: 42,
+        grade: "A",
+        scoreFactors: null,
+        protocolResults: null,
+      });
+      const after = Math.floor(Date.now() / 1000);
+
+      const row = [...scanStore.values()][0];
+      expect(row.scanned_at).toBeGreaterThanOrEqual(before);
+      expect(row.scanned_at).toBeLessThanOrEqual(after);
+    });
+
+    it("serializes null payloads safely", async () => {
+      await recordScan(db, {
+        domainId: 42,
+        grade: "F",
+        scoreFactors: undefined,
+        protocolResults: undefined,
+        scannedAt: 1,
+      });
+      const row = [...scanStore.values()][0];
+      expect(row.score_factors).toBe("null");
+      expect(row.protocol_results).toBe("null");
+    });
+  });
+
+  describe("getScanHistory", () => {
+    it("returns newest first, respects limit", async () => {
+      for (let i = 0; i < 5; i++) {
+        await recordScan(db, {
+          domainId: 42,
+          grade: "A",
+          scoreFactors: null,
+          protocolResults: null,
+          scannedAt: 1000 + i,
+        });
+      }
+      const history = await getScanHistory(db, 42, 3);
+      expect(history).toHaveLength(3);
+      expect(history.map((r) => r.scanned_at)).toEqual([1004, 1003, 1002]);
+    });
+
+    it("ignores scans for other domains", async () => {
+      domainStore.set(99, { id: 99, last_grade: null, last_scanned_at: null });
+      await recordScan(db, {
+        domainId: 99,
+        grade: "C",
+        scoreFactors: null,
+        protocolResults: null,
+        scannedAt: 500,
+      });
+      const history = await getScanHistory(db, 42);
+      expect(history).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `src/db/scans.ts`: `recordScan()` writes one `scan_history` row and updates `domains.last_grade` / `last_scanned_at` in a single D1 batch.
- `src/dashboard/routes.ts`: the "Scan Now" button on the domain detail page is no longer a stub — it runs the orchestrator for the user-owned domain, persists the result, and 303-redirects to the detail page. Returns 404 for domains not owned by the session user.
- 8 new tests (5 in `test/db-scans.test.ts`, 3 in `test/dashboard-routes.test.ts`) covering insert-and-update batching, timestamp defaults, null payload serialization, unauth redirect, 404 on non-owned, and the happy-path scan → redirect → persisted write.

## Why
Phase 1 (#140) shipped the `scan_history` table and a detail page that reads it, but nothing wrote to that table and the scan-now button redirected without doing anything. This PR makes the authenticated dashboard produce real grade history — the foundation for the nightly cron, delta detection, and email alerts that land in follow-up PRs (Phase 2b/c).

Per the freemium spec at [docs/superpowers/specs/2026-04-01-freemium-monetization-design.md](https://github.com/schmug/dmarcheck/blob/main/docs/superpowers/specs/2026-04-01-freemium-monetization-design.md), Phase 2 = Monitoring + Alerts (lands before Phase 3 Stripe billing).

## Self-host safety
Public `/check` is untouched; a self-host deploy with no D1 binding still works exactly as before. Persistence only runs inside authed `/dashboard/*` routes that already require `DB`.

## Test plan
- [x] `npm test` — 422/422 green
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [ ] Manual smoke on staging: log in, click Scan Now on the auto-provisioned free domain, confirm grade history chart populates

🤖 Generated with [Claude Code](https://claude.com/claude-code)