### PR TITLE
Phase 2b: nightly cron rescan + grade-drop/protocol-regression detection

### DIFF
--- a/src/alerts/detector.ts
+++ b/src/alerts/detector.ts
@@ -1,0 +1,104 @@
+// Pure grade-drop + protocol-regression detection. No I/O — the cron and
+// the test suite both feed it plain values and read back an AlertPayload
+// (or null when nothing changed).
+
+export type AlertType = "grade_drop" | "protocol_regression";
+
+export interface AlertPayload {
+  type: AlertType;
+  previousValue: string;
+  newValue: string;
+}
+
+// Higher rank = better grade. Anything unrecognized ranks as -1 so an
+// unknown grade neither triggers nor suppresses an alert on its own.
+const GRADE_RANK: Record<string, number> = {
+  F: 0,
+  "D-": 1,
+  D: 2,
+  "D+": 3,
+  "C-": 4,
+  C: 5,
+  "C+": 6,
+  "B-": 7,
+  B: 8,
+  "B+": 9,
+  "A-": 10,
+  A: 11,
+  "A+": 12,
+  S: 13,
+};
+
+export function gradeRank(grade: string | null | undefined): number {
+  if (!grade) return -1;
+  return GRADE_RANK[grade] ?? -1;
+}
+
+export function detectGradeDrop(
+  previousGrade: string | null | undefined,
+  newGrade: string,
+): AlertPayload | null {
+  if (!previousGrade) return null; // first-ever scan is not a drop
+  const prev = gradeRank(previousGrade);
+  const next = gradeRank(newGrade);
+  if (prev < 0 || next < 0) return null; // unknown grade on either side
+  if (next >= prev) return null;
+  return {
+    type: "grade_drop",
+    previousValue: previousGrade,
+    newValue: newGrade,
+  };
+}
+
+// Protocol statuses ordered worst → best. A regression is any transition
+// from a "better" status to a "worse" one on a scored protocol. MX is
+// informational-only so it's excluded.
+const STATUS_RANK: Record<string, number> = {
+  fail: 0,
+  warn: 1,
+  pass: 2,
+};
+
+type ProtocolId = "dmarc" | "spf" | "dkim" | "bimi" | "mta_sts";
+const SCORED_PROTOCOLS: ProtocolId[] = [
+  "dmarc",
+  "spf",
+  "dkim",
+  "bimi",
+  "mta_sts",
+];
+
+interface ProtocolStatuses {
+  dmarc?: string;
+  spf?: string;
+  dkim?: string;
+  bimi?: string;
+  mta_sts?: string;
+}
+
+// Returns one regression per protocol that went backwards, in the canonical
+// protocol order. Callers typically care about the worst one (first return)
+// but the full list is useful for diagnostic logs.
+export function detectProtocolRegressions(
+  previous: ProtocolStatuses | null | undefined,
+  next: ProtocolStatuses,
+): AlertPayload[] {
+  if (!previous) return [];
+  const out: AlertPayload[] = [];
+  for (const id of SCORED_PROTOCOLS) {
+    const prevStatus = previous[id];
+    const nextStatus = next[id];
+    if (!prevStatus || !nextStatus) continue;
+    const prevRank = STATUS_RANK[prevStatus];
+    const nextRank = STATUS_RANK[nextStatus];
+    if (prevRank === undefined || nextRank === undefined) continue;
+    if (nextRank < prevRank) {
+      out.push({
+        type: "protocol_regression",
+        previousValue: `${id}:${prevStatus}`,
+        newValue: `${id}:${nextStatus}`,
+      });
+    }
+  }
+  return out;
+}

--- a/src/cron/rescan.ts
+++ b/src/cron/rescan.ts
@@ -1,0 +1,151 @@
+import * as Sentry from "@sentry/cloudflare";
+import {
+  type AlertPayload,
+  detectGradeDrop,
+  detectProtocolRegressions,
+} from "../alerts/detector.js";
+import type { ScanResult } from "../analyzers/types.js";
+import { recordAlert } from "../db/alerts.js";
+import { type Domain, getDueDomains } from "../db/domains.js";
+import { recordScan } from "../db/scans.js";
+import { scan as defaultScan } from "../orchestrator.js";
+
+export interface RescanResult {
+  scanned: number;
+  alerts: number;
+  errors: number;
+}
+
+interface RescanDeps {
+  db: D1Database;
+  now: number;
+  batchSize?: number;
+  scanFn?: (domain: string) => Promise<ScanResult>;
+}
+
+interface PreviousProtocolStatuses {
+  dmarc?: string;
+  spf?: string;
+  dkim?: string;
+  bimi?: string;
+  mta_sts?: string;
+}
+
+// Reads the most recent scan_history row's protocol_results (parsed JSON) so
+// we can diff protocol statuses. Returns null on first-ever scan or when the
+// row is missing / unparseable — detectProtocolRegressions handles null.
+async function getPreviousProtocolStatuses(
+  db: D1Database,
+  domainId: number,
+): Promise<PreviousProtocolStatuses | null> {
+  const row = await db
+    .prepare(
+      "SELECT protocol_results FROM scan_history WHERE domain_id = ? ORDER BY scanned_at DESC LIMIT 1",
+    )
+    .bind(domainId)
+    .first<{ protocol_results: string | null }>();
+  if (!row?.protocol_results) return null;
+  try {
+    const parsed = JSON.parse(row.protocol_results) as Record<
+      string,
+      { status?: string }
+    >;
+    return {
+      dmarc: parsed.dmarc?.status,
+      spf: parsed.spf?.status,
+      dkim: parsed.dkim?.status,
+      bimi: parsed.bimi?.status,
+      mta_sts: parsed.mta_sts?.status,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function extractStatuses(result: ScanResult): PreviousProtocolStatuses {
+  return {
+    dmarc: result.protocols.dmarc.status,
+    spf: result.protocols.spf.status,
+    dkim: result.protocols.dkim.status,
+    bimi: result.protocols.bimi.status,
+    mta_sts: result.protocols.mta_sts.status,
+  };
+}
+
+async function rescanOne(
+  deps: RescanDeps,
+  domain: Domain,
+): Promise<{ alerts: number; error?: unknown }> {
+  const scanFn = deps.scanFn ?? defaultScan;
+  const prevStatuses = await getPreviousProtocolStatuses(deps.db, domain.id);
+
+  let result: ScanResult;
+  try {
+    result = await scanFn(domain.domain);
+  } catch (err) {
+    return { alerts: 0, error: err };
+  }
+
+  await recordScan(deps.db, {
+    domainId: domain.id,
+    grade: result.grade,
+    scoreFactors: result.breakdown.factors,
+    protocolResults: result.protocols,
+    scannedAt: deps.now,
+  });
+
+  const alerts: AlertPayload[] = [];
+  const gradeAlert = detectGradeDrop(domain.last_grade, result.grade);
+  if (gradeAlert) alerts.push(gradeAlert);
+  const protocolAlerts = detectProtocolRegressions(
+    prevStatuses,
+    extractStatuses(result),
+  );
+  alerts.push(...protocolAlerts);
+
+  for (const alert of alerts) {
+    await recordAlert(deps.db, {
+      domainId: domain.id,
+      type: alert.type,
+      previousValue: alert.previousValue,
+      newValue: alert.newValue,
+      createdAt: deps.now,
+    });
+  }
+
+  return { alerts: alerts.length };
+}
+
+// Entry point for the scheduled() handler. Runs the rescan pipeline across
+// all due domains in bounded batches. Failures on individual domains are
+// caught and counted — one domain's DNS timeout must not stop the rest.
+export async function runDueRescans(deps: RescanDeps): Promise<RescanResult> {
+  const batchSize = deps.batchSize ?? 25;
+  const due = await getDueDomains(deps.db, deps.now);
+  let scanned = 0;
+  let alertCount = 0;
+  let errors = 0;
+
+  for (let i = 0; i < due.length; i += batchSize) {
+    const batch = due.slice(i, i + batchSize);
+    const outcomes = await Promise.allSettled(
+      batch.map((d) => rescanOne(deps, d)),
+    );
+    for (const outcome of outcomes) {
+      if (outcome.status === "rejected") {
+        errors += 1;
+        Sentry.captureException(outcome.reason);
+        continue;
+      }
+      if (outcome.value.error) {
+        errors += 1;
+        Sentry.captureException(outcome.value.error);
+        continue;
+      }
+      scanned += 1;
+      alertCount += outcome.value.alerts;
+    }
+  }
+
+  return { scanned, alerts: alertCount, errors };
+}

--- a/src/db/alerts.ts
+++ b/src/db/alerts.ts
@@ -1,0 +1,74 @@
+import type { AlertType } from "../alerts/detector.js";
+
+export interface AlertRow {
+  id: number;
+  domain_id: number;
+  alert_type: string;
+  previous_value: string | null;
+  new_value: string | null;
+  notified_via: string | null;
+  created_at: number;
+}
+
+export interface RecordAlertInput {
+  domainId: number;
+  type: AlertType;
+  previousValue: string;
+  newValue: string;
+  createdAt?: number;
+}
+
+export async function recordAlert(
+  db: D1Database,
+  input: RecordAlertInput,
+): Promise<void> {
+  const createdAt = input.createdAt ?? Math.floor(Date.now() / 1000);
+  await db
+    .prepare(
+      "INSERT INTO alerts (domain_id, alert_type, previous_value, new_value, created_at) VALUES (?, ?, ?, ?, ?)",
+    )
+    .bind(
+      input.domainId,
+      input.type,
+      input.previousValue,
+      input.newValue,
+      createdAt,
+    )
+    .run();
+}
+
+// Returns alerts that haven't been delivered yet (notified_via IS NULL).
+// Joins to domains to expose the owning user_id for alert routing.
+export interface UnsentAlert extends AlertRow {
+  user_id: string;
+  domain: string;
+}
+
+export async function listUnsentAlerts(
+  db: D1Database,
+  limit = 100,
+): Promise<UnsentAlert[]> {
+  const result = await db
+    .prepare(
+      `SELECT a.*, d.user_id, d.domain
+       FROM alerts a
+       JOIN domains d ON d.id = a.domain_id
+       WHERE a.notified_via IS NULL
+       ORDER BY a.created_at ASC
+       LIMIT ?`,
+    )
+    .bind(limit)
+    .all<UnsentAlert>();
+  return result.results;
+}
+
+export async function markAlertNotified(
+  db: D1Database,
+  alertId: number,
+  channel: string,
+): Promise<void> {
+  await db
+    .prepare("UPDATE alerts SET notified_via = ? WHERE id = ?")
+    .bind(channel, alertId)
+    .run();
+}

--- a/src/db/domains.ts
+++ b/src/db/domains.ts
@@ -55,6 +55,30 @@ export async function deleteDomain(
     .run();
 }
 
+// Returns domains whose cadence has come due: monthly domains scanned more
+// than 30 days ago (or never), weekly domains scanned more than 7 days ago.
+// The constants are defined inline because the schema only permits two
+// frequencies today; if we add more, split this into a per-frequency helper.
+export async function getDueDomains(
+  db: D1Database,
+  now: number,
+  limit = 500,
+): Promise<Domain[]> {
+  const monthlyCutoff = now - 30 * 24 * 60 * 60;
+  const weeklyCutoff = now - 7 * 24 * 60 * 60;
+  const result = await db
+    .prepare(
+      `SELECT * FROM domains
+       WHERE (scan_frequency = 'monthly' AND (last_scanned_at IS NULL OR last_scanned_at < ?))
+          OR (scan_frequency = 'weekly' AND (last_scanned_at IS NULL OR last_scanned_at < ?))
+       ORDER BY last_scanned_at ASC NULLS FIRST
+       LIMIT ?`,
+    )
+    .bind(monthlyCutoff, weeklyCutoff, limit)
+    .all<Domain>();
+  return result.results;
+}
+
 export async function updateLastScan(
   db: D1Database,
   domainId: number,

--- a/src/env.ts
+++ b/src/env.ts
@@ -4,4 +4,5 @@ export interface Env {
   WORKOS_CLIENT_SECRET: string;
   WORKOS_REDIRECT_URI: string;
   SESSION_SECRET: string;
+  SENTRY_DSN?: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { API_CATALOG_JSON } from "./api/catalog.js";
 import { OPENAPI_JSON } from "./api/openapi.js";
 import { authRoutes } from "./auth/routes.js";
 import { getCachedScan, setCachedScan } from "./cache.js";
+import { runDueRescans } from "./cron/rescan.js";
 import { generateCsv } from "./csv.js";
 import { dashboardRoutes } from "./dashboard/routes.js";
 import type { Env } from "./env.js";
@@ -67,7 +68,10 @@ import {
 import { JS } from "./views/scripts.js";
 import { CSS } from "./views/styles.js";
 
-const app = new Hono<{ Bindings: Env }>();
+// The Hono app is exported for tests (which call `app.request(...)`).
+// Runtime Workers use the Sentry-wrapped default export below, which adds
+// cron (`scheduled`) alongside `fetch`.
+export const app = new Hono<{ Bindings: Env }>();
 
 // Set Sentry scope context for every request
 app.use("*", async (c, next) => {
@@ -911,8 +915,39 @@ export function parseSelectors(raw: string | undefined): string[] {
     .filter((s) => s.length > 0 && VALID_SELECTOR.test(s));
 }
 
-export default Sentry.withSentry(
-  (env?: { SENTRY_DSN?: string }) => ({
+// Cron handler — runs nightly per the `[triggers] crons` entry in wrangler.toml.
+// Rescans domains whose cadence has come due (monthly or weekly), persists
+// results, and records grade_drop / protocol_regression alerts. Fails soft
+// when DB is unbound so self-host deploys without D1 don't fault.
+async function scheduled(
+  _controller: ScheduledController,
+  env: Env,
+  ctx: ExecutionContext,
+): Promise<void> {
+  if (!env.DB) return;
+  const work = runDueRescans({
+    db: env.DB,
+    now: Math.floor(Date.now() / 1000),
+  })
+    .then((result) => {
+      const scope = Sentry.getCurrentScope();
+      scope.setTag("cron.scanned", String(result.scanned));
+      scope.setTag("cron.alerts", String(result.alerts));
+      scope.setTag("cron.errors", String(result.errors));
+    })
+    .catch((err) => {
+      Sentry.captureException(err);
+    });
+  ctx.waitUntil(work);
+}
+
+const handler: ExportedHandler<Env> = {
+  fetch: app.fetch.bind(app),
+  scheduled,
+};
+
+export default Sentry.withSentry<Env>(
+  (env) => ({
     dsn: env?.SENTRY_DSN ?? "",
     tracesSampler: (samplingContext: { parentSampled?: boolean }) => {
       if (samplingContext.parentSampled !== undefined)
@@ -920,5 +955,5 @@ export default Sentry.withSentry(
       return 0.3;
     },
   }),
-  app,
+  handler,
 );

--- a/test/agent-discovery.test.ts
+++ b/test/agent-discovery.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import app from "../src/index.js";
+import { app } from "../src/index.js";
 import { _memoryStore } from "../src/rate-limit.js";
 
 vi.mock("../src/cache.js", () => ({

--- a/test/alert-detector.test.ts
+++ b/test/alert-detector.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import {
+  detectGradeDrop,
+  detectProtocolRegressions,
+  gradeRank,
+} from "../src/alerts/detector.js";
+
+describe("gradeRank", () => {
+  it("ranks S highest", () => {
+    expect(gradeRank("S")).toBeGreaterThan(gradeRank("A+"));
+  });
+
+  it("ranks A+ above A above A-", () => {
+    expect(gradeRank("A+")).toBeGreaterThan(gradeRank("A"));
+    expect(gradeRank("A")).toBeGreaterThan(gradeRank("A-"));
+  });
+
+  it("ranks F lowest", () => {
+    expect(gradeRank("F")).toBe(0);
+  });
+
+  it("returns -1 for unknown or missing grades", () => {
+    expect(gradeRank(null)).toBe(-1);
+    expect(gradeRank(undefined)).toBe(-1);
+    expect(gradeRank("Z")).toBe(-1);
+    expect(gradeRank("")).toBe(-1);
+  });
+});
+
+describe("detectGradeDrop", () => {
+  it("returns null when previous grade is null (first scan)", () => {
+    expect(detectGradeDrop(null, "A")).toBeNull();
+    expect(detectGradeDrop(undefined, "A")).toBeNull();
+  });
+
+  it("returns null when grade is unchanged", () => {
+    expect(detectGradeDrop("B", "B")).toBeNull();
+  });
+
+  it("returns null when grade improves", () => {
+    expect(detectGradeDrop("B", "A")).toBeNull();
+    expect(detectGradeDrop("F", "D")).toBeNull();
+    expect(detectGradeDrop("A", "A+")).toBeNull();
+  });
+
+  it("flags a drop across letter tiers", () => {
+    const alert = detectGradeDrop("A", "B");
+    expect(alert).toEqual({
+      type: "grade_drop",
+      previousValue: "A",
+      newValue: "B",
+    });
+  });
+
+  it("flags a drop within a letter tier (A+ → A)", () => {
+    expect(detectGradeDrop("A+", "A")).toEqual({
+      type: "grade_drop",
+      previousValue: "A+",
+      newValue: "A",
+    });
+  });
+
+  it("flags a drop from S all the way down to F", () => {
+    const alert = detectGradeDrop("S", "F");
+    expect(alert?.type).toBe("grade_drop");
+  });
+
+  it("returns null when one side is unknown", () => {
+    expect(detectGradeDrop("A", "Z")).toBeNull();
+    expect(detectGradeDrop("Q", "F")).toBeNull();
+  });
+});
+
+describe("detectProtocolRegressions", () => {
+  it("returns [] when previous is missing", () => {
+    expect(
+      detectProtocolRegressions(null, { dmarc: "pass", spf: "pass" }),
+    ).toEqual([]);
+  });
+
+  it("returns [] when nothing changed", () => {
+    expect(
+      detectProtocolRegressions(
+        { dmarc: "pass", spf: "warn", dkim: "pass" },
+        { dmarc: "pass", spf: "warn", dkim: "pass" },
+      ),
+    ).toEqual([]);
+  });
+
+  it("returns [] when protocols improved", () => {
+    expect(
+      detectProtocolRegressions(
+        { dmarc: "warn", spf: "fail" },
+        { dmarc: "pass", spf: "pass" },
+      ),
+    ).toEqual([]);
+  });
+
+  it("flags pass → fail as a regression", () => {
+    const regressions = detectProtocolRegressions(
+      { dmarc: "pass" },
+      { dmarc: "fail" },
+    );
+    expect(regressions).toHaveLength(1);
+    expect(regressions[0]).toEqual({
+      type: "protocol_regression",
+      previousValue: "dmarc:pass",
+      newValue: "dmarc:fail",
+    });
+  });
+
+  it("flags pass → warn and warn → fail", () => {
+    const regressions = detectProtocolRegressions(
+      { dmarc: "pass", spf: "warn" },
+      { dmarc: "warn", spf: "fail" },
+    );
+    expect(regressions.map((r) => r.previousValue)).toEqual([
+      "dmarc:pass",
+      "spf:warn",
+    ]);
+  });
+
+  it("returns regressions in canonical protocol order", () => {
+    const regressions = detectProtocolRegressions(
+      { mta_sts: "pass", dmarc: "pass" },
+      { mta_sts: "fail", dmarc: "fail" },
+    );
+    expect(regressions.map((r) => r.previousValue.split(":")[0])).toEqual([
+      "dmarc",
+      "mta_sts",
+    ]);
+  });
+
+  it("ignores MX (informational, not scored)", () => {
+    const regressions = detectProtocolRegressions(
+      { dmarc: "pass" } as Record<string, string>,
+      { dmarc: "pass" } as Record<string, string>,
+    );
+    expect(regressions).toEqual([]);
+  });
+
+  it("ignores unknown status values", () => {
+    const regressions = detectProtocolRegressions(
+      { dmarc: "weird" },
+      { dmarc: "fail" },
+    );
+    expect(regressions).toEqual([]);
+  });
+});

--- a/test/cron-rescan.test.ts
+++ b/test/cron-rescan.test.ts
@@ -1,0 +1,396 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runDueRescans } from "../src/cron/rescan.js";
+
+interface DomainRow {
+  id: number;
+  user_id: string;
+  domain: string;
+  is_free: number;
+  scan_frequency: string;
+  last_scanned_at: number | null;
+  last_grade: string | null;
+  created_at: number;
+}
+
+interface AlertRow {
+  id: number;
+  domain_id: number;
+  alert_type: string;
+  previous_value: string | null;
+  new_value: string | null;
+  notified_via: string | null;
+  created_at: number;
+}
+
+interface ScanHistoryRow {
+  id: number;
+  domain_id: number;
+  grade: string;
+  score_factors: string | null;
+  protocol_results: string | null;
+  scanned_at: number;
+}
+
+let domains: Map<number, DomainRow>;
+let alerts: Map<number, AlertRow>;
+let history: Map<number, ScanHistoryRow>;
+let nextScanId: number;
+let nextAlertId: number;
+
+function makeD1Mock(): D1Database {
+  const prepare = (sql: string) => ({
+    bind: (...params: unknown[]) => ({
+      run: async () => {
+        if (/^INSERT INTO scan_history/i.test(sql)) {
+          const [domainId, grade, scoreFactors, protocolResults, scannedAt] =
+            params as [number, string, string, string, number];
+          const id = nextScanId++;
+          history.set(id, {
+            id,
+            domain_id: domainId,
+            grade,
+            score_factors: scoreFactors,
+            protocol_results: protocolResults,
+            scanned_at: scannedAt,
+          });
+        } else if (/^UPDATE domains SET last_grade/i.test(sql)) {
+          const [grade, scannedAt, domainId] = params as [
+            string,
+            number,
+            number,
+          ];
+          const row = domains.get(domainId);
+          if (row) {
+            domains.set(domainId, {
+              ...row,
+              last_grade: grade,
+              last_scanned_at: scannedAt,
+            });
+          }
+        } else if (/^INSERT INTO alerts/i.test(sql)) {
+          const [domainId, type, prevVal, newVal, createdAt] = params as [
+            number,
+            string,
+            string,
+            string,
+            number,
+          ];
+          const id = nextAlertId++;
+          alerts.set(id, {
+            id,
+            domain_id: domainId,
+            alert_type: type,
+            previous_value: prevVal,
+            new_value: newVal,
+            notified_via: null,
+            created_at: createdAt,
+          });
+        }
+        return { success: true };
+      },
+      first: async <T>(): Promise<T | null> => {
+        if (/FROM scan_history WHERE domain_id = \? ORDER BY/i.test(sql)) {
+          const [domainId] = params as [number];
+          const rows = [...history.values()]
+            .filter((r) => r.domain_id === domainId)
+            .sort((a, b) => b.scanned_at - a.scanned_at);
+          return (rows[0] ?? null) as T | null;
+        }
+        return null;
+      },
+      all: async <T>(): Promise<{ results: T[] }> => {
+        if (/FROM domains[\s\S]*scan_frequency = 'monthly'/i.test(sql)) {
+          const [monthlyCutoff, weeklyCutoff, limit] = params as [
+            number,
+            number,
+            number,
+          ];
+          const due = [...domains.values()]
+            .filter((d) => {
+              if (d.scan_frequency === "monthly") {
+                return (
+                  d.last_scanned_at === null ||
+                  d.last_scanned_at < monthlyCutoff
+                );
+              }
+              if (d.scan_frequency === "weekly") {
+                return (
+                  d.last_scanned_at === null || d.last_scanned_at < weeklyCutoff
+                );
+              }
+              return false;
+            })
+            .sort((a, b) => (a.last_scanned_at ?? 0) - (b.last_scanned_at ?? 0))
+            .slice(0, limit);
+          return { results: due as T[] };
+        }
+        return { results: [] };
+      },
+    }),
+  });
+  return {
+    prepare,
+    batch: async (
+      stmts: Array<{ run: () => Promise<{ success: boolean }> }>,
+    ) => {
+      for (const stmt of stmts) await stmt.run();
+      return [];
+    },
+  } as unknown as D1Database;
+}
+
+// Minimal fake ScanResult shape — only what rescan reads.
+function makeScanResult(
+  domain: string,
+  grade: string,
+  statuses: Record<string, string>,
+) {
+  return {
+    domain,
+    timestamp: "2026-04-19T00:00:00Z",
+    grade,
+    breakdown: {
+      grade,
+      tier: grade,
+      tierReason: "",
+      modifier: 0,
+      modifierLabel: "",
+      factors: [],
+      recommendations: [],
+      protocolSummaries: {},
+    },
+    summary: { mx_records: 0, mx_providers: [], dmarc_policy: null },
+    protocols: {
+      mx: { status: "info" },
+      dmarc: { status: statuses.dmarc ?? "pass" },
+      spf: { status: statuses.spf ?? "pass" },
+      dkim: { status: statuses.dkim ?? "pass" },
+      bimi: { status: statuses.bimi ?? "pass" },
+      mta_sts: { status: statuses.mta_sts ?? "pass" },
+    },
+  };
+}
+
+describe("cron/runDueRescans", () => {
+  const now = 1_700_000_000;
+  const monthSeconds = 30 * 24 * 60 * 60;
+  const weekSeconds = 7 * 24 * 60 * 60;
+
+  beforeEach(() => {
+    domains = new Map();
+    alerts = new Map();
+    history = new Map();
+    nextScanId = 1;
+    nextAlertId = 1;
+  });
+
+  it("skips domains that are not yet due", async () => {
+    domains.set(1, {
+      id: 1,
+      user_id: "u",
+      domain: "recent.com",
+      is_free: 1,
+      scan_frequency: "monthly",
+      last_scanned_at: now - 1000,
+      last_grade: "A",
+      created_at: 0,
+    });
+
+    const scanFn = vi.fn();
+    const result = await runDueRescans({
+      db: makeD1Mock(),
+      now,
+      scanFn: scanFn as never,
+    });
+
+    expect(result.scanned).toBe(0);
+    expect(scanFn).not.toHaveBeenCalled();
+  });
+
+  it("scans due monthly domains and persists scan_history", async () => {
+    domains.set(1, {
+      id: 1,
+      user_id: "u",
+      domain: "stale.com",
+      is_free: 1,
+      scan_frequency: "monthly",
+      last_scanned_at: now - monthSeconds - 100,
+      last_grade: "A",
+      created_at: 0,
+    });
+
+    const scanFn = vi
+      .fn()
+      .mockResolvedValue(makeScanResult("stale.com", "A", {}));
+
+    const result = await runDueRescans({
+      db: makeD1Mock(),
+      now,
+      scanFn: scanFn as never,
+    });
+
+    expect(result).toEqual({ scanned: 1, alerts: 0, errors: 0 });
+    expect(scanFn).toHaveBeenCalledWith("stale.com");
+    expect(history.size).toBe(1);
+    expect([...history.values()][0].grade).toBe("A");
+    expect(domains.get(1)?.last_grade).toBe("A");
+    expect(domains.get(1)?.last_scanned_at).toBe(now);
+  });
+
+  it("skips weekly domains scanned within the last week", async () => {
+    domains.set(1, {
+      id: 1,
+      user_id: "u",
+      domain: "weekly.com",
+      is_free: 0,
+      scan_frequency: "weekly",
+      last_scanned_at: now - 100,
+      last_grade: "A",
+      created_at: 0,
+    });
+
+    const scanFn = vi.fn();
+    const result = await runDueRescans({
+      db: makeD1Mock(),
+      now,
+      scanFn: scanFn as never,
+    });
+    expect(result.scanned).toBe(0);
+  });
+
+  it("includes never-scanned domains (last_scanned_at IS NULL)", async () => {
+    domains.set(1, {
+      id: 1,
+      user_id: "u",
+      domain: "brand-new.com",
+      is_free: 1,
+      scan_frequency: "monthly",
+      last_scanned_at: null,
+      last_grade: null,
+      created_at: 0,
+    });
+
+    const scanFn = vi
+      .fn()
+      .mockResolvedValue(makeScanResult("brand-new.com", "B", {}));
+
+    const result = await runDueRescans({
+      db: makeD1Mock(),
+      now,
+      scanFn: scanFn as never,
+    });
+    expect(result.scanned).toBe(1);
+    expect(result.alerts).toBe(0); // first scan is not a "drop"
+  });
+
+  it("records a grade_drop alert when the grade falls", async () => {
+    domains.set(1, {
+      id: 1,
+      user_id: "u",
+      domain: "falling.com",
+      is_free: 1,
+      scan_frequency: "monthly",
+      last_scanned_at: now - monthSeconds - 1,
+      last_grade: "A",
+      created_at: 0,
+    });
+
+    const scanFn = vi
+      .fn()
+      .mockResolvedValue(makeScanResult("falling.com", "C", {}));
+
+    const result = await runDueRescans({
+      db: makeD1Mock(),
+      now,
+      scanFn: scanFn as never,
+    });
+    expect(result.alerts).toBe(1);
+    expect([...alerts.values()][0]).toMatchObject({
+      domain_id: 1,
+      alert_type: "grade_drop",
+      previous_value: "A",
+      new_value: "C",
+    });
+  });
+
+  it("records protocol_regression alerts when statuses worsen", async () => {
+    domains.set(1, {
+      id: 1,
+      user_id: "u",
+      domain: "regress.com",
+      is_free: 0,
+      scan_frequency: "weekly",
+      last_scanned_at: now - weekSeconds - 1,
+      last_grade: "B",
+      created_at: 0,
+    });
+    // Seed previous history so protocol diff has a baseline
+    history.set(99, {
+      id: 99,
+      domain_id: 1,
+      grade: "B",
+      score_factors: null,
+      protocol_results: JSON.stringify({
+        dmarc: { status: "pass" },
+        spf: { status: "pass" },
+        dkim: { status: "pass" },
+        bimi: { status: "pass" },
+        mta_sts: { status: "pass" },
+      }),
+      scanned_at: now - weekSeconds - 1,
+    });
+
+    const scanFn = vi
+      .fn()
+      .mockResolvedValue(
+        makeScanResult("regress.com", "B", { dmarc: "fail", spf: "warn" }),
+      );
+
+    const result = await runDueRescans({
+      db: makeD1Mock(),
+      now,
+      scanFn: scanFn as never,
+    });
+
+    expect(result.scanned).toBe(1);
+    expect(result.alerts).toBe(2); // dmarc pass→fail, spf pass→warn
+    const types = [...alerts.values()].map((a) => a.alert_type);
+    expect(types.every((t) => t === "protocol_regression")).toBe(true);
+  });
+
+  it("counts errors but continues past a failing domain", async () => {
+    domains.set(1, {
+      id: 1,
+      user_id: "u",
+      domain: "broken.com",
+      is_free: 1,
+      scan_frequency: "monthly",
+      last_scanned_at: null,
+      last_grade: null,
+      created_at: 0,
+    });
+    domains.set(2, {
+      id: 2,
+      user_id: "u",
+      domain: "ok.com",
+      is_free: 1,
+      scan_frequency: "monthly",
+      last_scanned_at: null,
+      last_grade: null,
+      created_at: 1,
+    });
+
+    const scanFn = vi.fn(async (domain: string) => {
+      if (domain === "broken.com") throw new Error("DNS timeout");
+      return makeScanResult(domain, "A", {});
+    });
+
+    const result = await runDueRescans({
+      db: makeD1Mock(),
+      now,
+      scanFn: scanFn as never,
+    });
+    expect(result.errors).toBe(1);
+    expect(result.scanned).toBe(1);
+  });
+});

--- a/test/db-alerts.test.ts
+++ b/test/db-alerts.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  type AlertRow,
+  listUnsentAlerts,
+  markAlertNotified,
+  recordAlert,
+} from "../src/db/alerts.js";
+
+let alertStore: Map<number, AlertRow>;
+let domainStore: Map<number, { id: number; user_id: string; domain: string }>;
+let nextId: number;
+
+function makeD1Mock(): D1Database {
+  const prepare = (sql: string) => ({
+    bind: (...params: unknown[]) => ({
+      run: async () => {
+        if (/^INSERT INTO alerts/i.test(sql)) {
+          const [domainId, type, prevVal, newVal, createdAt] = params as [
+            number,
+            string,
+            string,
+            string,
+            number,
+          ];
+          const id = nextId++;
+          alertStore.set(id, {
+            id,
+            domain_id: domainId,
+            alert_type: type,
+            previous_value: prevVal,
+            new_value: newVal,
+            notified_via: null,
+            created_at: createdAt,
+          });
+        } else if (/^UPDATE alerts SET notified_via/i.test(sql)) {
+          const [channel, id] = params as [string, number];
+          const row = alertStore.get(id);
+          if (row) alertStore.set(id, { ...row, notified_via: channel });
+        }
+        return { success: true };
+      },
+      all: async <T>(): Promise<{ results: T[] }> => {
+        if (/FROM alerts[\s\S]*JOIN domains/i.test(sql)) {
+          const [limit] = params as [number];
+          const rows = [...alertStore.values()]
+            .filter((a) => a.notified_via === null)
+            .sort((a, b) => a.created_at - b.created_at)
+            .slice(0, limit)
+            .map((a) => {
+              const d = domainStore.get(a.domain_id);
+              return {
+                ...a,
+                user_id: d?.user_id ?? "",
+                domain: d?.domain ?? "",
+              };
+            });
+          return { results: rows as T[] };
+        }
+        return { results: [] };
+      },
+    }),
+  });
+  return { prepare } as unknown as D1Database;
+}
+
+describe("db/alerts", () => {
+  let db: D1Database;
+
+  beforeEach(() => {
+    alertStore = new Map();
+    domainStore = new Map([
+      [7, { id: 7, user_id: "user_1", domain: "example.com" }],
+      [9, { id: 9, user_id: "user_2", domain: "other.com" }],
+    ]);
+    nextId = 1;
+    db = makeD1Mock();
+  });
+
+  describe("recordAlert", () => {
+    it("inserts a grade_drop alert with the given values", async () => {
+      await recordAlert(db, {
+        domainId: 7,
+        type: "grade_drop",
+        previousValue: "A",
+        newValue: "C",
+        createdAt: 1_700_000_000,
+      });
+
+      expect(alertStore.size).toBe(1);
+      const row = [...alertStore.values()][0];
+      expect(row.domain_id).toBe(7);
+      expect(row.alert_type).toBe("grade_drop");
+      expect(row.previous_value).toBe("A");
+      expect(row.new_value).toBe("C");
+      expect(row.notified_via).toBeNull();
+      expect(row.created_at).toBe(1_700_000_000);
+    });
+
+    it("defaults createdAt to current unix time", async () => {
+      const before = Math.floor(Date.now() / 1000);
+      await recordAlert(db, {
+        domainId: 7,
+        type: "protocol_regression",
+        previousValue: "dmarc:pass",
+        newValue: "dmarc:fail",
+      });
+      const after = Math.floor(Date.now() / 1000);
+      const row = [...alertStore.values()][0];
+      expect(row.created_at).toBeGreaterThanOrEqual(before);
+      expect(row.created_at).toBeLessThanOrEqual(after);
+    });
+  });
+
+  describe("listUnsentAlerts", () => {
+    it("returns only alerts with notified_via IS NULL, oldest first", async () => {
+      await recordAlert(db, {
+        domainId: 7,
+        type: "grade_drop",
+        previousValue: "A",
+        newValue: "B",
+        createdAt: 100,
+      });
+      await recordAlert(db, {
+        domainId: 9,
+        type: "grade_drop",
+        previousValue: "B",
+        newValue: "C",
+        createdAt: 50,
+      });
+      await recordAlert(db, {
+        domainId: 7,
+        type: "grade_drop",
+        previousValue: "C",
+        newValue: "D",
+        createdAt: 200,
+      });
+
+      await markAlertNotified(db, 1, "email");
+
+      const unsent = await listUnsentAlerts(db);
+      expect(unsent.map((a) => a.id)).toEqual([2, 3]);
+      expect(unsent[0].user_id).toBe("user_2");
+      expect(unsent[0].domain).toBe("other.com");
+    });
+
+    it("respects the limit", async () => {
+      for (let i = 0; i < 5; i++) {
+        await recordAlert(db, {
+          domainId: 7,
+          type: "grade_drop",
+          previousValue: "A",
+          newValue: "B",
+          createdAt: 100 + i,
+        });
+      }
+      const unsent = await listUnsentAlerts(db, 2);
+      expect(unsent).toHaveLength(2);
+    });
+  });
+
+  describe("markAlertNotified", () => {
+    it("sets notified_via on the target row only", async () => {
+      await recordAlert(db, {
+        domainId: 7,
+        type: "grade_drop",
+        previousValue: "A",
+        newValue: "B",
+        createdAt: 100,
+      });
+      await recordAlert(db, {
+        domainId: 7,
+        type: "grade_drop",
+        previousValue: "B",
+        newValue: "C",
+        createdAt: 101,
+      });
+
+      await markAlertNotified(db, 1, "email");
+
+      expect(alertStore.get(1)?.notified_via).toBe("email");
+      expect(alertStore.get(2)?.notified_via).toBeNull();
+    });
+  });
+});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import app, { normalizeDomain, parseSelectors } from "../src/index.js";
+import { app, normalizeDomain, parseSelectors } from "../src/index.js";
 import { _memoryStore } from "../src/rate-limit.js";
 
 vi.mock("../src/cache.js", () => ({

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -11,6 +11,11 @@ routes = [
 [dev]
 port = 8790
 
+# Nightly rescan of monitored domains for authed users. 06:17 UTC chosen
+# off-peak and off-the-hour to spread DNS load away from :00 herd cycles.
+[triggers]
+crons = ["17 6 * * *"]
+
 [[d1_databases]]
 binding = "DB"
 database_name = "dmarcheck-db"


### PR DESCRIPTION
## Summary
Builds the monitoring half of Phase 2 on top of Phase 2a ([#141](https://github.com/schmug/dmarcheck/pull/141), merged): a nightly cron trigger now rescans monitored domains whose cadence has come due, persists the result, and records `grade_drop` / `protocol_regression` alerts in `alerts`. Email delivery lands separately in Phase 2c.

- **Pure detectors** (`src/alerts/detector.ts`): `detectGradeDrop()` ranks grades S > A+ > A > A- > … > F and flags a drop; `detectProtocolRegressions()` diffs `pass` / `warn` / `fail` across DMARC / SPF / DKIM / BIMI / MTA-STS. No I/O, table-driven tests.
- **Alerts persistence** (`src/db/alerts.ts`): `recordAlert` / `listUnsentAlerts` / `markAlertNotified`. Alerts stay unsent until a delivery channel stamps `notified_via`.
- **Cadence query** (`src/db/domains.ts#getDueDomains`): monthly domains >=30 days stale, weekly >=7, NULL-first, bounded `LIMIT`.
- **Orchestration** (`src/cron/rescan.ts#runDueRescans`): pulls due domains, rescans in `Promise.allSettled` batches of 25 so one DNS timeout cannot abort the run, persists via Phase 2a `recordScan`, diffs against the previous `scan_history.protocol_results` JSON, records alerts. Returns `{ scanned, alerts, errors }` tagged on the Sentry scope.
- **Wiring**: `src/index.ts` default export is now `{ fetch, scheduled }` wrapped by `Sentry.withSentry<Env>`. The Hono app ships as the named export `app` for tests that use `app.request()`. `wrangler.toml` gets `[triggers] crons = ["17 6 * * *"]` (06:17 UTC nightly — off-peak, off-the-hour).

## Self-host safety
`scheduled()` returns early if `env.DB` is unbound, so a self-host deploy without D1 still boots without tripping a cron error. The public `fetch` path is unchanged.

## Follow-up (Phase 2c, next PR)
Cloudflare Email Sending binding + templated grade-drop email + unsubscribe token + per-user `email_alerts_enabled` toggle. Alerts written by this PR sit in the DB until 2c wires delivery.

## Test plan
- [x] `npm test` — 453/453 green (31 new across `alert-detector`, `db-alerts`, `cron-rescan`)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [ ] Staging: deploy via Git integration, seed a grade-drop by UPDATE-ing `domains.last_grade = 'A'` + clearing `last_scanned_at`, wait for the 06:17 UTC cron, confirm an `alerts` row with `alert_type = 'grade_drop'` and the domain's `last_grade` reflects the new result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)