### PR TITLE
Phase 2c: Cloudflare Email Sending + unsubscribe + settings toggle

### DIFF
--- a/src/alerts/dispatcher.ts
+++ b/src/alerts/dispatcher.ts
@@ -1,0 +1,81 @@
+import * as Sentry from "@sentry/cloudflare";
+import { listUnsentAlerts, markAlertNotified } from "../db/alerts.js";
+import { getUserById } from "../db/users.js";
+import type { Env } from "../env.js";
+import type { AlertType } from "./detector.js";
+import { sendGradeDropEmail } from "./email.js";
+import { createUnsubscribeToken } from "./unsubscribe.js";
+
+export interface DispatchResult {
+  considered: number;
+  sent: number;
+  skipped: number;
+  errors: number;
+}
+
+const PUBLIC_BASE_URL = "https://dmarc.mx";
+const SENDER_ADDRESS = "alerts@dmarc.mx";
+
+// Walks the queue of unsent alerts, resolves each to a user, respects
+// email_alerts_enabled, emits the email, and marks the row notified_via='email'.
+// Idempotent: the SQL query filters on notified_via IS NULL so a retry can
+// never double-send an alert that was already delivered.
+export async function dispatchPendingAlerts(env: Env): Promise<DispatchResult> {
+  const db = env.DB;
+  const alerts = await listUnsentAlerts(db);
+  let sent = 0;
+  let skipped = 0;
+  let errors = 0;
+
+  for (const alert of alerts) {
+    try {
+      const user = await getUserById(db, alert.user_id);
+      if (!user) {
+        // Orphaned alert (user deleted). Mark as "skipped" so we don't
+        // re-examine it on every cron run.
+        await markAlertNotified(db, alert.id, "skipped:no_user");
+        skipped += 1;
+        continue;
+      }
+      if (user.email_alerts_enabled === 0) {
+        await markAlertNotified(db, alert.id, "skipped:opt_out");
+        skipped += 1;
+        continue;
+      }
+
+      const unsubscribeToken = await createUnsubscribeToken(
+        user.id,
+        env.SESSION_SECRET,
+      );
+
+      const outcome = await sendGradeDropEmail(
+        env.EMAIL,
+        user.email,
+        SENDER_ADDRESS,
+        {
+          domain: alert.domain,
+          alertType: alert.alert_type as AlertType,
+          previousValue: alert.previous_value ?? "",
+          newValue: alert.new_value ?? "",
+          dashboardUrl: `${PUBLIC_BASE_URL}/dashboard/domain/${encodeURIComponent(alert.domain)}`,
+          unsubscribeUrl: `${PUBLIC_BASE_URL}/alerts/unsubscribe?token=${unsubscribeToken}`,
+        },
+      );
+
+      if (outcome.sent) {
+        await markAlertNotified(db, alert.id, "email");
+        sent += 1;
+      } else if (outcome.reason === "no_binding") {
+        // Leave the row unsent so it re-dispatches once the binding arrives.
+        skipped += 1;
+      } else {
+        errors += 1;
+      }
+    } catch (err) {
+      errors += 1;
+      Sentry.captureException(err);
+    }
+  }
+
+  return { considered: alerts.length, sent, skipped, errors };
+}

--- a/src/alerts/email.ts
+++ b/src/alerts/email.ts
@@ -1,0 +1,43 @@
+import * as Sentry from "@sentry/cloudflare";
+import {
+  type GradeDropEmailInput,
+  renderGradeDropHtml,
+  renderGradeDropSubject,
+  renderGradeDropText,
+} from "./templates.js";
+
+export interface SendOutcome {
+  sent: boolean;
+  reason?: "no_binding" | "send_error";
+  messageId?: string;
+}
+
+// Thin wrapper around the Cloudflare `send_email` binding. The binding is
+// optional (self-host safety); callers must handle the `no_binding` outcome.
+// Errors from the binding (E_SENDER_NOT_VERIFIED, E_RATE_LIMIT_EXCEEDED,
+// network) are captured to Sentry and surfaced as `send_error` rather than
+// rethrown, so one bad delivery cannot abort the dispatcher loop.
+export async function sendGradeDropEmail(
+  email: SendEmail | undefined,
+  toAddress: string,
+  fromAddress: string,
+  input: GradeDropEmailInput,
+): Promise<SendOutcome> {
+  if (!email) {
+    return { sent: false, reason: "no_binding" };
+  }
+
+  try {
+    const response = await email.send({
+      to: toAddress,
+      from: fromAddress,
+      subject: renderGradeDropSubject(input),
+      html: renderGradeDropHtml(input),
+      text: renderGradeDropText(input),
+    });
+    return { sent: true, messageId: response?.messageId };
+  } catch (err) {
+    Sentry.captureException(err);
+    return { sent: false, reason: "send_error" };
+  }
+}

--- a/src/alerts/templates.ts
+++ b/src/alerts/templates.ts
@@ -1,0 +1,99 @@
+// Grade-drop email templates. Kept simple — no external CSS, no remote
+// fonts, inline styles only so render consistency doesn't depend on the
+// recipient's client. DMarcus (worried mood) keeps the brand visible.
+
+import type { AlertType } from "./detector.js";
+
+function esc(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export interface GradeDropEmailInput {
+  domain: string;
+  alertType: AlertType;
+  previousValue: string;
+  newValue: string;
+  dashboardUrl: string;
+  unsubscribeUrl: string;
+}
+
+export function renderGradeDropSubject(input: GradeDropEmailInput): string {
+  if (input.alertType === "grade_drop") {
+    return `dmarc.mx: ${input.domain} dropped from ${input.previousValue} to ${input.newValue}`;
+  }
+  return `dmarc.mx: ${input.domain} protocol regression (${input.previousValue} → ${input.newValue})`;
+}
+
+export function renderGradeDropText(input: GradeDropEmailInput): string {
+  const headline =
+    input.alertType === "grade_drop"
+      ? `${input.domain} dropped from ${input.previousValue} to ${input.newValue}.`
+      : `${input.domain} regressed: ${input.previousValue} → ${input.newValue}.`;
+
+  return [
+    headline,
+    "",
+    "Open the dashboard to see the full protocol breakdown and fix recommendations:",
+    input.dashboardUrl,
+    "",
+    "—",
+    "You are receiving this because you have grade-drop alerts enabled.",
+    `Unsubscribe: ${input.unsubscribeUrl}`,
+  ].join("\n");
+}
+
+// Inline-CSS HTML. The DMarcus "worried" SVG here is a compact variant of
+// the one in src/views/components.ts — a full SVG + CSS animation pipeline
+// would not survive most email clients, so we ship a static image.
+function dmarcusWorriedSvg(): string {
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" width="72" height="72" role="img" aria-label="DMarcus looking worried">
+    <text x="60" y="82" font-family="monospace" font-size="72" fill="#f97316" text-anchor="middle">@</text>
+    <circle cx="44" cy="44" r="9" fill="#fff"/>
+    <circle cx="76" cy="44" r="9" fill="#fff"/>
+    <circle cx="41" cy="46" r="4" fill="#0a0a0f"/>
+    <circle cx="73" cy="46" r="4" fill="#0a0a0f"/>
+    <rect x="38" y="96" width="7" height="14" rx="3" fill="#ea580c"/>
+    <rect x="56" y="96" width="7" height="10" rx="3" fill="#ea580c"/>
+    <rect x="74" y="96" width="7" height="14" rx="3" fill="#ea580c"/>
+  </svg>`;
+}
+
+export function renderGradeDropHtml(input: GradeDropEmailInput): string {
+  const headline =
+    input.alertType === "grade_drop"
+      ? `${esc(input.domain)} dropped from <strong>${esc(input.previousValue)}</strong> to <strong>${esc(input.newValue)}</strong>`
+      : `${esc(input.domain)} regressed: <strong>${esc(input.previousValue)}</strong> → <strong>${esc(input.newValue)}</strong>`;
+
+  return `<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>dmarc.mx alert</title></head>
+<body style="margin:0;padding:0;background:#0a0a0f;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#e4e4e7">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#0a0a0f">
+    <tr><td align="center" style="padding:32px 16px">
+      <table role="presentation" width="560" cellpadding="0" cellspacing="0" border="0" style="max-width:560px;width:100%">
+        <tr><td align="center" style="padding-bottom:16px">${dmarcusWorriedSvg()}</td></tr>
+        <tr><td style="padding:24px;background:#18181b;border-radius:12px">
+          <h1 style="margin:0 0 16px;font-size:20px;line-height:1.3;color:#fafafa">${headline}</h1>
+          <p style="margin:0 0 24px;color:#a1a1aa;font-size:14px;line-height:1.5">
+            The nightly scan detected a change in your domain's email-security posture.
+            Click through to see which protocol regressed and how to fix it.
+          </p>
+          <p style="margin:0 0 16px">
+            <a href="${esc(input.dashboardUrl)}" style="display:inline-block;padding:12px 20px;background:#f97316;color:#0a0a0f;text-decoration:none;border-radius:8px;font-weight:600">Open dashboard</a>
+          </p>
+        </td></tr>
+        <tr><td style="padding:24px 8px;color:#71717a;font-size:12px;line-height:1.5">
+          You are receiving this because you have grade-drop alerts enabled.
+          <a href="${esc(input.unsubscribeUrl)}" style="color:#71717a;text-decoration:underline">Unsubscribe</a>
+        </td></tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>`;
+}

--- a/src/alerts/unsubscribe.ts
+++ b/src/alerts/unsubscribe.ts
@@ -1,0 +1,75 @@
+// One-click unsubscribe token. Signs `{user_id}` with HMAC-SHA256 keyed on
+// SESSION_SECRET (the same secret already used for session JWTs). No
+// expiration — unsubscribe links in historical emails should keep working
+// forever. Rotating SESSION_SECRET invalidates old links, which is the
+// correct behaviour if the secret ever leaks.
+
+const ENCODER = new TextEncoder();
+
+function base64UrlEncode(data: ArrayBuffer | Uint8Array): string {
+  const bytes = data instanceof ArrayBuffer ? new Uint8Array(data) : data;
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function base64UrlDecode(str: string): Uint8Array {
+  const padded = str.replace(/-/g, "+").replace(/_/g, "/");
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+async function getKey(secret: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    "raw",
+    ENCODER.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign", "verify"],
+  );
+}
+
+export async function createUnsubscribeToken(
+  userId: string,
+  secret: string,
+): Promise<string> {
+  const payload = base64UrlEncode(ENCODER.encode(userId));
+  const key = await getKey(secret);
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    ENCODER.encode(payload),
+  );
+  return `${payload}.${base64UrlEncode(signature)}`;
+}
+
+export async function validateUnsubscribeToken(
+  token: string,
+  secret: string,
+): Promise<string | null> {
+  const parts = token.split(".");
+  if (parts.length !== 2) return null;
+  const [payload, sig] = parts;
+  try {
+    const key = await getKey(secret);
+    const valid = await crypto.subtle.verify(
+      "HMAC",
+      key,
+      base64UrlDecode(sig),
+      ENCODER.encode(payload),
+    );
+    if (!valid) return null;
+    return new TextDecoder().decode(base64UrlDecode(payload));
+  } catch {
+    return null;
+  }
+}

--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -3,7 +3,7 @@ import { requireAuth } from "../auth/middleware.js";
 import type { SessionPayload } from "../auth/session.js";
 import { getDomainByUserAndName, getDomainsByUser } from "../db/domains.js";
 import { recordScan } from "../db/scans.js";
-import { getUserById, setApiKey } from "../db/users.js";
+import { getUserById, setApiKey, setEmailAlertsEnabled } from "../db/users.js";
 import { scan } from "../orchestrator.js";
 import {
   renderDashboardPage,
@@ -112,8 +112,20 @@ dashboardRoutes.get("/settings", async (c) => {
       apiKey: user.api_key,
       webhookUrl: webhook?.url ?? null,
       hasStripe: !!user.stripe_customer_id,
+      emailAlertsEnabled: user.email_alerts_enabled === 1,
     }),
   );
+});
+
+// Toggle email alert preference. Presence of a "enabled" form field means on,
+// absence means off (standard checkbox semantics from HTML forms).
+dashboardRoutes.post("/settings/email-alerts", async (c) => {
+  const session = c.get("user" as never) as SessionPayload;
+  const db = (c.env as { DB: D1Database }).DB;
+  const body = await c.req.parseBody();
+  const enabled = body.enabled === "on" || body.enabled === "1";
+  await setEmailAlertsEnabled(db, session.sub, enabled);
+  return c.redirect("/dashboard/settings");
 });
 
 // Generate/regenerate API key

--- a/src/db/migrations/0002_email_alerts.sql
+++ b/src/db/migrations/0002_email_alerts.sql
@@ -1,0 +1,6 @@
+-- Phase 2c — per-user toggle for grade-drop email alerts. Default 1 (opt-out
+-- rather than opt-in) so the feature is useful for users who signed up during
+-- Phase 1 before the setting existed. Users can flip it off via the settings
+-- page or any /alerts/unsubscribe link in a prior email.
+
+ALTER TABLE users ADD COLUMN email_alerts_enabled INTEGER NOT NULL DEFAULT 1;

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -5,6 +5,7 @@ CREATE TABLE IF NOT EXISTS users (
   email_domain TEXT NOT NULL,
   stripe_customer_id TEXT,
   api_key TEXT UNIQUE,
+  email_alerts_enabled INTEGER NOT NULL DEFAULT 1,
   created_at INTEGER NOT NULL DEFAULT (unixepoch())
 );
 

--- a/src/db/users.ts
+++ b/src/db/users.ts
@@ -4,6 +4,7 @@ export interface User {
   email_domain: string;
   stripe_customer_id: string | null;
   api_key: string | null;
+  email_alerts_enabled: number;
   created_at: number;
 }
 
@@ -53,5 +54,16 @@ export async function setApiKey(
   await db
     .prepare("UPDATE users SET api_key = ? WHERE id = ?")
     .bind(apiKey, userId)
+    .run();
+}
+
+export async function setEmailAlertsEnabled(
+  db: D1Database,
+  userId: string,
+  enabled: boolean,
+): Promise<void> {
+  await db
+    .prepare("UPDATE users SET email_alerts_enabled = ? WHERE id = ?")
+    .bind(enabled ? 1 : 0, userId)
     .run();
 }

--- a/src/env.ts
+++ b/src/env.ts
@@ -5,4 +5,7 @@ export interface Env {
   WORKOS_REDIRECT_URI: string;
   SESSION_SECRET: string;
   SENTRY_DSN?: string;
+  // Cloudflare Email Sending binding. Optional so self-host deploys without
+  // a verified sender still boot; the dispatcher no-ops when absent.
+  EMAIL?: SendEmail;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ import * as Sentry from "@sentry/cloudflare";
 import { type Context, Hono } from "hono";
 import { cors } from "hono/cors";
 import { streamSSE } from "hono/streaming";
+import { dispatchPendingAlerts } from "./alerts/dispatcher.js";
+import { validateUnsubscribeToken } from "./alerts/unsubscribe.js";
 import type {
   BimiResult,
   DkimResult,
@@ -18,6 +20,7 @@ import { getCachedScan, setCachedScan } from "./cache.js";
 import { runDueRescans } from "./cron/rescan.js";
 import { generateCsv } from "./csv.js";
 import { dashboardRoutes } from "./dashboard/routes.js";
+import { setEmailAlertsEnabled } from "./db/users.js";
 import type { Env } from "./env.js";
 import type { ProtocolId, ProtocolResult } from "./orchestrator.js";
 import { scan, scanStreaming } from "./orchestrator.js";
@@ -925,21 +928,46 @@ async function scheduled(
   ctx: ExecutionContext,
 ): Promise<void> {
   if (!env.DB) return;
-  const work = runDueRescans({
-    db: env.DB,
-    now: Math.floor(Date.now() / 1000),
-  })
-    .then((result) => {
-      const scope = Sentry.getCurrentScope();
-      scope.setTag("cron.scanned", String(result.scanned));
-      scope.setTag("cron.alerts", String(result.alerts));
-      scope.setTag("cron.errors", String(result.errors));
-    })
-    .catch((err) => {
-      Sentry.captureException(err);
+  const work = (async () => {
+    const rescanResult = await runDueRescans({
+      db: env.DB,
+      now: Math.floor(Date.now() / 1000),
     });
+    const scope = Sentry.getCurrentScope();
+    scope.setTag("cron.scanned", String(rescanResult.scanned));
+    scope.setTag("cron.alerts", String(rescanResult.alerts));
+    scope.setTag("cron.errors", String(rescanResult.errors));
+
+    // Dispatch runs unconditionally — alerts from prior cron runs may still
+    // be pending if the EMAIL binding was absent or failed previously.
+    const dispatchResult = await dispatchPendingAlerts(env);
+    scope.setTag("cron.emails_sent", String(dispatchResult.sent));
+    scope.setTag("cron.emails_skipped", String(dispatchResult.skipped));
+    scope.setTag("cron.emails_errors", String(dispatchResult.errors));
+  })().catch((err) => {
+    Sentry.captureException(err);
+  });
   ctx.waitUntil(work);
 }
+
+// Public unsubscribe endpoint reached from email links. The token is the
+// authentication — no session cookie required. Invalid / tampered tokens
+// return a 400. Successful unsubscribe flips users.email_alerts_enabled to 0
+// and renders a confirmation page.
+app.get("/alerts/unsubscribe", async (c) => {
+  const token = c.req.query("token");
+  if (!token) {
+    return c.html(renderError("Missing unsubscribe token."), 400);
+  }
+  const userId = await validateUnsubscribeToken(token, c.env.SESSION_SECRET);
+  if (!userId) {
+    return c.html(renderError("Invalid or expired unsubscribe link."), 400);
+  }
+  await setEmailAlertsEnabled(c.env.DB, userId, false);
+  return c.html(
+    `<!doctype html><html><head><meta charset="utf-8"><title>Unsubscribed</title></head><body style="font-family:system-ui;padding:32px;max-width:520px;margin:0 auto;line-height:1.5"><h1>Unsubscribed</h1><p>You will no longer receive grade-drop alerts from dmarc.mx.</p><p>You can re-enable alerts any time from <a href="/dashboard/settings">dashboard settings</a>.</p></body></html>`,
+  );
+});
 
 const handler: ExportedHandler<Env> = {
   fetch: app.fetch.bind(app),

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -449,11 +449,13 @@ export function renderSettingsPage({
   apiKey,
   webhookUrl,
   hasStripe,
+  emailAlertsEnabled,
 }: {
   email: string;
   apiKey: string | null;
   webhookUrl: string | null;
   hasStripe: boolean;
+  emailAlertsEnabled: boolean;
 }): string {
   const apiKeySection = apiKey
     ? `<div class="api-key-display">${esc(apiKey)}</div>
@@ -495,6 +497,20 @@ export function renderSettingsPage({
       value="${webhookUrl ? esc(webhookUrl) : ""}"
     >
     <button type="submit" class="btn">Save Webhook</button>
+  </form>
+</div>
+
+<div class="settings-section">
+  <h2>Email Alerts</h2>
+  <p style="font-size:0.875rem;color:var(--clr-text-muted);margin-bottom:0.75rem">
+    We email you when a monitored domain's grade drops or a protocol regresses.
+  </p>
+  <form method="POST" action="/dashboard/settings/email-alerts">
+    <label style="display:flex;align-items:center;gap:0.5rem;margin-bottom:0.75rem">
+      <input type="checkbox" name="enabled" ${emailAlertsEnabled ? "checked" : ""}>
+      <span>Send me grade-drop alerts by email</span>
+    </label>
+    <button type="submit" class="btn btn-secondary">Save Preference</button>
   </form>
 </div>
 

--- a/test/alert-dispatcher.test.ts
+++ b/test/alert-dispatcher.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { dispatchPendingAlerts } from "../src/alerts/dispatcher.js";
+import type { Env } from "../src/env.js";
+
+interface AlertRow {
+  id: number;
+  domain_id: number;
+  user_id: string;
+  domain: string;
+  alert_type: string;
+  previous_value: string | null;
+  new_value: string | null;
+  notified_via: string | null;
+  created_at: number;
+}
+
+interface UserRow {
+  id: string;
+  email: string;
+  email_domain: string;
+  stripe_customer_id: string | null;
+  api_key: string | null;
+  email_alerts_enabled: number;
+  created_at: number;
+}
+
+let alerts: Map<number, AlertRow>;
+let users: Map<string, UserRow>;
+
+function makeD1Mock(): D1Database {
+  const prepare = (sql: string) => ({
+    bind: (...params: unknown[]) => ({
+      first: async <T>() => {
+        if (sql.includes("SELECT * FROM users WHERE id")) {
+          const [id] = params as [string];
+          return (users.get(id) ?? null) as T | null;
+        }
+        return null as T | null;
+      },
+      all: async <T>(): Promise<{ results: T[] }> => {
+        if (/FROM alerts[\s\S]*JOIN domains/i.test(sql)) {
+          const [limit] = params as [number];
+          const rows = [...alerts.values()]
+            .filter((a) => a.notified_via === null)
+            .sort((a, b) => a.created_at - b.created_at)
+            .slice(0, limit);
+          return { results: rows as T[] };
+        }
+        return { results: [] };
+      },
+      run: async () => {
+        if (/^UPDATE alerts SET notified_via/i.test(sql)) {
+          const [channel, id] = params as [string, number];
+          const row = alerts.get(id);
+          if (row) alerts.set(id, { ...row, notified_via: channel });
+        }
+        return { success: true };
+      },
+    }),
+  });
+  return { prepare } as unknown as D1Database;
+}
+
+function makeEnv(opts: {
+  hasEmailBinding?: boolean;
+  sendImpl?: SendEmail["send"];
+}): Env {
+  const email: SendEmail | undefined = opts.hasEmailBinding
+    ? ({
+        send:
+          opts.sendImpl ??
+          vi.fn().mockResolvedValue({ messageId: "msg-fake-1" }),
+      } as SendEmail)
+    : undefined;
+  return {
+    DB: makeD1Mock(),
+    WORKOS_CLIENT_ID: "",
+    WORKOS_CLIENT_SECRET: "",
+    WORKOS_REDIRECT_URI: "",
+    SESSION_SECRET: "test-secret",
+    EMAIL: email,
+  };
+}
+
+function seedAlert(id: number, overrides: Partial<AlertRow> = {}): void {
+  alerts.set(id, {
+    id,
+    domain_id: 1,
+    user_id: "user_1",
+    domain: "example.com",
+    alert_type: "grade_drop",
+    previous_value: "A",
+    new_value: "C",
+    notified_via: null,
+    created_at: 1_700_000_000 + id,
+    ...overrides,
+  });
+}
+
+function seedUser(overrides: Partial<UserRow> = {}): void {
+  const id = overrides.id ?? "user_1";
+  users.set(id, {
+    id,
+    email: "alice@example.com",
+    email_domain: "example.com",
+    stripe_customer_id: null,
+    api_key: null,
+    email_alerts_enabled: 1,
+    created_at: 1,
+    ...overrides,
+  });
+}
+
+describe("alerts/dispatchPendingAlerts", () => {
+  beforeEach(() => {
+    alerts = new Map();
+    users = new Map();
+  });
+
+  it("no-ops when there are no unsent alerts", async () => {
+    const env = makeEnv({ hasEmailBinding: true });
+    const result = await dispatchPendingAlerts(env);
+    expect(result).toEqual({ considered: 0, sent: 0, skipped: 0, errors: 0 });
+  });
+
+  it("sends an email and marks the alert notified_via='email'", async () => {
+    seedAlert(1);
+    seedUser();
+    const sendMock = vi.fn().mockResolvedValue({ messageId: "msg-1" });
+    const env = makeEnv({ hasEmailBinding: true, sendImpl: sendMock });
+
+    const result = await dispatchPendingAlerts(env);
+
+    expect(result.sent).toBe(1);
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    const call = sendMock.mock.calls[0][0];
+    expect(call.to).toBe("alice@example.com");
+    expect(call.from).toBe("alerts@dmarc.mx");
+    expect(call.subject).toContain("example.com");
+    expect(call.html).toContain("example.com");
+    expect(alerts.get(1)?.notified_via).toBe("email");
+  });
+
+  it("is idempotent — a second dispatch with no new alerts does nothing", async () => {
+    seedAlert(1);
+    seedUser();
+    const sendMock = vi.fn().mockResolvedValue({ messageId: "m" });
+    const env = makeEnv({ hasEmailBinding: true, sendImpl: sendMock });
+
+    await dispatchPendingAlerts(env);
+    sendMock.mockClear();
+    const result = await dispatchPendingAlerts(env);
+
+    expect(result.considered).toBe(0);
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("skips users who opted out and marks the alert 'skipped:opt_out'", async () => {
+    seedAlert(1);
+    seedUser({ email_alerts_enabled: 0 });
+    const sendMock = vi.fn();
+    const env = makeEnv({ hasEmailBinding: true, sendImpl: sendMock });
+
+    const result = await dispatchPendingAlerts(env);
+
+    expect(result.sent).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(sendMock).not.toHaveBeenCalled();
+    expect(alerts.get(1)?.notified_via).toBe("skipped:opt_out");
+  });
+
+  it("skips orphaned alerts (user deleted) without crashing", async () => {
+    seedAlert(1, { user_id: "ghost" });
+    const env = makeEnv({ hasEmailBinding: true });
+
+    const result = await dispatchPendingAlerts(env);
+
+    expect(result.skipped).toBe(1);
+    expect(alerts.get(1)?.notified_via).toBe("skipped:no_user");
+  });
+
+  it("leaves alerts unsent when the EMAIL binding is missing", async () => {
+    seedAlert(1);
+    seedUser();
+    const env = makeEnv({ hasEmailBinding: false });
+
+    const result = await dispatchPendingAlerts(env);
+
+    expect(result.skipped).toBe(1);
+    expect(result.sent).toBe(0);
+    // Row NOT marked — so a later run (once the binding is configured) can
+    // retry delivery.
+    expect(alerts.get(1)?.notified_via).toBeNull();
+  });
+
+  it("counts send failures as errors and leaves the alert unsent for retry", async () => {
+    seedAlert(1);
+    seedUser();
+    const sendMock = vi.fn().mockRejectedValue(new Error("E_RATE_LIMIT"));
+    const env = makeEnv({ hasEmailBinding: true, sendImpl: sendMock });
+
+    const result = await dispatchPendingAlerts(env);
+
+    expect(result.errors).toBe(1);
+    expect(result.sent).toBe(0);
+    expect(alerts.get(1)?.notified_via).toBeNull();
+  });
+
+  it("includes a signed unsubscribe link in the sent email", async () => {
+    seedAlert(1);
+    seedUser();
+    const sendMock = vi.fn().mockResolvedValue({ messageId: "m" });
+    const env = makeEnv({ hasEmailBinding: true, sendImpl: sendMock });
+
+    await dispatchPendingAlerts(env);
+
+    const call = sendMock.mock.calls[0][0];
+    expect(call.text).toMatch(/\/alerts\/unsubscribe\?token=[\w.-]+/);
+    expect(call.html).toMatch(/\/alerts\/unsubscribe\?token=[\w.-]+/);
+  });
+});

--- a/test/alerts-unsubscribe.test.ts
+++ b/test/alerts-unsubscribe.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  createUnsubscribeToken,
+  validateUnsubscribeToken,
+} from "../src/alerts/unsubscribe.js";
+
+const SECRET = "test-unsub-secret";
+
+describe("alerts/unsubscribe", () => {
+  it("round-trips a user id", async () => {
+    const token = await createUnsubscribeToken("user_1", SECRET);
+    expect(await validateUnsubscribeToken(token, SECRET)).toBe("user_1");
+  });
+
+  it("rejects a token signed with a different secret", async () => {
+    const token = await createUnsubscribeToken("user_1", SECRET);
+    expect(await validateUnsubscribeToken(token, "other-secret")).toBeNull();
+  });
+
+  it("rejects a token with tampered payload", async () => {
+    const token = await createUnsubscribeToken("user_1", SECRET);
+    const [, sig] = token.split(".");
+    const tamperedPayload = btoa("attacker")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    const tampered = `${tamperedPayload}.${sig}`;
+    expect(await validateUnsubscribeToken(tampered, SECRET)).toBeNull();
+  });
+
+  it("rejects malformed tokens", async () => {
+    expect(await validateUnsubscribeToken("", SECRET)).toBeNull();
+    expect(await validateUnsubscribeToken("abc", SECRET)).toBeNull();
+    expect(await validateUnsubscribeToken("a.b.c", SECRET)).toBeNull();
+    expect(await validateUnsubscribeToken("!!!.???", SECRET)).toBeNull();
+  });
+
+  it("handles user ids containing unicode and punctuation", async () => {
+    const id = "user_ñ&=/@";
+    const token = await createUnsubscribeToken(id, SECRET);
+    expect(await validateUnsubscribeToken(token, SECRET)).toBe(id);
+  });
+});

--- a/test/dashboard-routes.test.ts
+++ b/test/dashboard-routes.test.ts
@@ -502,6 +502,63 @@ describe("dashboard/routes", () => {
     });
   });
 
+  describe("POST /dashboard/settings/email-alerts", () => {
+    it("redirects to /auth/login without a session cookie", async () => {
+      const db = createMockDB({});
+      const app = createTestApp(db);
+      const res = await app.request("/dashboard/settings/email-alerts", {
+        method: "POST",
+      });
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/auth/login");
+    });
+
+    it("flips email_alerts_enabled to 0 when checkbox is unchecked", async () => {
+      const writes: Array<{ sql: string; bindings: unknown[] }> = [];
+      const db = createMockDB({ writes });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+
+      const res = await app.request("/dashboard/settings/email-alerts", {
+        method: "POST",
+        headers: {
+          Cookie: cookie,
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: "",
+      });
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/dashboard/settings");
+      const update = writes.find((w) =>
+        w.sql.includes("UPDATE users SET email_alerts_enabled"),
+      );
+      expect(update?.bindings[0]).toBe(0);
+    });
+
+    it("flips email_alerts_enabled to 1 when checkbox is checked", async () => {
+      const writes: Array<{ sql: string; bindings: unknown[] }> = [];
+      const db = createMockDB({ writes });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+
+      const res = await app.request("/dashboard/settings/email-alerts", {
+        method: "POST",
+        headers: {
+          Cookie: cookie,
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: "enabled=on",
+      });
+
+      expect(res.status).toBe(302);
+      const update = writes.find((w) =>
+        w.sql.includes("UPDATE users SET email_alerts_enabled"),
+      );
+      expect(update?.bindings[0]).toBe(1);
+    });
+  });
+
   describe("POST /dashboard/settings/webhook", () => {
     it("redirects to /auth/login without a session cookie", async () => {
       const db = createMockDB({});

--- a/test/dashboard-views.test.ts
+++ b/test/dashboard-views.test.ts
@@ -191,6 +191,7 @@ describe("renderSettingsPage", () => {
       apiKey: null,
       webhookUrl: null,
       hasStripe: false,
+      emailAlertsEnabled: true,
     });
     expect(html).toContain("Generate API Key");
     expect(html).not.toContain("Regenerate");
@@ -202,6 +203,7 @@ describe("renderSettingsPage", () => {
       apiKey: "dmx_abc123secret",
       webhookUrl: null,
       hasStripe: false,
+      emailAlertsEnabled: true,
     });
     expect(html).toContain("dmx_abc123secret");
     expect(html).toContain("Regenerate");
@@ -213,6 +215,7 @@ describe("renderSettingsPage", () => {
       apiKey: null,
       webhookUrl: null,
       hasStripe: false,
+      emailAlertsEnabled: true,
     });
     expect(html).toContain("admin@example.com");
     expect(html).toContain("Account");
@@ -224,6 +227,7 @@ describe("renderSettingsPage", () => {
       apiKey: null,
       webhookUrl: "https://hooks.example.com/dmarc",
       hasStripe: false,
+      emailAlertsEnabled: true,
     });
     expect(html).toContain("https://hooks.example.com/dmarc");
     expect(html).toContain("Webhook");
@@ -235,6 +239,7 @@ describe("renderSettingsPage", () => {
       apiKey: null,
       webhookUrl: null,
       hasStripe: true,
+      emailAlertsEnabled: true,
     });
     expect(html).toContain("Manage Billing");
   });
@@ -245,6 +250,7 @@ describe("renderSettingsPage", () => {
       apiKey: null,
       webhookUrl: null,
       hasStripe: false,
+      emailAlertsEnabled: true,
     });
     expect(html).toContain("no active subscription");
     expect(html).toContain("Upgrade");
@@ -256,10 +262,36 @@ describe("renderSettingsPage", () => {
       apiKey: "<script>alert(1)</script>",
       webhookUrl: null,
       hasStripe: false,
+      emailAlertsEnabled: true,
     });
     // The escaped form must appear; raw user content must not be injected as HTML
     expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
     // The api-key-display div must contain escaped content
     expect(html).toContain('class="api-key-display">&lt;script&gt;');
+  });
+
+  it("renders the email-alerts section with the checkbox checked when enabled", () => {
+    const html = renderSettingsPage({
+      email: "user@example.com",
+      apiKey: null,
+      webhookUrl: null,
+      hasStripe: false,
+      emailAlertsEnabled: true,
+    });
+    expect(html).toContain("Email Alerts");
+    expect(html).toContain('name="enabled" checked');
+    expect(html).toContain("/dashboard/settings/email-alerts");
+  });
+
+  it("renders the checkbox unchecked when email alerts are disabled", () => {
+    const html = renderSettingsPage({
+      email: "user@example.com",
+      apiKey: null,
+      webhookUrl: null,
+      hasStripe: false,
+      emailAlertsEnabled: false,
+    });
+    expect(html).toContain('name="enabled" >');
+    expect(html).not.toContain('name="enabled" checked');
   });
 });

--- a/test/unsubscribe-route.test.ts
+++ b/test/unsubscribe-route.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import { createUnsubscribeToken } from "../src/alerts/unsubscribe.js";
+
+vi.mock("../src/cache.js", () => ({
+  getCachedScan: vi.fn().mockResolvedValue(null),
+  setCachedScan: vi.fn(),
+}));
+vi.mock("../src/dns/client.js", () => ({
+  queryTxt: vi.fn().mockResolvedValue(null),
+  queryMx: vi.fn().mockResolvedValue(null),
+}));
+
+const { app } = await import("../src/index.js");
+
+const SECRET = "test-unsub-route-secret";
+
+function makeEnv(opts: {
+  userId: string;
+  captureUpdate?: (bindings: unknown[]) => void;
+}): { SESSION_SECRET: string; DB: D1Database } {
+  const db = {
+    prepare: () => ({
+      bind: (...params: unknown[]) => ({
+        run: async () => {
+          opts.captureUpdate?.(params);
+          return { success: true };
+        },
+      }),
+    }),
+  } as unknown as D1Database;
+  return { SESSION_SECRET: SECRET, DB: db };
+}
+
+describe("GET /alerts/unsubscribe", () => {
+  it("returns 400 when token is missing", async () => {
+    const env = makeEnv({ userId: "user_1" });
+    const res = await app.request("/alerts/unsubscribe", {}, env);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for an invalid/tampered token", async () => {
+    const env = makeEnv({ userId: "user_1" });
+    const res = await app.request(
+      "/alerts/unsubscribe?token=not-a-real-token",
+      {},
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when the token was signed with a different secret", async () => {
+    const token = await createUnsubscribeToken("user_1", "other-secret");
+    const env = makeEnv({ userId: "user_1" });
+    const res = await app.request(
+      `/alerts/unsubscribe?token=${token}`,
+      {},
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("flips email_alerts_enabled = 0 for a valid token and confirms", async () => {
+    const token = await createUnsubscribeToken("user_42", SECRET);
+    let captured: unknown[] | null = null;
+    const env = makeEnv({
+      userId: "user_42",
+      captureUpdate: (bindings) => {
+        captured = bindings;
+      },
+    });
+
+    const res = await app.request(
+      `/alerts/unsubscribe?token=${token}`,
+      {},
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    expect(captured).toEqual([0, "user_42"]);
+    const html = await res.text();
+    expect(html).toContain("Unsubscribed");
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -20,3 +20,10 @@ crons = ["17 6 * * *"]
 binding = "DB"
 database_name = "dmarcheck-db"
 database_id = "7e6e7e64-5477-458f-b206-941ea58b7dba"
+
+# Cloudflare Email Sending for grade-drop alerts. alerts@dmarc.mx must be a
+# verified sender in the Cloudflare dashboard before this binding delivers
+# mail; the dispatcher catches E_SENDER_NOT_VERIFIED and skips gracefully.
+[[send_email]]
+name = "EMAIL"
+allowed_sender_addresses = ["alerts@dmarc.mx"]


### PR DESCRIPTION
## Summary
Delivers the alerts Phase 2b ([#142](https://github.com/schmug/dmarcheck/pull/142), merged) wrote into the DB as real email over the Cloudflare Email Sending binding. Closes out Phase 2 of the freemium spec — **monitoring (2a), detection (2b), and delivery (2c) are all live**.

### New modules
- `src/alerts/templates.ts` — subject / text / HTML email bodies. Inline CSS only; a compact DMarcus "worried" SVG carries the brand (animated variants do not survive most email clients).
- `src/alerts/email.ts` — `sendGradeDropEmail()` wraps `env.EMAIL.send()` and swallows `E_SENDER_NOT_VERIFIED` / `E_RATE_LIMIT_EXCEEDED` / network errors into a structured `SendOutcome` so the dispatcher loop can keep going.
- `src/alerts/dispatcher.ts` — `dispatchPendingAlerts()` walks unsent alerts, respects `users.email_alerts_enabled`, sends, and stamps `alerts.notified_via = 'email'` on success (or `skipped:opt_out` / `skipped:no_user` to prevent re-examination). Leaves the row unsent on `send_error` or `no_binding` so retries are possible.
- `src/alerts/unsubscribe.ts` — HS256-signed one-click tokens over the user id, keyed on `SESSION_SECRET`. No expiration — historical email links keep working until the secret rotates.

### Schema + binding
- `users.email_alerts_enabled INTEGER NOT NULL DEFAULT 1` (opt-out, not opt-in — Phase 1 users get value immediately).
- `src/db/migrations/0002_email_alerts.sql` holds the ALTER for prod.
- `wrangler.toml` gets `[[send_email]] name = "EMAIL"` with `allowed_sender_addresses = ["alerts@dmarc.mx"]`. **One-time manual step**: verify `alerts@dmarc.mx` as a sender in the Cloudflare dashboard before delivery works.
- `src/env.ts` — `EMAIL` is optional (`SendEmail | undefined`) so self-host deploys without a verified sender still boot.

### Wiring
- `src/index.ts` `scheduled()` now runs `dispatchPendingAlerts` after `runDueRescans`. Tags `cron.emails_{sent,skipped,errors}` on the Sentry scope.
- `GET /alerts/unsubscribe` is mounted publicly; the token is the auth, so inboxes can one-click. 400 on missing / tampered / wrong-secret tokens; 200 with a confirmation page on success.
- Dashboard `/settings` gains an email-alerts checkbox that POSTs to `/dashboard/settings/email-alerts`. Absence = off, `enabled=on` = on.

## Self-host safety
- Missing `EMAIL` binding → dispatcher logs `no_binding`, skips, leaves rows unsent for retry.
- Unverified sender → `sendGradeDropEmail` catches `E_SENDER_NOT_VERIFIED` from the binding and returns `send_error`. Alerts remain unsent and retry next cron.
- Missing `DB` → `scheduled()` already returns early (unchanged from 2b). Public `/check` is untouched.

## Operational checklist (before merging to prod)
- [ ] Verify `alerts@dmarc.mx` as a sender in the Cloudflare Email Sending dashboard
- [ ] Publish SPF / DKIM records per the Cloudflare verification wizard (dogfood moment: scan `dmarc.mx` after setup)
- [ ] Apply `src/db/migrations/0002_email_alerts.sql` to the prod D1 (`dmarcheck-db`)

## Follow-up (Phase 3, separate PR)
Stripe Checkout + customer portal + `$3/domain/month` billing. Webhook alerts (paid) on top of the existing `webhooks` table. API-key hashing per HANDOFF §M3.

## Test plan
- [x] `npm test` — 475/475 green (21 new this PR)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [ ] Staging: after DNS + sender verification are in place, seed a grade-drop (UPDATE `domains.last_grade = 'A'` + clear `last_scanned_at`), wait for 06:17 UTC cron, confirm exactly one email arrives, confirm `alerts.notified_via = 'email'`, click the unsubscribe link, confirm `users.email_alerts_enabled` flips to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)