### PR TITLE
Phase 3b: Stripe Checkout + Portal + webhook handler

### DIFF
--- a/src/billing/routes.ts
+++ b/src/billing/routes.ts
@@ -1,0 +1,160 @@
+import { Hono } from "hono";
+import { requireAuth } from "../auth/middleware.js";
+import type { SessionPayload } from "../auth/session.js";
+import {
+  recordStripeEventOnce,
+  upsertSubscription,
+} from "../db/subscriptions.js";
+import {
+  getUserById,
+  getUserByStripeCustomerId,
+  setStripeCustomerId,
+} from "../db/users.js";
+import type { Env } from "../env.js";
+import { isBillingEnabled } from "./feature-flag.js";
+import {
+  constructWebhookEvent,
+  createCheckoutSession,
+  createPortalSession,
+  createStripeCustomer,
+  StripeSignatureError,
+  type StripeSubscriptionEvent,
+} from "./stripe.js";
+
+// Authed billing routes — mounted under /dashboard/billing by src/index.ts.
+// All handlers assume requireAuth has already attached a SessionPayload and
+// that isBillingEnabled(env) is true at mount time.
+export const dashboardBillingRoutes = new Hono();
+
+dashboardBillingRoutes.use("*", requireAuth);
+
+// GET /dashboard/billing/subscribe — starts the upgrade flow. Creates a Stripe
+// Customer on first click (lazy so free users never touch Stripe), then a
+// Checkout Session, then 303-redirects to Stripe's hosted checkout page.
+dashboardBillingRoutes.get("/subscribe", async (c) => {
+  const env = c.env as Env;
+  if (!isBillingEnabled(env)) {
+    return c.text("Billing not configured", 404);
+  }
+  const session = c.get("user" as never) as SessionPayload;
+  const db = env.DB;
+  const user = await getUserById(db, session.sub);
+  if (!user) {
+    return c.redirect("/auth/logout");
+  }
+
+  let customerId = user.stripe_customer_id;
+  if (!customerId) {
+    customerId = await createStripeCustomer(env, {
+      userId: user.id,
+      email: user.email,
+    });
+    await setStripeCustomerId(db, user.id, customerId);
+  }
+
+  const origin = new URL(c.req.url).origin;
+  const checkout = await createCheckoutSession(env, {
+    customerId,
+    userId: user.id,
+    successUrl: `${origin}/dashboard/settings?upgraded=1`,
+    cancelUrl: `${origin}/dashboard/settings?upgrade_cancelled=1`,
+  });
+  return c.redirect(checkout.url, 303);
+});
+
+// GET /dashboard/billing/portal — Stripe Customer Portal for managing
+// subscription, payment method, invoices, cancellation.
+dashboardBillingRoutes.get("/portal", async (c) => {
+  const env = c.env as Env;
+  if (!isBillingEnabled(env)) {
+    return c.text("Billing not configured", 404);
+  }
+  const session = c.get("user" as never) as SessionPayload;
+  const db = env.DB;
+  const user = await getUserById(db, session.sub);
+  if (!user?.stripe_customer_id) {
+    return c.redirect("/dashboard/settings");
+  }
+
+  const origin = new URL(c.req.url).origin;
+  const portal = await createPortalSession(env, {
+    customerId: user.stripe_customer_id,
+    returnUrl: `${origin}/dashboard/settings`,
+  });
+  return c.redirect(portal.url, 303);
+});
+
+// Public webhook route. Mounted at /webhooks/stripe by src/index.ts. Not
+// authed (obviously) — signature verification is the auth. No CORS.
+export const stripeWebhookRoutes = new Hono();
+
+stripeWebhookRoutes.post("/stripe", async (c) => {
+  const env = c.env as Env;
+  if (!isBillingEnabled(env)) {
+    return c.text("Billing not configured", 404);
+  }
+
+  // MUST read raw body before anything else parses it — the signature is
+  // over the exact byte sequence Stripe sent.
+  const rawBody = await c.req.text();
+  const sigHeader = c.req.header("stripe-signature") ?? null;
+
+  let event: StripeSubscriptionEvent;
+  try {
+    event = await constructWebhookEvent(
+      rawBody,
+      sigHeader,
+      env.STRIPE_WEBHOOK_SECRET,
+    );
+  } catch (err) {
+    if (err instanceof StripeSignatureError) {
+      return c.text("Invalid signature", 400);
+    }
+    throw err;
+  }
+
+  // Idempotency guard — Stripe retries delivery for up to 3 days on 5xx or
+  // network error. Reject replays of an event id we've already handled.
+  const db = env.DB;
+  const fresh = await recordStripeEventOnce(db, event.id);
+  if (!fresh) {
+    return c.json({ received: true, replay: true });
+  }
+
+  if (
+    event.type === "customer.subscription.created" ||
+    event.type === "customer.subscription.updated" ||
+    event.type === "customer.subscription.deleted"
+  ) {
+    const sub = event.data.object;
+    const user = await getUserByStripeCustomerId(db, sub.customer);
+    if (!user) {
+      // Probably a misrouted event from the shared donthype-me Stripe
+      // account, or a customer created outside dmarcheck's flow. Log once
+      // via Sentry (caller's onError) by rethrowing? No — safer to 200
+      // so Stripe stops retrying, but surface via a minimal log.
+      console.warn(
+        `[stripe webhook] no dmarcheck user for customer ${sub.customer} (event ${event.id})`,
+      );
+      return c.json({ received: true, ignored: "unknown_customer" });
+    }
+
+    const priceId = sub.items?.data?.[0]?.price?.id ?? "";
+    // For `customer.subscription.deleted`, Stripe still sends status (usually
+    // "canceled"); upserting with that status is exactly what we want —
+    // getPlanForUser will drop the user to "free" next request.
+    await upsertSubscription(db, {
+      user_id: user.id,
+      stripe_subscription_id: sub.id,
+      stripe_price_id: priceId,
+      status: sub.status,
+      current_period_end: sub.current_period_end ?? null,
+      cancel_at_period_end: sub.cancel_at_period_end === true,
+    });
+  }
+  // All other event types are accepted but not acted on. Returning 2xx stops
+  // Stripe from retrying them; we'd rather silently ignore unknown types
+  // than error the delivery pipeline.
+
+  return c.json({ received: true });
+});

--- a/src/billing/stripe.ts
+++ b/src/billing/stripe.ts
@@ -127,8 +127,7 @@ function constantTimeEqualHex(a: string, b: string): boolean {
   return diff === 0;
 }
 
-// Thin POST helper for future Checkout / Portal calls (PR 2 wires these up).
-// Exported now so PR 2 is additive, not a rewrite.
+// Thin POST helper for Checkout / Portal / Customer calls.
 export async function stripeRequest<T>(
   env: BillingEnv,
   path: string,
@@ -149,4 +148,69 @@ export async function stripeRequest<T>(
     throw new Error(`Stripe API ${res.status}: ${err?.message ?? "unknown"}`);
   }
   return json as T;
+}
+
+interface StripeCustomer {
+  id: string;
+}
+
+// Creates a Stripe Customer for a dmarcheck user. We do this lazily on the
+// first upgrade click rather than at signup so free users never hit Stripe.
+// Email is set so it appears in the Stripe dashboard; metadata.user_id lets
+// the webhook handler resolve a Stripe event back to our user row.
+export async function createStripeCustomer(
+  env: BillingEnv,
+  input: { userId: string; email: string },
+): Promise<string> {
+  const customer = await stripeRequest<StripeCustomer>(env, "/customers", {
+    email: input.email,
+    "metadata[user_id]": input.userId,
+  });
+  return customer.id;
+}
+
+interface StripeCheckoutSession {
+  id: string;
+  url: string;
+}
+
+// Creates a Checkout Session in `subscription` mode for the Pro plan. The
+// returned `url` is the hosted Checkout page we redirect the user to.
+export async function createCheckoutSession(
+  env: BillingEnv,
+  input: {
+    customerId: string;
+    successUrl: string;
+    cancelUrl: string;
+    userId: string;
+  },
+): Promise<StripeCheckoutSession> {
+  return stripeRequest<StripeCheckoutSession>(env, "/checkout/sessions", {
+    mode: "subscription",
+    customer: input.customerId,
+    "line_items[0][price]": env.STRIPE_PRICE_ID_PRO,
+    "line_items[0][quantity]": "1",
+    success_url: input.successUrl,
+    cancel_url: input.cancelUrl,
+    // Stripe copies this onto the created subscription; lets the webhook
+    // handler cross-check the user_id matches the customer lookup.
+    "subscription_data[metadata][user_id]": input.userId,
+  });
+}
+
+interface StripePortalSession {
+  id: string;
+  url: string;
+}
+
+// Creates a Customer Portal session. Users manage cancel / payment method /
+// invoice history here — dmarcheck doesn't need to build any of that.
+export async function createPortalSession(
+  env: BillingEnv,
+  input: { customerId: string; returnUrl: string },
+): Promise<StripePortalSession> {
+  return stripeRequest<StripePortalSession>(env, "/billing_portal/sessions", {
+    customer: input.customerId,
+    return_url: input.returnUrl,
+  });
 }

--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -1,8 +1,10 @@
 import { Hono } from "hono";
 import { requireAuth } from "../auth/middleware.js";
 import type { SessionPayload } from "../auth/session.js";
+import { dashboardBillingRoutes } from "../billing/routes.js";
 import { getDomainByUserAndName, getDomainsByUser } from "../db/domains.js";
 import { recordScan } from "../db/scans.js";
+import { getPlanForUser } from "../db/subscriptions.js";
 import { getUserById, setApiKey, setEmailAlertsEnabled } from "../db/users.js";
 import { scan } from "../orchestrator.js";
 import {
@@ -15,6 +17,10 @@ export const dashboardRoutes = new Hono();
 
 // All dashboard routes require auth
 dashboardRoutes.use("*", requireAuth);
+
+// Billing sub-routes (upgrade / portal). Self-gates on isBillingEnabled so a
+// self-host deploy without Stripe env vars still 404s these cleanly.
+dashboardRoutes.route("/billing", dashboardBillingRoutes);
 
 // Domain list
 dashboardRoutes.get("/", async (c) => {
@@ -106,12 +112,15 @@ dashboardRoutes.get("/settings", async (c) => {
     .prepare("SELECT url FROM webhooks WHERE user_id = ?")
     .bind(session.sub)
     .first<{ url: string }>();
+  const plan = await getPlanForUser(db, session.sub);
+  const env = c.env as { STRIPE_SECRET_KEY?: string };
   return c.html(
     renderSettingsPage({
       email: user.email,
       apiKey: user.api_key,
       webhookUrl: webhook?.url ?? null,
-      hasStripe: !!user.stripe_customer_id,
+      plan,
+      billingEnabled: Boolean(env.STRIPE_SECRET_KEY),
       emailAlertsEnabled: user.email_alerts_enabled === 1,
     }),
   );

--- a/src/db/users.ts
+++ b/src/db/users.ts
@@ -57,6 +57,27 @@ export async function setApiKey(
     .run();
 }
 
+export async function getUserByStripeCustomerId(
+  db: D1Database,
+  stripeCustomerId: string,
+): Promise<User | null> {
+  return db
+    .prepare("SELECT * FROM users WHERE stripe_customer_id = ?")
+    .bind(stripeCustomerId)
+    .first<User>();
+}
+
+export async function setStripeCustomerId(
+  db: D1Database,
+  userId: string,
+  stripeCustomerId: string,
+): Promise<void> {
+  await db
+    .prepare("UPDATE users SET stripe_customer_id = ? WHERE id = ?")
+    .bind(stripeCustomerId, userId)
+    .run();
+}
+
 export async function setEmailAlertsEnabled(
   db: D1Database,
   userId: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import type {
 import { API_CATALOG_JSON } from "./api/catalog.js";
 import { OPENAPI_JSON } from "./api/openapi.js";
 import { authRoutes } from "./auth/routes.js";
+import { stripeWebhookRoutes } from "./billing/routes.js";
 import { getCachedScan, setCachedScan } from "./cache.js";
 import { runDueRescans } from "./cron/rescan.js";
 import { generateCsv } from "./csv.js";
@@ -198,6 +199,10 @@ app.route("/auth", authRoutes);
 
 // Dashboard routes (auth enforced inside dashboardRoutes via requireAuth)
 app.route("/dashboard", dashboardRoutes);
+
+// Stripe webhook (public — signature-verified). Self-gates on
+// isBillingEnabled so self-host deploys without Stripe env still boot.
+app.route("/webhooks", stripeWebhookRoutes);
 
 function markdownResponse(c: Context, body: string, status = 200) {
   return c.body(body, status as 200, {

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -448,13 +448,15 @@ export function renderSettingsPage({
   email,
   apiKey,
   webhookUrl,
-  hasStripe,
+  plan,
+  billingEnabled,
   emailAlertsEnabled,
 }: {
   email: string;
   apiKey: string | null;
   webhookUrl: string | null;
-  hasStripe: boolean;
+  plan: "free" | "pro";
+  billingEnabled: boolean;
   emailAlertsEnabled: boolean;
 }): string {
   const apiKeySection = apiKey
@@ -467,10 +469,14 @@ export function renderSettingsPage({
   <button type="submit" class="btn">Generate API Key</button>
 </form>`;
 
-  const billingSection = hasStripe
-    ? `<a href="/dashboard/billing" class="btn btn-secondary">Manage Billing</a>`
-    : `<p>You have no active subscription.</p>
-<a href="/dashboard/billing/subscribe" class="btn">Upgrade</a>`;
+  const planLabel = plan === "pro" ? "Pro" : "Free";
+  const billingSection = !billingEnabled
+    ? `<p>Billing is not configured on this deployment.</p>`
+    : plan === "pro"
+      ? `<p>You're on the <strong>${planLabel}</strong> plan.</p>
+<a href="/dashboard/billing/portal" class="btn btn-secondary">Manage Billing</a>`
+      : `<p>You're on the <strong>${planLabel}</strong> plan.</p>
+<a href="/dashboard/billing/subscribe" class="btn">Upgrade to Pro</a>`;
 
   const body = `<h1 class="dashboard-title">Settings</h1>
 

--- a/test/billing-routes.test.ts
+++ b/test/billing-routes.test.ts
@@ -1,0 +1,566 @@
+import { Hono } from "hono";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSessionToken } from "../src/auth/session.js";
+import {
+  dashboardBillingRoutes,
+  stripeWebhookRoutes,
+} from "../src/billing/routes.js";
+
+const SECRET = "test-session-secret";
+const STRIPE_SECRETS = {
+  STRIPE_SECRET_KEY: "sk_test_billing_routes",
+  STRIPE_WEBHOOK_SECRET: "whsec_test_billing_routes",
+  STRIPE_PRICE_ID_PRO: "price_test_pro",
+};
+
+// Minimal mock D1 targeted at the SQL executed by the billing webhook and
+// dashboard routes. Tracks in-memory state so replay semantics can be
+// asserted.
+interface MockState {
+  users: Map<
+    string,
+    {
+      id: string;
+      email: string;
+      email_domain: string;
+      stripe_customer_id: string | null;
+      api_key: string | null;
+      email_alerts_enabled: number;
+      created_at: number;
+    }
+  >;
+  subscriptions: Map<string, Record<string, unknown>>;
+  events: Set<string>;
+}
+
+function makeDb(state: MockState): D1Database {
+  const prepare = (sql: string) => ({
+    bind: (...params: unknown[]) => ({
+      run: async () => {
+        if (/^INSERT OR IGNORE INTO stripe_events/i.test(sql)) {
+          const [eventId] = params as [string];
+          if (state.events.has(eventId)) {
+            return { success: true, meta: { changes: 0 } };
+          }
+          state.events.add(eventId);
+          return { success: true, meta: { changes: 1 } };
+        }
+        if (/^INSERT INTO subscriptions/i.test(sql)) {
+          const [
+            user_id,
+            stripe_subscription_id,
+            stripe_price_id,
+            status,
+            current_period_end,
+            cancel_at_period_end,
+          ] = params as [string, string, string, string, number | null, number];
+          state.subscriptions.set(user_id, {
+            user_id,
+            stripe_subscription_id,
+            stripe_price_id,
+            status,
+            current_period_end,
+            cancel_at_period_end,
+          });
+          return { success: true, meta: { changes: 1 } };
+        }
+        if (/^UPDATE users SET stripe_customer_id/i.test(sql)) {
+          const [cid, uid] = params as [string, string];
+          const u = state.users.get(uid);
+          if (u) state.users.set(uid, { ...u, stripe_customer_id: cid });
+          return { success: true, meta: { changes: 1 } };
+        }
+        return { success: true, meta: { changes: 0 } };
+      },
+      first: async <T>(): Promise<T | null> => {
+        if (/FROM users WHERE id = \?/i.test(sql)) {
+          return (state.users.get(params[0] as string) ?? null) as T | null;
+        }
+        if (/FROM users WHERE stripe_customer_id = \?/i.test(sql)) {
+          for (const u of state.users.values()) {
+            if (u.stripe_customer_id === params[0]) return u as T;
+          }
+          return null;
+        }
+        if (/FROM subscriptions WHERE user_id = \?/i.test(sql)) {
+          return (state.subscriptions.get(params[0] as string) ??
+            null) as T | null;
+        }
+        return null;
+      },
+    }),
+  });
+  return { prepare } as unknown as D1Database;
+}
+
+function makeState(): MockState {
+  return {
+    users: new Map(),
+    subscriptions: new Map(),
+    events: new Set(),
+  };
+}
+
+async function signStripePayload(
+  secret: string,
+  timestamp: number,
+  body: string,
+): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(`${timestamp}.${body}`),
+  );
+  const hex = [...new Uint8Array(sig)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return `t=${timestamp},v1=${hex}`;
+}
+
+function subscriptionEventBody(input: {
+  eventId: string;
+  eventType: string;
+  customerId: string;
+  subscriptionId: string;
+  status: string;
+  priceId?: string;
+  currentPeriodEnd?: number;
+  cancelAtPeriodEnd?: boolean;
+}): string {
+  return JSON.stringify({
+    id: input.eventId,
+    type: input.eventType,
+    data: {
+      object: {
+        id: input.subscriptionId,
+        customer: input.customerId,
+        status: input.status,
+        cancel_at_period_end: input.cancelAtPeriodEnd ?? false,
+        current_period_end: input.currentPeriodEnd ?? 1_700_000_000,
+        items: {
+          data: [{ price: { id: input.priceId ?? "price_test_pro" } }],
+        },
+      },
+    },
+  });
+}
+
+describe("stripeWebhookRoutes POST /webhooks/stripe", () => {
+  it("returns 404 when billing is not configured", async () => {
+    const app = new Hono();
+    app.route("/webhooks", stripeWebhookRoutes);
+    const state = makeState();
+    const res = await app.request(
+      "/webhooks/stripe",
+      { method: "POST", body: "{}" },
+      { DB: makeDb(state) },
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects an invalid signature with 400", async () => {
+    const app = new Hono();
+    app.route("/webhooks", stripeWebhookRoutes);
+    const state = makeState();
+    const res = await app.request(
+      "/webhooks/stripe",
+      {
+        method: "POST",
+        body: "{}",
+        headers: { "stripe-signature": "t=123,v1=deadbeef" },
+      },
+      { DB: makeDb(state), ...STRIPE_SECRETS },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("upserts a subscription on customer.subscription.created", async () => {
+    const state = makeState();
+    state.users.set("u1", {
+      id: "u1",
+      email: "pro@example.com",
+      email_domain: "example.com",
+      stripe_customer_id: "cus_pro",
+      api_key: null,
+      email_alerts_enabled: 1,
+      created_at: 0,
+    });
+    const app = new Hono();
+    app.route("/webhooks", stripeWebhookRoutes);
+
+    const body = subscriptionEventBody({
+      eventId: "evt_1",
+      eventType: "customer.subscription.created",
+      customerId: "cus_pro",
+      subscriptionId: "sub_1",
+      status: "active",
+    });
+    const ts = Math.floor(Date.now() / 1000);
+    const sig = await signStripePayload(
+      STRIPE_SECRETS.STRIPE_WEBHOOK_SECRET,
+      ts,
+      body,
+    );
+    const res = await app.request(
+      "/webhooks/stripe",
+      {
+        method: "POST",
+        body,
+        headers: { "stripe-signature": sig },
+      },
+      { DB: makeDb(state), ...STRIPE_SECRETS },
+    );
+    expect(res.status).toBe(200);
+    expect(state.subscriptions.get("u1")).toMatchObject({
+      stripe_subscription_id: "sub_1",
+      status: "active",
+      stripe_price_id: "price_test_pro",
+    });
+  });
+
+  it("flips status to canceled on customer.subscription.deleted", async () => {
+    const state = makeState();
+    state.users.set("u1", {
+      id: "u1",
+      email: "pro@example.com",
+      email_domain: "example.com",
+      stripe_customer_id: "cus_pro",
+      api_key: null,
+      email_alerts_enabled: 1,
+      created_at: 0,
+    });
+    state.subscriptions.set("u1", {
+      user_id: "u1",
+      stripe_subscription_id: "sub_1",
+      stripe_price_id: "price_test_pro",
+      status: "active",
+      current_period_end: 1_700_000_000,
+      cancel_at_period_end: 0,
+    });
+    const app = new Hono();
+    app.route("/webhooks", stripeWebhookRoutes);
+
+    const body = subscriptionEventBody({
+      eventId: "evt_2",
+      eventType: "customer.subscription.deleted",
+      customerId: "cus_pro",
+      subscriptionId: "sub_1",
+      status: "canceled",
+    });
+    const ts = Math.floor(Date.now() / 1000);
+    const sig = await signStripePayload(
+      STRIPE_SECRETS.STRIPE_WEBHOOK_SECRET,
+      ts,
+      body,
+    );
+    const res = await app.request(
+      "/webhooks/stripe",
+      { method: "POST", body, headers: { "stripe-signature": sig } },
+      { DB: makeDb(state), ...STRIPE_SECRETS },
+    );
+    expect(res.status).toBe(200);
+    expect(state.subscriptions.get("u1")).toMatchObject({ status: "canceled" });
+  });
+
+  it("replays the same event id without re-processing", async () => {
+    const state = makeState();
+    state.users.set("u1", {
+      id: "u1",
+      email: "pro@example.com",
+      email_domain: "example.com",
+      stripe_customer_id: "cus_pro",
+      api_key: null,
+      email_alerts_enabled: 1,
+      created_at: 0,
+    });
+    const app = new Hono();
+    app.route("/webhooks", stripeWebhookRoutes);
+
+    const body = subscriptionEventBody({
+      eventId: "evt_replay",
+      eventType: "customer.subscription.created",
+      customerId: "cus_pro",
+      subscriptionId: "sub_1",
+      status: "active",
+    });
+    const ts = Math.floor(Date.now() / 1000);
+    const sig = await signStripePayload(
+      STRIPE_SECRETS.STRIPE_WEBHOOK_SECRET,
+      ts,
+      body,
+    );
+
+    const first = await app.request(
+      "/webhooks/stripe",
+      { method: "POST", body, headers: { "stripe-signature": sig } },
+      { DB: makeDb(state), ...STRIPE_SECRETS },
+    );
+    expect(first.status).toBe(200);
+
+    // Simulate Stripe retry — mutate subscription in DB to prove replay
+    // didn't overwrite it.
+    state.subscriptions.set("u1", {
+      ...(state.subscriptions.get("u1") ?? {}),
+      status: "manually_mutated_between_deliveries",
+    });
+
+    const second = await app.request(
+      "/webhooks/stripe",
+      { method: "POST", body, headers: { "stripe-signature": sig } },
+      { DB: makeDb(state), ...STRIPE_SECRETS },
+    );
+    expect(second.status).toBe(200);
+    const payload = (await second.json()) as { replay?: boolean };
+    expect(payload.replay).toBe(true);
+    expect(state.subscriptions.get("u1")?.status).toBe(
+      "manually_mutated_between_deliveries",
+    );
+  });
+
+  it("ignores events for customers not owned by any dmarcheck user", async () => {
+    const state = makeState();
+    const app = new Hono();
+    app.route("/webhooks", stripeWebhookRoutes);
+    const body = subscriptionEventBody({
+      eventId: "evt_unknown",
+      eventType: "customer.subscription.created",
+      customerId: "cus_donthypeme_not_ours",
+      subscriptionId: "sub_1",
+      status: "active",
+    });
+    const ts = Math.floor(Date.now() / 1000);
+    const sig = await signStripePayload(
+      STRIPE_SECRETS.STRIPE_WEBHOOK_SECRET,
+      ts,
+      body,
+    );
+    const res = await app.request(
+      "/webhooks/stripe",
+      { method: "POST", body, headers: { "stripe-signature": sig } },
+      { DB: makeDb(state), ...STRIPE_SECRETS },
+    );
+    expect(res.status).toBe(200);
+    expect(state.subscriptions.size).toBe(0);
+  });
+
+  it("ignores unsupported event types without error", async () => {
+    const state = makeState();
+    const app = new Hono();
+    app.route("/webhooks", stripeWebhookRoutes);
+    const body = JSON.stringify({
+      id: "evt_ping",
+      type: "ping",
+      data: { object: { id: "x", customer: "y", status: "z" } },
+    });
+    const ts = Math.floor(Date.now() / 1000);
+    const sig = await signStripePayload(
+      STRIPE_SECRETS.STRIPE_WEBHOOK_SECRET,
+      ts,
+      body,
+    );
+    const res = await app.request(
+      "/webhooks/stripe",
+      { method: "POST", body, headers: { "stripe-signature": sig } },
+      { DB: makeDb(state), ...STRIPE_SECRETS },
+    );
+    expect(res.status).toBe(200);
+    expect(state.subscriptions.size).toBe(0);
+  });
+});
+
+describe("dashboardBillingRoutes GET /subscribe", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith("/customers")) {
+        return new Response(JSON.stringify({ id: "cus_new" }), {
+          status: 200,
+        });
+      }
+      if (url.endsWith("/checkout/sessions")) {
+        return new Response(
+          JSON.stringify({
+            id: "cs_123",
+            url: "https://checkout.stripe.com/pay/cs_123",
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.endsWith("/billing_portal/sessions")) {
+        return new Response(
+          JSON.stringify({
+            id: "bps_123",
+            url: "https://billing.stripe.com/p/session/bps_123",
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response("{}", { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  async function sessionCookie(sub: string, email: string): Promise<string> {
+    const token = await createSessionToken({ sub, email }, SECRET);
+    return `session=${token}`;
+  }
+
+  it("returns 404 when billing is not configured", async () => {
+    const app = new Hono();
+    app.route("/dashboard/billing", dashboardBillingRoutes);
+    const state = makeState();
+    const cookie = await sessionCookie("u1", "x@y.com");
+    const res = await app.request(
+      "/dashboard/billing/subscribe",
+      { headers: { Cookie: cookie } },
+      { DB: makeDb(state), SESSION_SECRET: SECRET },
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("creates a Stripe customer lazily then redirects to Checkout", async () => {
+    const app = new Hono();
+    app.route("/dashboard/billing", dashboardBillingRoutes);
+    const state = makeState();
+    state.users.set("u1", {
+      id: "u1",
+      email: "upgrade@example.com",
+      email_domain: "example.com",
+      stripe_customer_id: null,
+      api_key: null,
+      email_alerts_enabled: 1,
+      created_at: 0,
+    });
+    const cookie = await sessionCookie("u1", "upgrade@example.com");
+
+    const res = await app.request(
+      "/dashboard/billing/subscribe",
+      { headers: { Cookie: cookie } },
+      { DB: makeDb(state), SESSION_SECRET: SECRET, ...STRIPE_SECRETS },
+    );
+
+    expect(res.status).toBe(303);
+    expect(res.headers.get("Location")).toBe(
+      "https://checkout.stripe.com/pay/cs_123",
+    );
+    expect(state.users.get("u1")?.stripe_customer_id).toBe("cus_new");
+    // First call creates the customer, second creates the Checkout Session.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("reuses an existing Stripe customer on re-upgrade", async () => {
+    const app = new Hono();
+    app.route("/dashboard/billing", dashboardBillingRoutes);
+    const state = makeState();
+    state.users.set("u1", {
+      id: "u1",
+      email: "upgrade@example.com",
+      email_domain: "example.com",
+      stripe_customer_id: "cus_existing",
+      api_key: null,
+      email_alerts_enabled: 1,
+      created_at: 0,
+    });
+    const cookie = await sessionCookie("u1", "upgrade@example.com");
+
+    const res = await app.request(
+      "/dashboard/billing/subscribe",
+      { headers: { Cookie: cookie } },
+      { DB: makeDb(state), SESSION_SECRET: SECRET, ...STRIPE_SECRETS },
+    );
+
+    expect(res.status).toBe(303);
+    // Only the Checkout Session call — no customer creation.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain("/checkout/sessions");
+  });
+});
+
+describe("dashboardBillingRoutes GET /portal", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              id: "bps_123",
+              url: "https://billing.stripe.com/p/session/bps_123",
+            }),
+            { status: 200 },
+          ),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("redirects to settings when the user has no Stripe customer", async () => {
+    const app = new Hono();
+    app.route("/dashboard/billing", dashboardBillingRoutes);
+    const state = makeState();
+    state.users.set("u1", {
+      id: "u1",
+      email: "free@example.com",
+      email_domain: "example.com",
+      stripe_customer_id: null,
+      api_key: null,
+      email_alerts_enabled: 1,
+      created_at: 0,
+    });
+    const token = await createSessionToken(
+      { sub: "u1", email: "free@example.com" },
+      SECRET,
+    );
+    const res = await app.request(
+      "/dashboard/billing/portal",
+      { headers: { Cookie: `session=${token}` } },
+      { DB: makeDb(state), SESSION_SECRET: SECRET, ...STRIPE_SECRETS },
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/dashboard/settings");
+  });
+
+  it("redirects to the Stripe portal URL when the user has a customer", async () => {
+    const app = new Hono();
+    app.route("/dashboard/billing", dashboardBillingRoutes);
+    const state = makeState();
+    state.users.set("u1", {
+      id: "u1",
+      email: "pro@example.com",
+      email_domain: "example.com",
+      stripe_customer_id: "cus_pro",
+      api_key: null,
+      email_alerts_enabled: 1,
+      created_at: 0,
+    });
+    const token = await createSessionToken(
+      { sub: "u1", email: "pro@example.com" },
+      SECRET,
+    );
+    const res = await app.request(
+      "/dashboard/billing/portal",
+      { headers: { Cookie: `session=${token}` } },
+      { DB: makeDb(state), SESSION_SECRET: SECRET, ...STRIPE_SECRETS },
+    );
+    expect(res.status).toBe(303);
+    expect(res.headers.get("Location")).toBe(
+      "https://billing.stripe.com/p/session/bps_123",
+    );
+  });
+});

--- a/test/dashboard-views.test.ts
+++ b/test/dashboard-views.test.ts
@@ -190,7 +190,8 @@ describe("renderSettingsPage", () => {
       email: "user@example.com",
       apiKey: null,
       webhookUrl: null,
-      hasStripe: false,
+      plan: "free",
+      billingEnabled: true,
       emailAlertsEnabled: true,
     });
     expect(html).toContain("Generate API Key");
@@ -202,7 +203,8 @@ describe("renderSettingsPage", () => {
       email: "user@example.com",
       apiKey: "dmx_abc123secret",
       webhookUrl: null,
-      hasStripe: false,
+      plan: "free",
+      billingEnabled: true,
       emailAlertsEnabled: true,
     });
     expect(html).toContain("dmx_abc123secret");
@@ -214,7 +216,8 @@ describe("renderSettingsPage", () => {
       email: "admin@example.com",
       apiKey: null,
       webhookUrl: null,
-      hasStripe: false,
+      plan: "free",
+      billingEnabled: true,
       emailAlertsEnabled: true,
     });
     expect(html).toContain("admin@example.com");
@@ -226,34 +229,51 @@ describe("renderSettingsPage", () => {
       email: "user@example.com",
       apiKey: null,
       webhookUrl: "https://hooks.example.com/dmarc",
-      hasStripe: false,
+      plan: "free",
+      billingEnabled: true,
       emailAlertsEnabled: true,
     });
     expect(html).toContain("https://hooks.example.com/dmarc");
     expect(html).toContain("Webhook");
   });
 
-  it("renders manage billing link when hasStripe is true", () => {
+  it("renders the Pro badge and Manage Billing link for pro users", () => {
     const html = renderSettingsPage({
       email: "user@example.com",
       apiKey: null,
       webhookUrl: null,
-      hasStripe: true,
+      plan: "pro",
+      billingEnabled: true,
       emailAlertsEnabled: true,
     });
     expect(html).toContain("Manage Billing");
+    expect(html).toContain("<strong>Pro</strong>");
   });
 
-  it("renders no subscription message when hasStripe is false", () => {
+  it("renders the Free badge and an Upgrade link for free users", () => {
     const html = renderSettingsPage({
       email: "user@example.com",
       apiKey: null,
       webhookUrl: null,
-      hasStripe: false,
+      plan: "free",
+      billingEnabled: true,
       emailAlertsEnabled: true,
     });
-    expect(html).toContain("no active subscription");
-    expect(html).toContain("Upgrade");
+    expect(html).toContain("<strong>Free</strong>");
+    expect(html).toContain("Upgrade to Pro");
+  });
+
+  it("shows a 'not configured' message when billing is disabled on this deployment", () => {
+    const html = renderSettingsPage({
+      email: "user@example.com",
+      apiKey: null,
+      webhookUrl: null,
+      plan: "free",
+      billingEnabled: false,
+      emailAlertsEnabled: true,
+    });
+    expect(html).toContain("not configured");
+    expect(html).not.toContain("Upgrade to Pro");
   });
 
   it("escapes API key to prevent XSS", () => {
@@ -261,7 +281,8 @@ describe("renderSettingsPage", () => {
       email: "user@example.com",
       apiKey: "<script>alert(1)</script>",
       webhookUrl: null,
-      hasStripe: false,
+      plan: "free",
+      billingEnabled: true,
       emailAlertsEnabled: true,
     });
     // The escaped form must appear; raw user content must not be injected as HTML
@@ -275,7 +296,8 @@ describe("renderSettingsPage", () => {
       email: "user@example.com",
       apiKey: null,
       webhookUrl: null,
-      hasStripe: false,
+      plan: "free",
+      billingEnabled: true,
       emailAlertsEnabled: true,
     });
     expect(html).toContain("Email Alerts");
@@ -288,7 +310,8 @@ describe("renderSettingsPage", () => {
       email: "user@example.com",
       apiKey: null,
       webhookUrl: null,
-      hasStripe: false,
+      plan: "free",
+      billingEnabled: true,
       emailAlertsEnabled: false,
     });
     expect(html).toContain('name="enabled" >');


### PR DESCRIPTION
## Summary

Second PR in the Phase 3 series. Builds on the scaffolding from [schmug/dmarcheck#145](https://github.com/schmug/dmarcheck/pull/145) to deliver the end-to-end billing flow for the \$9/mo Pro plan. Self-host deploys without Stripe env vars remain unaffected.

**What users see:**
- Settings page shows a real plan badge (**Free** / **Pro**) instead of the old `hasStripe` boolean.
- Free users get an "Upgrade to Pro" button that kicks off Stripe Checkout.
- Pro users get a "Manage Billing" button that opens Stripe's Customer Portal for cancel/payment-method/invoices.
- On self-host deploys without Stripe configured, the billing section says "Billing is not configured on this deployment" and both buttons are absent.

**What the server does:**
- `GET /dashboard/billing/subscribe` — lazily creates a Stripe Customer on first click (so free users never touch Stripe), stores `stripe_customer_id` on the user, creates a Checkout Session in `subscription` mode, 303-redirects to Stripe.
- `GET /dashboard/billing/portal` — creates a Customer Portal session, 303-redirects.
- `POST /webhooks/stripe` — reads raw body, verifies the HMAC signature against `STRIPE_WEBHOOK_SECRET`, idempotency-guards on the `stripe_events` ledger from PR 1, upserts subscription state on `customer.subscription.{created,updated,deleted}`. Events for customers not owned by any dmarcheck user are 200'd and logged — this protects against misrouted events from the shared donthype-me Stripe account.

**Design notes:**
- `subscription_data[metadata][user_id]` is set on Checkout so the created subscription carries the user ID (even though we primarily resolve by customer ID on webhook delivery).
- Webhook handler exits early on unknown customers rather than 500'ing — retries don't help and we don't want Stripe to flag the endpoint unhealthy.
- The webhook *self-gates* on `isBillingEnabled`. A self-hoster who deploys without Stripe env won't accidentally process a stray POST — it's a plain 404.
- No Stripe SDK — raw `fetch` + Web Crypto keeps the bundle small.

**Follow-ups in this series:**
- PR 3 — Hashed API keys (drop cleartext \`users.api_key\`, new \`api_keys\` table, bearer middleware).
- PR 4 — Per-plan rate limits (anon unchanged; Pro = 60 req/hour per-user).

## Test plan

- [x] \`npm test\` — 511/511 passing (13 new tests across webhook signature validation, idempotent replay, subscription lifecycle, Checkout lazy-customer, Portal redirect, feature-flag 404)
- [x] \`npm run lint\` — clean
- [x] \`npm run typecheck\` — clean
- [ ] **End-to-end smoke test** (Cory): after merge, in staging/prod:
  - Sign in → \`/dashboard/settings\` shows "Free" badge → click "Upgrade to Pro"
  - Complete Checkout with test card \`4242 4242 4242 4242\` → redirected to \`/dashboard/settings?upgraded=1\` → badge flips to "Pro"
  - Click "Manage Billing" → Stripe Portal opens → cancel subscription → return to settings
  - Stripe CLI: \`stripe listen --forward-to https://dmarc.mx/webhooks/stripe\` while the above runs; confirm three events land (customer.subscription.created/updated/deleted).
- [ ] **Webhook isolation sanity:** confirm donthype-me's webhook endpoint still fires for its own events and the dmarcheck endpoint logs 'unknown_customer' for any misrouted event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)