### PR TITLE
Fix: wire up add-domain / delete-domain dashboard routes

### DIFF
--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -2,12 +2,19 @@ import { Hono } from "hono";
 import { requireAuth } from "../auth/middleware.js";
 import type { SessionPayload } from "../auth/session.js";
 import { dashboardBillingRoutes } from "../billing/routes.js";
-import { getDomainByUserAndName, getDomainsByUser } from "../db/domains.js";
+import {
+  createDomain,
+  deleteDomain,
+  getDomainByUserAndName,
+  getDomainsByUser,
+} from "../db/domains.js";
 import { recordScan } from "../db/scans.js";
 import { getPlanForUser } from "../db/subscriptions.js";
 import { getUserById, setApiKey, setEmailAlertsEnabled } from "../db/users.js";
 import { scan } from "../orchestrator.js";
+import { normalizeDomain } from "../shared/domain.js";
 import {
+  renderAddDomainPage,
   renderDashboardPage,
   renderDomainDetailPage,
   renderSettingsPage,
@@ -41,6 +48,47 @@ dashboardRoutes.get("/", async (c) => {
       })),
     }),
   );
+});
+
+// Add-domain form. Simple GET → form; POST → validate + insert.
+// `/domain/add` is matched before `/domain/:domain` because Hono picks routes
+// in registration order for literal-vs-param collisions.
+dashboardRoutes.get("/domain/add", (c) => {
+  const session = c.get("user" as never) as SessionPayload;
+  return c.html(renderAddDomainPage({ email: session.email, error: null }));
+});
+
+dashboardRoutes.post("/domain/add", async (c) => {
+  const session = c.get("user" as never) as SessionPayload;
+  const db = (c.env as { DB: D1Database }).DB;
+  const body = await c.req.parseBody();
+  const normalized = normalizeDomain(body.domain as string | undefined);
+  if (!normalized) {
+    return c.html(
+      renderAddDomainPage({
+        email: session.email,
+        error: "Enter a valid domain (e.g. example.com).",
+      }),
+      400,
+    );
+  }
+
+  // Prevent duplicates per-user cleanly rather than surfacing the raw
+  // UNIQUE(user_id, domain) constraint violation from D1.
+  const existing = await getDomainByUserAndName(db, session.sub, normalized);
+  if (existing) {
+    return c.redirect(
+      `/dashboard/domain/${encodeURIComponent(normalized)}`,
+      303,
+    );
+  }
+
+  await createDomain(db, {
+    userId: session.sub,
+    domain: normalized,
+    isFree: false,
+  });
+  return c.redirect(`/dashboard/domain/${encodeURIComponent(normalized)}`, 303);
 });
 
 // Domain detail
@@ -98,6 +146,18 @@ dashboardRoutes.post("/domain/:domain/scan", async (c) => {
   });
 
   return c.redirect(`/dashboard/domain/${encodeURIComponent(domainName)}`, 303);
+});
+
+// Delete monitored domain. POST-only (no idempotent DELETE since HTML forms
+// can't send DELETE without JS). Ownership check is inherent: the SQL WHERE
+// clause in deleteDomain keys on user_id, so one user can't delete another's
+// row even if they guess the domain name.
+dashboardRoutes.post("/domain/:domain/delete", async (c) => {
+  const session = c.get("user" as never) as SessionPayload;
+  const db = (c.env as { DB: D1Database }).DB;
+  const domainName = c.req.param("domain");
+  await deleteDomain(db, session.sub, domainName);
+  return c.redirect("/dashboard", 303);
 });
 
 // Settings page

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import type { Env } from "./env.js";
 import type { ProtocolId, ProtocolResult } from "./orchestrator.js";
 import { scan, scanStreaming } from "./orchestrator.js";
 import { checkRateLimit, rateLimitHeaders } from "./rate-limit.js";
+import { normalizeDomain } from "./shared/domain.js";
 import { CSS_PATH, JS_PATH } from "./views/assets.js";
 import {
   APPLE_TOUCH_ICON_BASE64,
@@ -870,44 +871,9 @@ app.get("/check", async (c) => {
   return c.html(renderStreamingLoading(domain, selectors.join(",")));
 });
 
-export function normalizeDomain(raw: string | undefined): string | null {
-  if (!raw) return null;
-  let domain = raw.trim().toLowerCase();
-  // Strip protocol if pasted as URL
-  domain = domain.replace(/^https?:\/\//, "");
-  // Use URL constructor to normalize (handles ports, userinfo, Punycode/IDN)
-  try {
-    domain = new URL(`http://${domain}`).hostname;
-  } catch {
-    // Fall back to manual parsing for inputs the URL constructor rejects
-    domain = domain.split("/")[0].split("?")[0];
-  }
-  // RFC 1035: domain names must not exceed 253 characters
-  if (domain.length > 253) return null;
-  // Strip trailing dot
-  domain = domain.replace(/\.$/, "");
-  // Restrict to ASCII hostname charset. IDNs are Punycode-encoded by `new URL`
-  // (e.g. münchen.de → xn--mnchen-3ya.de), so this set covers valid IDNs too.
-  // Rejects anything exotic (quotes, spaces, brackets) that could break out of
-  // an HTML attribute or JS literal downstream.
-  if (!/^[a-z0-9.-]+$/.test(domain)) return null;
-  // Must have at least one dot
-  if (!domain.includes(".")) return null;
-  // Reject IPv4 literals. DMARC/SPF/DKIM/BIMI/MTA-STS records are published
-  // in DNS at domain names, not IPs — there is no legitimate dmarcheck use
-  // case for scanning `1.2.3.4`. This also closes a defense-in-depth gap
-  // around the MTA-STS fetch in `src/analyzers/mta-sts.ts`, which interpolates
-  // the validated domain into a URL (flagged CWE-918 by static analysis);
-  // previously, metadata-service IPs like 169.254.169.254 were only shielded
-  // by the `mta-sts.` prefix happening to route them back through public DNS.
-  // WHATWG URL (used above) normalizes hex, integer, and short-form IPv4
-  // inputs into canonical dotted-decimal, so a single anchored check covers
-  // `0xc0a80101`, `3232235777`, `127.1`, and `1.2.3` as well as plain forms.
-  // `999.999.999.999` throws from `new URL` and is caught by the fallback
-  // branch above, then rejected here by regex shape.
-  if (/^(?:\d{1,3}\.){3}\d{1,3}$/.test(domain)) return null;
-  return domain;
-}
+// Re-exported so long-standing callers (and tests) that import from
+// `src/index.js` keep working. Canonical location: src/shared/domain.ts.
+export { normalizeDomain };
 
 // DKIM selector charset per RFC 6376 §3.1: sub-domain syntax, which is
 // letters / digits / hyphens, with dot-separated labels. We also allow

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -1,0 +1,43 @@
+// Shared, side-effect-free domain normalization + validation used by both
+// the public scan endpoints in src/index.ts and the dashboard CRUD routes
+// in src/dashboard/routes.ts. Kept in src/shared/ to avoid a circular
+// import (dashboard → index → dashboard) when both sides need the helper.
+
+export function normalizeDomain(raw: string | undefined): string | null {
+  if (!raw) return null;
+  let domain = raw.trim().toLowerCase();
+  // Strip protocol if pasted as URL
+  domain = domain.replace(/^https?:\/\//, "");
+  // Use URL constructor to normalize (handles ports, userinfo, Punycode/IDN)
+  try {
+    domain = new URL(`http://${domain}`).hostname;
+  } catch {
+    // Fall back to manual parsing for inputs the URL constructor rejects
+    domain = domain.split("/")[0].split("?")[0];
+  }
+  // RFC 1035: domain names must not exceed 253 characters
+  if (domain.length > 253) return null;
+  // Strip trailing dot
+  domain = domain.replace(/\.$/, "");
+  // Restrict to ASCII hostname charset. IDNs are Punycode-encoded by `new URL`
+  // (e.g. münchen.de → xn--mnchen-3ya.de), so this set covers valid IDNs too.
+  // Rejects anything exotic (quotes, spaces, brackets) that could break out of
+  // an HTML attribute or JS literal downstream.
+  if (!/^[a-z0-9.-]+$/.test(domain)) return null;
+  // Must have at least one dot
+  if (!domain.includes(".")) return null;
+  // Reject IPv4 literals. DMARC/SPF/DKIM/BIMI/MTA-STS records are published
+  // in DNS at domain names, not IPs — there is no legitimate dmarcheck use
+  // case for scanning `1.2.3.4`. This also closes a defense-in-depth gap
+  // around the MTA-STS fetch in `src/analyzers/mta-sts.ts`, which interpolates
+  // the validated domain into a URL (flagged CWE-918 by static analysis);
+  // previously, metadata-service IPs like 169.254.169.254 were only shielded
+  // by the `mta-sts.` prefix happening to route them back through public DNS.
+  // WHATWG URL (used above) normalizes hex, integer, and short-form IPv4
+  // inputs into canonical dotted-decimal, so a single anchored check covers
+  // `0xc0a80101`, `3232235777`, `127.1`, and `1.2.3` as well as plain forms.
+  // `999.999.999.999` throws from `new URL` and is caught by the fallback
+  // branch above, then rejected here by regex shape.
+  if (/^(?:\d{1,3}\.){3}\d{1,3}$/.test(domain)) return null;
+  return domain;
+}

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -435,6 +435,9 @@ export function renderDomainDetailPage({
     <button type="submit" class="btn">Scan Now</button>
   </form>
   <a href="/check?domain=${encodeURIComponent(domain)}" class="btn btn-secondary">View Full Report</a>
+  <form method="POST" action="/dashboard/domain/${encodeURIComponent(domain)}/delete" style="display:inline" onsubmit="return confirm('Stop monitoring ${esc(domain)}?');">
+    <button type="submit" class="btn btn-secondary">Delete</button>
+  </form>
 </div>
 <div class="section-card">
   <h2>Grade History</h2>
@@ -442,6 +445,42 @@ export function renderDomainDetailPage({
 </div>`;
 
   return dashboardPage(`${domain} — dmarc.mx`, body, email);
+}
+
+export function renderAddDomainPage({
+  email,
+  error,
+}: {
+  email: string;
+  error: string | null;
+}): string {
+  const errorBlock = error
+    ? `<div class="settings-section" style="border-color:var(--clr-danger, #b91c1c);color:var(--clr-danger, #b91c1c)">${esc(error)}</div>`
+    : "";
+
+  const body = `<h1 class="dashboard-title">Add Domain</h1>
+${errorBlock}
+<form method="POST" action="/dashboard/domain/add" class="settings-section">
+  <label for="domain-input" style="display:block;font-size:0.875rem;color:var(--clr-text-muted);margin-bottom:0.4rem">Domain to monitor</label>
+  <input
+    id="domain-input"
+    class="settings-input"
+    type="text"
+    name="domain"
+    placeholder="example.com"
+    autofocus
+    required
+  >
+  <p style="font-size:0.8125rem;color:var(--clr-text-muted);margin:0.5rem 0 1rem">
+    We'll run a full DMARC/SPF/DKIM/BIMI/MTA-STS scan and notify you if the grade drops.
+  </p>
+  <div class="action-row">
+    <button type="submit" class="btn">Add Domain</button>
+    <a href="/dashboard" class="btn btn-secondary">Cancel</a>
+  </div>
+</form>`;
+
+  return dashboardPage("Add Domain — dmarc.mx", body, email);
 }
 
 export function renderSettingsPage({

--- a/test/dashboard-routes.test.ts
+++ b/test/dashboard-routes.test.ts
@@ -589,4 +589,173 @@ describe("dashboard/routes", () => {
       expect(res.headers.get("Location")).toBe("/dashboard/settings");
     });
   });
+
+  describe("GET /dashboard/domain/add", () => {
+    it("redirects to /auth/login without a session cookie", async () => {
+      const db = createMockDB({});
+      const app = createTestApp(db);
+      const res = await app.request("/dashboard/domain/add");
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/auth/login");
+    });
+
+    it("renders the add-domain form with a session cookie", async () => {
+      const db = createMockDB({});
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/domain/add", {
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body).toContain("Add Domain");
+      expect(body).toContain('name="domain"');
+    });
+  });
+
+  describe("POST /dashboard/domain/add", () => {
+    it("redirects to /auth/login without a session cookie", async () => {
+      const db = createMockDB({});
+      const app = createTestApp(db);
+      const res = await app.request("/dashboard/domain/add", {
+        method: "POST",
+      });
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/auth/login");
+    });
+
+    it("rejects an invalid domain with 400 and re-renders the form", async () => {
+      const db = createMockDB({});
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const body = new URLSearchParams({ domain: "not a domain" });
+      const res = await app.request("/dashboard/domain/add", {
+        method: "POST",
+        headers: {
+          Cookie: cookie,
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: body.toString(),
+      });
+      expect(res.status).toBe(400);
+      const html = await res.text();
+      expect(html).toContain("valid domain");
+    });
+
+    it("creates the domain and 303-redirects to the detail page", async () => {
+      const writes: Array<{ sql: string; bindings: unknown[] }> = [];
+      const db = createMockDB({ writes });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const body = new URLSearchParams({ domain: "example.com" });
+      const res = await app.request("/dashboard/domain/add", {
+        method: "POST",
+        headers: {
+          Cookie: cookie,
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: body.toString(),
+      });
+      expect(res.status).toBe(303);
+      expect(res.headers.get("Location")).toBe("/dashboard/domain/example.com");
+      const inserted = writes.find((w) =>
+        w.sql.includes("INSERT INTO domains"),
+      );
+      expect(inserted).toBeDefined();
+      expect(inserted?.bindings).toEqual([
+        "user_1",
+        "example.com",
+        0, // isFree=false → 0
+        "weekly",
+      ]);
+    });
+
+    it("does not create a duplicate when the user already owns the domain", async () => {
+      const writes: Array<{ sql: string; bindings: unknown[] }> = [];
+      const db = createMockDB({
+        domains: [
+          {
+            id: 1,
+            user_id: "user_1",
+            domain: "example.com",
+            is_free: 0,
+            scan_frequency: "weekly",
+            last_scanned_at: null,
+            last_grade: null,
+            created_at: 1_700_000_000,
+          },
+        ],
+        writes,
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const body = new URLSearchParams({ domain: "example.com" });
+      const res = await app.request("/dashboard/domain/add", {
+        method: "POST",
+        headers: {
+          Cookie: cookie,
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: body.toString(),
+      });
+      expect(res.status).toBe(303);
+      expect(res.headers.get("Location")).toBe("/dashboard/domain/example.com");
+      const inserted = writes.find((w) =>
+        w.sql.includes("INSERT INTO domains"),
+      );
+      expect(inserted).toBeUndefined();
+    });
+
+    it("normalizes protocol-prefixed input to a bare domain", async () => {
+      const writes: Array<{ sql: string; bindings: unknown[] }> = [];
+      const db = createMockDB({ writes });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const body = new URLSearchParams({
+        domain: "https://Example.COM/path",
+      });
+      const res = await app.request("/dashboard/domain/add", {
+        method: "POST",
+        headers: {
+          Cookie: cookie,
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: body.toString(),
+      });
+      expect(res.status).toBe(303);
+      expect(res.headers.get("Location")).toBe("/dashboard/domain/example.com");
+      const inserted = writes.find((w) =>
+        w.sql.includes("INSERT INTO domains"),
+      );
+      expect(inserted?.bindings[1]).toBe("example.com");
+    });
+  });
+
+  describe("POST /dashboard/domain/:domain/delete", () => {
+    it("redirects to /auth/login without a session cookie", async () => {
+      const db = createMockDB({});
+      const app = createTestApp(db);
+      const res = await app.request("/dashboard/domain/example.com/delete", {
+        method: "POST",
+      });
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/auth/login");
+    });
+
+    it("deletes the domain and 303-redirects to /dashboard", async () => {
+      const writes: Array<{ sql: string; bindings: unknown[] }> = [];
+      const db = createMockDB({ writes });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/domain/example.com/delete", {
+        method: "POST",
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(303);
+      expect(res.headers.get("Location")).toBe("/dashboard");
+      const deleted = writes.find((w) => w.sql.includes("DELETE FROM domains"));
+      expect(deleted).toBeDefined();
+      expect(deleted?.bindings).toEqual(["user_1", "example.com"]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes a gap left over from Phase 2a. The empty-state dashboard shows an "Add Domain" button linking to `/dashboard/domain/add`, but the route was never implemented — clicking it 404'd. The `createDomain` / `deleteDomain` DB helpers already existed; only the HTTP side was missing.

Without this, the paid monitoring tier can't do its job — users couldn't add anything beyond the auto-provisioned email domain.

**What's added:**
- `GET /dashboard/domain/add` — form page
- `POST /dashboard/domain/add` — validates via the existing `normalizeDomain`, inserts with `isFree: false` (weekly cadence), redirects to detail page. Duplicates redirect instead of surfacing the UNIQUE constraint.
- `POST /dashboard/domain/:domain/delete` — ownership is enforced by `deleteDomain`'s `WHERE user_id = ?` clause; JS `confirm()` on the button is just UX, not security.
- Delete button on the domain detail page.

**Small refactor:**
- Moved `normalizeDomain` into `src/shared/domain.ts` so `src/dashboard/routes.ts` can import it without creating an `index.ts → dashboard → index.ts` cycle. `src/index.ts` re-exports it so the 30+ existing test imports don't move.

**Tests (9 new, 520 total):**
- Auth gating (`GET` and both `POST`s redirect to login without session)
- Invalid domain → 400 + re-rendered form with error
- Happy path → 303 to detail page + INSERT binding assertion
- Duplicate → 303 to detail page, no INSERT
- Protocol-prefixed input (\`https://Example.COM/path\`) → normalized to \`example.com\` before INSERT
- Delete → 303 to /dashboard + DELETE binding assertion

## Test plan

- [x] \`npm test\` — 520/520
- [x] \`npm run lint\` — clean
- [x] \`npm run typecheck\` — clean
- [ ] Local smoke: \`npm run dev\` → sign in → Add Domain → add \`dmarc.mx\` → detail page renders → Delete → back on empty dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)