### PR TITLE
feat(views): surface login-to-monitor CTA on landing and reports

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "wrangler-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 8790
+    }
+  ]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -405,7 +405,7 @@ app.get("/api/check/stream", async (c) => {
         data: JSON.stringify({
           grade: cached.grade,
           headerHtml: renderReportHeader(cached),
-          footerHtml: renderReportFooter(),
+          footerHtml: renderReportFooter(cached),
         }),
       });
       return;
@@ -434,7 +434,7 @@ app.get("/api/check/stream", async (c) => {
       data: JSON.stringify({
         grade: result.grade,
         headerHtml: renderReportHeader(result),
-        footerHtml: renderReportFooter(),
+        footerHtml: renderReportFooter(result),
       }),
     });
   });

--- a/src/views/components.ts
+++ b/src/views/components.ts
@@ -91,6 +91,71 @@ export function themeToggle(): string {
   return '<button class="theme-toggle" aria-label="Toggle theme" title="Toggle theme"></button>';
 }
 
+// TODO: gate on session state once a request-scoped session helper exists
+// outside src/auth/middleware.ts.
+export function navLoginButton(): string {
+  return `<a href="/auth/login" class="nav-login" aria-label="Log in to monitor a domain (free)">
+  <span class="nav-login-avatar">${generateCreature("sm")}</span>
+  <span class="nav-login-label">Log in to monitor</span>
+  <span class="nav-login-arrow" aria-hidden="true">&#8599;</span>
+</a>`;
+}
+
+export function monitorSnapshotCard(result: ScanResult): string {
+  const { domain, protocols, timestamp } = result;
+  const policy = protocols.dmarc.tags?.p;
+  const dmarcOk = policy === "reject" || policy === "quarantine";
+  const spfOk = protocols.spf.status === "pass";
+  const dkimCount = Object.values(protocols.dkim.selectors).filter(
+    (s) => s.found,
+  ).length;
+  const bimiOk = !!protocols.bimi.tags;
+  const nextUrl = `/auth/login?next=/dashboard&prompt=monitor:${encodeURIComponent(domain)}`;
+  const stamp = new Date(timestamp).toLocaleTimeString("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+
+  const row = (ok: boolean, label: string, value: string): string =>
+    `<div class="snap-row${ok ? "" : " snap-row-muted"}">
+      <span class="snap-mark">${ok ? "+" : "\u00b7"}</span>
+      <span class="snap-label">${esc(label)}</span>
+      <span class="snap-val">${esc(value)}</span>
+    </div>`;
+
+  const spfValue = protocols.spf.record
+    ? `${protocols.spf.lookups_used}/${protocols.spf.lookup_limit} lookups`
+    : "not set";
+  const dkimValue =
+    dkimCount > 0
+      ? `${dkimCount} selector${dkimCount > 1 ? "s" : ""}`
+      : "none found";
+  const bimiValue = bimiOk ? "configured" : "not configured";
+  const dmarcValue = policy ? `p=${policy}` : "not set";
+
+  return `<section class="monitor-card" aria-labelledby="monitor-card-title">
+  <div class="monitor-snap">
+    <div class="monitor-eyebrow">Snapshot &middot; ${esc(stamp)}</div>
+    <div id="monitor-card-title" class="monitor-snap-heading">We'd tell you if any of this changed:</div>
+    <div class="snap-list">
+      ${row(dmarcOk, "DMARC policy", dmarcValue)}
+      ${row(spfOk, "SPF", spfValue)}
+      ${row(dkimCount > 0, "DKIM", dkimValue)}
+      ${row(bimiOk, "BIMI", bimiValue)}
+    </div>
+  </div>
+  <div class="monitor-divider" aria-hidden="true"></div>
+  <div class="monitor-pitch">
+    <p class="monitor-pitch-lede">Monitor <strong>${esc(domain)}</strong> and we'll re-run this check every 24 hours. You'll get an email the moment anything drifts.</p>
+    <div class="monitor-cta-row">
+      <a href="${esc(nextUrl)}" class="monitor-cta">Start monitoring</a>
+      <span class="monitor-cta-meta">free &middot; no card &middot; MIT open source</span>
+    </div>
+  </div>
+</section>`;
+}
+
 export function gradeToMood(grade: string): CreatureMood {
   if (grade === "S") return "celebrating";
   const letter = grade.charAt(0).toUpperCase();

--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -14,8 +14,10 @@ import {
   generateCreature,
   gradeClass,
   lookupCounter,
+  monitorSnapshotCard,
   mtaStsPolicyTable,
   mxTable,
+  navLoginButton,
   protocolCard,
   protocolContributionGrid,
   rawRecord,
@@ -129,6 +131,7 @@ export function renderLandingPage(): string {
     jsonLd: LANDING_JSON_LD,
     body: `<main class="landing">
   <div class="landing-hero">
+    <div class="landing-nav">${navLoginButton()}</div>
     <div class="landing-main">
       <div class="logo">${generateCreature("lg")}<span class="logo-text">dmar<span>check</span></span></div>
       <h1 class="tagline">DNS email security analyzer &mdash; DMARC, SPF, DKIM, BIMI &amp; MTA-STS</h1>
@@ -171,7 +174,6 @@ export function renderLandingPage(): string {
         </a>
       </div>
       <div class="dmarcus-credit">Guarded by DMarcus ${generateCreature("sm", "content")}</div>
-      <div class="learn-link"><a href="/auth/login">Log in</a> to monitor a domain (free)</div>
     </div>
   </div>
   <section class="landing-explainer" id="what-we-check" aria-labelledby="explainer-heading">
@@ -268,6 +270,8 @@ function reportBody(result: ScanResult): string {
   return `<main class="report">
   <div class="report-nav">
     <a href="/">${generateCreature("sm")} dmarcheck</a>
+    <span class="report-nav-spacer"></span>
+    ${navLoginButton()}
   </div>
   <div class="report-header">
     <div class="overall-grade ${gradeClass(result.grade)}">${esc(result.grade)}</div>
@@ -288,6 +292,7 @@ function reportBody(result: ScanResult): string {
   ${renderDkimCard(dkim)}
   ${renderBimiCard(bimi)}
   ${renderMtaStsCard(mta_sts)}
+  ${monitorSnapshotCard(result)}
   <div class="learn-link" style="margin-top:2.5rem">Analyze message headers: <a href="https://toolbox.googleapps.com/apps/messageheader/" target="_blank" rel="noopener">Google &#8599;</a> &middot; <a href="https://mha.azurewebsites.net/" target="_blank" rel="noopener">Microsoft &#8599;</a></div>
   <div class="learn-link" style="margin-top:0.4rem;margin-bottom:1rem"><a href="/scoring">How is my score calculated?</a> &middot; <a href="https://www.cloudflare.com/learning/email-security/dmarc-dkim-spf/" target="_blank" rel="noopener">What is email security? &#8599;</a></div>
   <div class="foss-callout">
@@ -324,8 +329,9 @@ export function renderReportHeader(result: ScanResult): string {
   </div>`;
 }
 
-export function renderReportFooter(): string {
-  return `<div class="learn-link" style="margin-top:2.5rem">Analyze message headers: <a href="https://toolbox.googleapps.com/apps/messageheader/" target="_blank" rel="noopener">Google &#8599;</a> &middot; <a href="https://mha.azurewebsites.net/" target="_blank" rel="noopener">Microsoft &#8599;</a></div>
+export function renderReportFooter(result: ScanResult): string {
+  return `${monitorSnapshotCard(result)}
+  <div class="learn-link" style="margin-top:2.5rem">Analyze message headers: <a href="https://toolbox.googleapps.com/apps/messageheader/" target="_blank" rel="noopener">Google &#8599;</a> &middot; <a href="https://mha.azurewebsites.net/" target="_blank" rel="noopener">Microsoft &#8599;</a></div>
   <div class="learn-link" style="margin-top:0.4rem;margin-bottom:1rem"><a href="/scoring">How is my score calculated?</a> &middot; <a href="https://www.cloudflare.com/learning/email-security/dmarc-dkim-spf/" target="_blank" rel="noopener">What is email security? &#8599;</a></div>
   <div class="foss-callout">
     <a href="https://github.com/schmug/dmarcheck" class="foss-link">
@@ -371,6 +377,8 @@ export function renderStreamingLoading(
     body: `<main class="report" data-qs="${esc(qs)}">
   <div class="report-nav">
     <a href="/">${generateCreature("sm")} dmarcheck</a>
+    <span class="report-nav-spacer"></span>
+    ${navLoginButton()}
   </div>
   <div class="stream-header">
     <div class="grade-skeleton" style="margin:0 auto"></div>
@@ -453,6 +461,8 @@ export function renderScoreBreakdown(result: ScanResult): string {
   const body = `<main class="breakdown">
   <div class="report-nav">
     <a href="${backUrl}">${generateCreature("sm")} Back to results</a>
+    <span class="report-nav-spacer"></span>
+    ${navLoginButton()}
   </div>
   <div class="report-header">
     <div class="overall-grade ${gradeClass(result.grade)}">${esc(result.grade)}</div>

--- a/src/views/styles.ts
+++ b/src/views/styles.ts
@@ -131,6 +131,56 @@ code { font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace; font-siz
   min-height: 100vh;
   min-height: 100dvh;
   padding: 2rem;
+  position: relative;
+}
+.landing-nav {
+  position: absolute; top: 1.25rem; right: 1.5rem;
+  z-index: 2;
+}
+
+/* Persistent login pill (landing + report nav) */
+.nav-login {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 5px 12px 5px 5px;
+  background: var(--clr-surface);
+  border: 1px solid var(--clr-border);
+  border-radius: 999px;
+  color: var(--clr-text);
+  font-size: 0.82rem; font-weight: 500;
+  text-decoration: none;
+  transition: background 0.15s, border-color 0.15s;
+}
+.nav-login:hover {
+  background: var(--clr-bg);
+  border-color: var(--clr-border-hover);
+  text-decoration: none;
+}
+.nav-login:focus-visible {
+  outline: 2px solid var(--clr-accent);
+  outline-offset: 2px;
+}
+.nav-login-avatar {
+  display: inline-flex; align-items: center; justify-content: center;
+  flex-direction: column;
+  width: 26px; height: 26px;
+  border-radius: 50%;
+  background: var(--clr-bg);
+  overflow: hidden;
+  flex-shrink: 0;
+}
+.nav-login-avatar .creature { transform: scale(0.72); transform-origin: center; }
+.nav-login-arrow {
+  color: var(--clr-text-faint); font-size: 0.75rem;
+  transition: color 0.15s, transform 0.15s;
+}
+.nav-login:hover .nav-login-arrow {
+  color: var(--clr-accent);
+  transform: translate(1px, -1px);
+}
+@media (max-width: 480px) {
+  .nav-login-label { display: none; }
+  .nav-login { padding: 4px; }
+  .landing-nav { top: 0.75rem; right: 0.75rem; }
 }
 .landing-main {
   flex: 1; display: flex; flex-direction: column; align-items: center;
@@ -257,6 +307,8 @@ h1.tagline, .tagline { color: var(--clr-text-dim); font-size: 1.1rem; font-weigh
   display: flex; align-items: center; gap: 12px; margin-bottom: 2rem;
 }
 .report-nav a { font-size: 0.85rem; display: inline-flex; align-items: center; gap: 6px; }
+.report-nav-spacer { flex: 1; }
+.report-nav .nav-login { font-size: 0.82rem; }
 .report-header { display: flex; align-items: center; gap: 1rem; margin-bottom: 0.5rem; }
 .report-header .creature { margin-left: 8px; }
 h1.domain-name, .domain-name { font-size: 1.5rem; font-weight: 700; margin: 0; }
@@ -495,6 +547,75 @@ h1.domain-name, .domain-name { font-size: 1.5rem; font-weight: 700; margin: 0; }
   white-space: nowrap;
 }
 .snippet-link:hover { text-decoration: underline; }
+
+/* Post-scan monitor upsell */
+.monitor-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 1px minmax(0, 1.1fr);
+  gap: 22px;
+  align-items: stretch;
+  margin: 1.75rem 0 1rem;
+  padding: 18px 22px;
+  background: var(--clr-surface);
+  border: 1px solid var(--clr-border);
+  border-radius: 12px;
+}
+.monitor-snap { min-width: 0; }
+.monitor-eyebrow {
+  font-size: 0.7rem; text-transform: uppercase; letter-spacing: 1.5px;
+  color: var(--clr-text-faint); font-family: 'SF Mono', 'Fira Code', monospace;
+}
+.monitor-snap-heading {
+  font-size: 0.95rem; font-weight: 600; color: var(--clr-text);
+  margin-top: 4px;
+}
+.snap-list {
+  margin-top: 10px;
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-size: 0.78rem; line-height: 1.65;
+  color: var(--clr-text-muted);
+}
+.snap-row { display: grid; grid-template-columns: 14px auto 1fr; gap: 6px; }
+.snap-row-muted { opacity: 0.55; }
+.snap-mark { color: var(--clr-pass); font-weight: 700; text-align: center; }
+.snap-row-muted .snap-mark { color: var(--clr-text-faint); }
+.snap-label { color: var(--clr-text-dim); }
+.snap-val { color: var(--clr-text); }
+.monitor-divider { background: var(--clr-border); }
+.monitor-pitch {
+  display: flex; flex-direction: column; justify-content: center;
+  gap: 12px; min-width: 0;
+}
+.monitor-pitch-lede {
+  margin: 0;
+  font-size: 0.92rem; line-height: 1.5;
+  color: var(--clr-text);
+}
+.monitor-pitch-lede strong { color: var(--clr-accent); font-weight: 600; }
+.monitor-cta-row {
+  display: flex; align-items: center; gap: 14px; flex-wrap: wrap;
+}
+.monitor-cta {
+  display: inline-flex; align-items: center;
+  padding: 9px 16px;
+  background: var(--clr-accent); color: var(--clr-on-accent);
+  border-radius: 8px;
+  font-size: 0.86rem; font-weight: 600;
+  text-decoration: none;
+  transition: background 0.15s;
+}
+.monitor-cta:hover { background: var(--clr-accent-hover); text-decoration: none; }
+.monitor-cta-meta {
+  font-size: 0.72rem; color: var(--clr-text-faint);
+  font-family: 'SF Mono', 'Fira Code', monospace;
+}
+@media (max-width: 640px) {
+  .monitor-card {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+  .monitor-divider { display: none; }
+}
 
 /* Scoring breakdown page */
 .breakdown { max-width: 700px; margin: 0 auto; padding: 2rem; }

--- a/test/components.test.ts
+++ b/test/components.test.ts
@@ -1,14 +1,88 @@
 import { describe, expect, it } from "vitest";
+import type { ScanResult } from "../src/analyzers/types";
+import type { GradeBreakdown } from "../src/shared/scoring";
 import {
   esc,
   generateCreature,
   gradeToMood,
+  monitorSnapshotCard,
   mxTable,
   statusDot,
   themeToggle,
 } from "../src/views/components";
 import { renderError, renderLandingPage } from "../src/views/html";
 import { CSS } from "../src/views/styles";
+
+function makeScanResult(overrides: Partial<ScanResult> = {}): ScanResult {
+  return {
+    domain: "example.com",
+    timestamp: "2026-03-31T12:00:00.000Z",
+    grade: "B",
+    breakdown: {
+      grade: "B",
+      tier: "B",
+      tierReason: "",
+      modifier: 0,
+      modifierLabel: "",
+      factors: [],
+      recommendations: [],
+      protocolSummaries: {},
+    } as GradeBreakdown,
+    summary: {
+      mx_records: 0,
+      mx_providers: [],
+      dmarc_policy: "reject",
+      spf_result: "pass",
+      spf_lookups: "3/10",
+      dkim_selectors_found: 1,
+      bimi_enabled: false,
+      mta_sts_mode: null,
+    },
+    protocols: {
+      mx: {
+        status: "info",
+        records: [],
+        providers: [],
+        validations: [],
+      },
+      dmarc: {
+        status: "pass",
+        record: "v=DMARC1; p=reject",
+        tags: { v: "DMARC1", p: "reject" },
+        validations: [],
+      },
+      spf: {
+        status: "pass",
+        record: "v=spf1 include:_spf.google.com ~all",
+        lookups_used: 3,
+        lookup_limit: 10,
+        include_tree: null,
+        validations: [],
+      },
+      dkim: {
+        status: "pass",
+        selectors: {
+          google: { found: true, key_type: "rsa", key_bits: 2048 },
+          selector1: { found: false },
+        },
+        validations: [],
+      },
+      bimi: {
+        status: "fail",
+        record: null,
+        tags: null,
+        validations: [],
+      },
+      mta_sts: {
+        status: "fail",
+        dns_record: null,
+        policy: null,
+        validations: [],
+      },
+    },
+    ...overrides,
+  };
+}
 
 describe("esc", () => {
   it("escapes ampersands", () => {
@@ -180,6 +254,55 @@ describe("CSS theme variables", () => {
 
   it("includes theme toggle styles", () => {
     expect(CSS).toContain(".theme-toggle");
+  });
+});
+
+describe("monitorSnapshotCard", () => {
+  it("renders + for passing protocols and · for missing ones", () => {
+    const html = monitorSnapshotCard(makeScanResult());
+    // 3 passing: DMARC p=reject, SPF pass, DKIM 1 selector found
+    const plusMatches = html.match(/<span class="snap-mark">\+<\/span>/g) ?? [];
+    expect(plusMatches).toHaveLength(3);
+    // 1 muted: BIMI not configured (middle-dot is \u00b7)
+    expect(html).toContain(
+      '<div class="snap-row snap-row-muted">\n      <span class="snap-mark">\u00b7</span>',
+    );
+  });
+
+  it("embeds the CTA pointing at the login page with a monitor prompt", () => {
+    const html = monitorSnapshotCard(makeScanResult());
+    expect(html).toContain(
+      "/auth/login?next=/dashboard&amp;prompt=monitor:example.com",
+    );
+    expect(html).toContain('class="monitor-cta"');
+  });
+
+  it("escapes the domain in both the heading and the CTA href", () => {
+    const html = monitorSnapshotCard(makeScanResult({ domain: "<evil>.test" }));
+    expect(html).not.toContain("<evil>.test</strong>");
+    expect(html).toContain("&lt;evil&gt;.test</strong>");
+    // encodeURIComponent escapes < and > before esc() runs
+    expect(html).toContain("%3Cevil%3E.test");
+  });
+
+  it("mutes DMARC row when policy is p=none", () => {
+    const html = monitorSnapshotCard(
+      makeScanResult({
+        protocols: {
+          ...makeScanResult().protocols,
+          dmarc: {
+            status: "warn",
+            record: "v=DMARC1; p=none",
+            tags: { v: "DMARC1", p: "none" },
+            validations: [],
+          },
+        },
+      }),
+    );
+    // DMARC row should be muted (p=none is not reject/quarantine)
+    expect(html).toMatch(
+      /snap-row snap-row-muted">\s*<span class="snap-mark">\u00b7<\/span>\s*<span class="snap-label">DMARC policy/,
+    );
   });
 });
 

--- a/test/nav-link.test.ts
+++ b/test/nav-link.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { navLoginButton } from "../src/views/components.js";
 import { renderLandingPage } from "../src/views/html.js";
 
 describe("landing page nav", () => {
@@ -6,5 +7,30 @@ describe("landing page nav", () => {
     const html = renderLandingPage();
     expect(html).toContain("/auth/login");
     expect(html).toContain("Log in");
+  });
+
+  it("renders the persistent nav-login pill in the landing hero", () => {
+    const html = renderLandingPage();
+    expect(html).toContain('class="landing-nav"');
+    expect(html).toContain('class="nav-login"');
+  });
+
+  it("drops the legacy footer text-link", () => {
+    const html = renderLandingPage();
+    expect(html).not.toContain("Log in</a> to monitor a domain (free)");
+  });
+});
+
+describe("navLoginButton", () => {
+  it("links to /auth/login and embeds the sm creature", () => {
+    const html = navLoginButton();
+    expect(html).toContain('href="/auth/login"');
+    expect(html).toContain('class="creature creature-sm"');
+  });
+
+  it("provides an accessible label since the avatar is decorative", () => {
+    const html = navLoginButton();
+    expect(html).toContain('aria-label="Log in to monitor a domain (free)"');
+    expect(html).toContain('aria-hidden="true"');
   });
 });


### PR DESCRIPTION
## Summary

Replaces the buried 16px footer text-link ("Log in to monitor a domain (free)") with two high-visibility entry points into the freemium monitor flow:

- **Top-right "Log in to monitor" pill** — rendered on every public page (landing, direct report, streaming report, score breakdown) via a new `navLoginButton()` helper. Uses DMarcus's `sm` creature as the avatar, collapses to icon-only under 480px.
- **Post-scan snapshot card** — rendered under MTA-STS on report pages. Shows the four things monitoring would watch (DMARC policy, SPF lookups, DKIM selectors, BIMI) with a `+` / `·` diff derived from the live `ScanResult`, a short value prop, and a primary CTA into `/auth/login?next=/dashboard&prompt=monitor:<domain>`. The card renders on both the direct render and SSE-streamed flows — `renderReportFooter()` now takes `ScanResult` and prepends the card, keeping one source of truth.

Implements V2 + V6 from the freemium monetization design doc. No new routes, no schema changes, no auth logic changes — the `?next`/`?prompt` query params are forward-compatible and ignored by today's `/auth/login` handler.

## Reviewer notes

- **DMarcus invariant preserved.** The 24px nav avatar uses `transform: scale(0.72)` on the full creature instead of `display: none` on `.creature-legs`. All three legs stay visible — the DMARC pun is not sacrificed for pixel tidiness.
- **CSS uses only existing `--clr-*` tokens** (light + dark). No new hex values.
- **SSE wiring.** `renderReportFooter()` was zero-arg. It now accepts `ScanResult` so the monitor card is part of the single footer fragment emitted in the SSE `done` event. Both call sites in `src/index.ts` (cached + fresh scan paths) pass `result` through.
- **`.claude/launch.json`** added so future Claude sessions can launch `wrangler dev` via preview instead of raw Bash.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` — 506 pass, including new coverage in `test/nav-link.test.ts` (landing nav + `navLoginButton`) and `test/components.test.ts` (`monitorSnapshotCard` with a `ScanResult` fixture: `+`/`·` marks, CTA href, domain escaping, p=none mutes the DMARC row)
- [x] `curl -s http://localhost:8790/` — pill visible in landing hero
- [x] `curl -s http://localhost:8790/check?domain=dmarc.mx&_direct=1` — monitor card rendered under MTA-STS
- [x] Streaming `/check?domain=dmarc.mx` — monitor card comes through the SSE done event
- [x] `/check/score?domain=dmarc.mx` — pill visible in breakdown nav
- [ ] Manual: dark/light toggle legibility, 360px-wide responsive check (reviewer — please spot-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)