### PR TITLE
🛡️ Sentinel: [HIGH] Fix Login CSRF vulnerability by adding OAuth state parameter

### DIFF
--- a/src/auth/routes.ts
+++ b/src/auth/routes.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { deleteCookie, setCookie } from "hono/cookie";
+import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 import { createDomain } from "../db/domains.js";
 import { createUser, getUserByEmail } from "../db/users.js";
 import { createSessionToken } from "./session.js";
@@ -11,11 +11,20 @@ authRoutes.get("/login", (c) => {
     WORKOS_CLIENT_ID: string;
     WORKOS_REDIRECT_URI: string;
   };
+  const state = crypto.randomUUID();
+  setCookie(c, "oauth_state", state, {
+    httpOnly: true,
+    secure: true,
+    sameSite: "Lax",
+    path: "/",
+    maxAge: 10 * 60, // 10 minutes
+  });
   const params = new URLSearchParams({
     client_id: env.WORKOS_CLIENT_ID,
     redirect_uri: env.WORKOS_REDIRECT_URI,
     response_type: "code",
     provider: "authkit",
+    state,
   });
   return c.redirect(
     `https://api.workos.com/user_management/authorize?${params}`,
@@ -27,6 +36,16 @@ authRoutes.get("/callback", async (c) => {
   if (!code) {
     return c.text("Missing authorization code", 400);
   }
+
+  const queryState = c.req.query("state");
+  const cookieState = getCookie(c, "oauth_state");
+
+  if (!queryState || !cookieState || queryState !== cookieState) {
+    return c.text("Invalid or missing state parameter", 400);
+  }
+
+  // Clear the state cookie after successful validation
+  deleteCookie(c, "oauth_state", { path: "/" });
 
   const env = c.env as {
     WORKOS_CLIENT_ID: string;

--- a/test/auth-routes.test.ts
+++ b/test/auth-routes.test.ts
@@ -61,6 +61,25 @@ describe("auth/routes", () => {
       const url = new URL(location);
       expect(url.searchParams.get("provider")).toBe("authkit");
     });
+
+    it("sets oauth_state cookie and includes state in authorization URL", async () => {
+      const app = createTestApp();
+      const res = await app.request("/auth/login", {}, ENV);
+
+      const setCookieHeader = res.headers.get("Set-Cookie");
+      expect(setCookieHeader).not.toBeNull();
+      expect(setCookieHeader).toMatch(/oauth_state=[a-f0-9-]+;/);
+
+      const cookieMatch = setCookieHeader?.match(/oauth_state=([a-f0-9-]+);/);
+      const cookieState = cookieMatch?.[1];
+      expect(cookieState).toBeDefined();
+
+      const location = res.headers.get("Location") as string;
+      const url = new URL(location);
+      const urlState = url.searchParams.get("state");
+      expect(urlState).toBeDefined();
+      expect(urlState).toBe(cookieState);
+    });
   });
 
   describe("GET /auth/callback", () => {
@@ -70,6 +89,35 @@ describe("auth/routes", () => {
       expect(res.status).toBe(400);
       const body = await res.text();
       expect(body).toBe("Missing authorization code");
+    });
+
+    it("returns 400 when state query param is missing", async () => {
+      const app = createTestApp();
+      const req = new Request("http://localhost/auth/callback?code=test-code");
+      req.headers.set("Cookie", "oauth_state=test-state");
+      const res = await app.request(req, ENV);
+      expect(res.status).toBe(400);
+      const body = await res.text();
+      expect(body).toBe("Invalid or missing state parameter");
+    });
+
+    it("returns 400 when oauth_state cookie is missing", async () => {
+      const app = createTestApp();
+      const req = new Request("http://localhost/auth/callback?code=test-code&state=test-state");
+      const res = await app.request(req, ENV);
+      expect(res.status).toBe(400);
+      const body = await res.text();
+      expect(body).toBe("Invalid or missing state parameter");
+    });
+
+    it("returns 400 when state values do not match", async () => {
+      const app = createTestApp();
+      const req = new Request("http://localhost/auth/callback?code=test-code&state=query-state");
+      req.headers.set("Cookie", "oauth_state=cookie-state");
+      const res = await app.request(req, ENV);
+      expect(res.status).toBe(400);
+      const body = await res.text();
+      expect(body).toBe("Invalid or missing state parameter");
     });
   });
 

--- a/test/auth-routes.test.ts
+++ b/test/auth-routes.test.ts
@@ -103,7 +103,9 @@ describe("auth/routes", () => {
 
     it("returns 400 when oauth_state cookie is missing", async () => {
       const app = createTestApp();
-      const req = new Request("http://localhost/auth/callback?code=test-code&state=test-state");
+      const req = new Request(
+        "http://localhost/auth/callback?code=test-code&state=test-state",
+      );
       const res = await app.request(req, ENV);
       expect(res.status).toBe(400);
       const body = await res.text();
@@ -112,7 +114,9 @@ describe("auth/routes", () => {
 
     it("returns 400 when state values do not match", async () => {
       const app = createTestApp();
-      const req = new Request("http://localhost/auth/callback?code=test-code&state=query-state");
+      const req = new Request(
+        "http://localhost/auth/callback?code=test-code&state=query-state",
+      );
       req.headers.set("Cookie", "oauth_state=cookie-state");
       const res = await app.request(req, ENV);
       expect(res.status).toBe(400);


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: The OAuth login flow via WorkOS did not implement a `state` parameter check. This allowed an attacker to potentially log a victim into the attacker's account (Login CSRF).
🎯 **Impact**: An attacker could capture their own authorization code, create a malicious link, and trick a victim into clicking it. The victim would be logged into the attacker's account, allowing the attacker to monitor or intercept data the victim inputs while believing they are on their own account.
🔧 **Fix**: Implemented the OAuth 2.0 `state` parameter mechanism. Generates a secure random UUID, stores it in an HTTP-only, secure cookie, sends it to WorkOS, and rigorously validates the returned `state` against the cookie upon the callback.
✅ **Verification**: Run `pnpm test` to verify the new test blocks in `test/auth-routes.test.ts` pass, specifically covering missing or mismatched state parameters.

---
*PR created automatically by Jules for task [1459888353412817728](https://jules.google.com/task/1459888353412817728) started by @schmug*