### PR TITLE
Phase 3d: per-plan rate limits

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import type {
 } from "./analyzers/types.js";
 import { API_CATALOG_JSON } from "./api/catalog.js";
 import { OPENAPI_JSON } from "./api/openapi.js";
-import { resolveBearer } from "./auth/api-key.js";
+import { type BearerIdentity, resolveBearer } from "./auth/api-key.js";
 import { authRoutes } from "./auth/routes.js";
 import { stripeWebhookRoutes } from "./billing/routes.js";
 import { getCachedScan, setCachedScan } from "./cache.js";
@@ -24,11 +24,17 @@ import { generateCsv } from "./csv.js";
 import { dashboardRoutes } from "./dashboard/routes.js";
 import { getDomainByUserAndName } from "./db/domains.js";
 import { recordScan } from "./db/scans.js";
+import { getPlanForUser } from "./db/subscriptions.js";
 import { setEmailAlertsEnabled } from "./db/users.js";
 import type { Env } from "./env.js";
 import type { ProtocolId, ProtocolResult } from "./orchestrator.js";
 import { scan, scanStreaming } from "./orchestrator.js";
-import { checkRateLimit, rateLimitHeaders } from "./rate-limit.js";
+import {
+  checkRateLimit,
+  getRateLimitConfig,
+  type RateLimitResult,
+  rateLimitHeaders,
+} from "./rate-limit.js";
 import { normalizeDomain } from "./shared/domain.js";
 import { CSS_PATH, JS_PATH } from "./views/assets.js";
 import {
@@ -238,23 +244,84 @@ function getClientIp(c: Context): string {
   return "unknown";
 }
 
-// Rate limit scan endpoints (not the landing page)
-app.use("/check", async (c, next) => {
-  const ip = getClientIp(c);
-  const { allowed, remaining, pendingWrite } = await checkRateLimit(ip);
-  if (pendingWrite) {
-    c.executionCtx.waitUntil(pendingWrite.catch(() => {}));
+// Resolves rate-limit identity + config for a request. Pro-authed bearers
+// lift to the per-user bucket (60/hour). Everyone else — anonymous callers,
+// bearers whose subscription isn't active, free-plan bearers — falls through
+// to the per-IP anon bucket (10/60s). Free-authed keeps on IP on purpose: a
+// free bearer hitting from two IPs gets two anon buckets, which matches what
+// anonymous scanners already see and avoids making a free account worse than
+// no account. Bearer identity is stashed on context so downstream handlers
+// (/api/check scan-history persistence) can read it without re-verifying.
+export async function resolveRateLimitScope(c: Context): Promise<{
+  identity: string;
+  config: ReturnType<typeof getRateLimitConfig>;
+}> {
+  const bearer = await resolveBearer(c);
+  if (bearer) {
+    c.set("bearer" as never, bearer);
+    const db = (c.env as { DB?: D1Database }).DB;
+    if (db) {
+      const plan = await getPlanForUser(db, bearer.userId);
+      if (plan === "pro") {
+        return {
+          identity: `user:${bearer.userId}`,
+          config: getRateLimitConfig("pro"),
+        };
+      }
+    }
   }
+  return {
+    identity: `ip:${getClientIp(c)}`,
+    config: getRateLimitConfig("free"),
+  };
+}
 
-  if (!allowed) {
-    const headers = rateLimitHeaders(remaining);
+type RateLimitBlockedResponder = (
+  c: Context,
+  result: RateLimitResult,
+  headers: Record<string, string>,
+) => Response | Promise<Response>;
+
+export function rateLimitMiddleware(onBlocked: RateLimitBlockedResponder) {
+  return async (c: Context, next: () => Promise<void>) => {
+    const { identity, config } = await resolveRateLimitScope(c);
+    const result = await checkRateLimit(identity, config);
+    if (result.pendingWrite) {
+      c.executionCtx.waitUntil(result.pendingWrite.catch(() => {}));
+    }
+
+    const headers = rateLimitHeaders(result);
+
+    if (!result.allowed) {
+      return onBlocked(c, result, headers);
+    }
+
+    await next();
+    // ⚡ Bolt Optimization: Use for...in instead of Object.entries() on hot paths.
+    // Avoids allocating an array of key-value tuples for headers on every request,
+    // reducing GC pressure for high-traffic middleware.
+    for (const key in headers) {
+      c.res.headers.set(key, headers[key]);
+    }
+  };
+}
+
+function blockedMessage(result: RateLimitResult): string {
+  const waitSec = Math.max(1, result.resetAt - Math.floor(Date.now() / 1000));
+  return `Rate limit exceeded. Try again in ${waitSec} seconds.`;
+}
+
+// Rate limit scan endpoints (not the landing page)
+app.use(
+  "/check",
+  rateLimitMiddleware((c, result, headers) => {
     const format = c.req.query("format");
     const wantsJson =
       format === "json" || c.req.header("Accept")?.includes("application/json");
 
     if (wantsJson || format === "csv") {
       return c.json(
-        { error: "Rate limit exceeded. Try again in 60 seconds." },
+        { error: blockedMessage(result) },
         { status: 429, headers },
       );
     }
@@ -264,88 +331,37 @@ app.use("/check", async (c, next) => {
       ),
       { status: 429, headers },
     );
-  }
+  }),
+);
 
-  const headers = rateLimitHeaders(remaining);
-  await next();
-  // ⚡ Bolt Optimization: Use for...in instead of Object.entries() on hot paths.
-  // Avoids allocating an array of key-value tuples for headers on every request,
-  // reducing GC pressure for high-traffic middleware.
-  for (const key in headers) {
-    c.res.headers.set(key, headers[key]);
-  }
-});
-
-app.use("/check/score", async (c, next) => {
-  const ip = getClientIp(c);
-  const { allowed, remaining, pendingWrite } = await checkRateLimit(ip);
-  if (pendingWrite) {
-    c.executionCtx.waitUntil(pendingWrite.catch(() => {}));
-  }
-
-  if (!allowed) {
-    const headers = rateLimitHeaders(remaining);
-    return c.html(
+app.use(
+  "/check/score",
+  rateLimitMiddleware((_c, _result, headers) =>
+    _c.html(
       renderError(
         "Rate limit exceeded. Please wait a minute before scanning again.",
       ),
       { status: 429, headers },
-    );
-  }
+    ),
+  ),
+);
 
-  const headers = rateLimitHeaders(remaining);
-  await next();
-  for (const key in headers) {
-    c.res.headers.set(key, headers[key]);
-  }
-});
-
-app.use("/api/check", async (c, next) => {
-  const ip = getClientIp(c);
-  const { allowed, remaining, pendingWrite } = await checkRateLimit(ip);
-  if (pendingWrite) {
-    c.executionCtx.waitUntil(pendingWrite.catch(() => {}));
-  }
-
-  if (!allowed) {
-    const headers = rateLimitHeaders(remaining);
-    return c.json(
-      { error: "Rate limit exceeded. Try again in 60 seconds." },
-      { status: 429, headers },
-    );
-  }
-
-  const headers = rateLimitHeaders(remaining);
-  await next();
-  for (const key in headers) {
-    c.res.headers.set(key, headers[key]);
-  }
-});
+app.use(
+  "/api/check",
+  rateLimitMiddleware((c, result, headers) =>
+    c.json({ error: blockedMessage(result) }, { status: 429, headers }),
+  ),
+);
 
 // The SSE streaming endpoint fans out ~50 DNS lookups per request and is
 // bypassed by the `/api/check` middleware above (Hono matches exact paths).
 // Give it its own limiter so it cannot be used as a DNS amplification vector.
-app.use("/api/check/stream", async (c, next) => {
-  const ip = getClientIp(c);
-  const { allowed, remaining, pendingWrite } = await checkRateLimit(ip);
-  if (pendingWrite) {
-    c.executionCtx.waitUntil(pendingWrite.catch(() => {}));
-  }
-
-  if (!allowed) {
-    const headers = rateLimitHeaders(remaining);
-    return c.json(
-      { error: "Rate limit exceeded. Try again in 60 seconds." },
-      { status: 429, headers },
-    );
-  }
-
-  const headers = rateLimitHeaders(remaining);
-  await next();
-  for (const key in headers) {
-    c.res.headers.set(key, headers[key]);
-  }
-});
+app.use(
+  "/api/check/stream",
+  rateLimitMiddleware((c, result, headers) =>
+    c.json({ error: blockedMessage(result) }, { status: 429, headers }),
+  ),
+);
 
 const protocolRenderers: Record<
   ProtocolId,
@@ -376,7 +392,8 @@ app.get("/api/check/stream", async (c) => {
   }
 
   const selectors = parseSelectors(c.req.query("selectors"));
-  const bearer = await resolveBearer(c);
+  const bearer =
+    (c.get("bearer" as never) as BearerIdentity | undefined) ?? null;
 
   return streamSSE(c, async (stream) => {
     Sentry.addBreadcrumb({
@@ -678,7 +695,8 @@ app.get("/api/check", async (c) => {
   }
 
   const selectors = parseSelectors(c.req.query("selectors"));
-  const bearer = await resolveBearer(c);
+  const bearer =
+    (c.get("bearer" as never) as BearerIdentity | undefined) ?? null;
 
   try {
     Sentry.addBreadcrumb({

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -1,48 +1,104 @@
-const LIMIT = 10;
-const WINDOW_SECONDS = 60;
+export interface RateLimitConfig {
+  limit: number;
+  windowSec: number;
+}
 
-// In-memory fallback for local dev where caches.default is unavailable
-const memoryStore = new Map<string, { count: number; expires: number }>();
+export interface RateLimitResult {
+  allowed: boolean;
+  remaining: number;
+  limit: number;
+  windowSec: number;
+  resetAt: number;
+  pendingWrite?: Promise<void>;
+}
+
+export type PlanTier = "free" | "pro";
+
+const FREE_CONFIG: RateLimitConfig = { limit: 10, windowSec: 60 };
+const PRO_CONFIG: RateLimitConfig = { limit: 60, windowSec: 3600 };
+
+export function getRateLimitConfig(plan: PlanTier): RateLimitConfig {
+  return plan === "pro" ? PRO_CONFIG : FREE_CONFIG;
+}
+
+interface MemoryEntry {
+  count: number;
+  expires: number;
+  resetAt: number;
+}
+
+const memoryStore = new Map<string, MemoryEntry>();
 let callCount = 0;
 const SWEEP_INTERVAL = 100;
 
-export async function checkRateLimit(ip: string): Promise<{
-  allowed: boolean;
-  remaining: number;
-  pendingWrite?: Promise<void>;
-}> {
+export async function checkRateLimit(
+  identity: string,
+  config: RateLimitConfig,
+): Promise<RateLimitResult> {
   try {
     if (typeof caches !== "undefined" && caches.default) {
-      return await checkRateLimitCache(ip);
+      return await checkRateLimitCache(identity, config);
     }
   } catch {
     // Cache API unavailable — fall through to in-memory
   }
-  return checkRateLimitMemory(ip);
+  return checkRateLimitMemory(identity, config);
 }
 
-async function checkRateLimitCache(ip: string): Promise<{
-  allowed: boolean;
-  remaining: number;
-  pendingWrite?: Promise<void>;
-}> {
+interface StoredPayload {
+  count: number;
+  resetAt: number;
+}
+
+function parseStoredPayload(raw: string): StoredPayload | null {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      typeof (parsed as StoredPayload).count === "number" &&
+      typeof (parsed as StoredPayload).resetAt === "number"
+    ) {
+      return parsed as StoredPayload;
+    }
+  } catch {
+    // Legacy integer-only bodies from a previous deploy won't parse as JSON.
+    // Treat them as a fresh window — worst case a caller gets one extra
+    // quota bucket during the seconds it takes for the old entry to age out.
+  }
+  return null;
+}
+
+async function checkRateLimitCache(
+  identity: string,
+  config: RateLimitConfig,
+): Promise<RateLimitResult> {
   const cache = caches.default;
-  const key = new Request(`https://dmarc-mx-ratelimit.internal/${ip}`);
+  const key = new Request(
+    `https://dmarc-mx-ratelimit.internal/${encodeURIComponent(identity)}`,
+  );
 
   const cached = await cache.match(key);
+  const nowSec = Math.floor(Date.now() / 1000);
   let count = 0;
+  let resetAt = nowSec + config.windowSec;
 
   if (cached) {
-    count = parseInt(await cached.text(), 10) || 0;
+    const stored = parseStoredPayload(await cached.text());
+    if (stored && stored.resetAt > nowSec) {
+      count = stored.count;
+      resetAt = stored.resetAt;
+    }
   }
 
   count++;
-  const allowed = count <= LIMIT;
-  const remaining = Math.max(0, LIMIT - count);
+  const allowed = count <= config.limit;
+  const remaining = Math.max(0, config.limit - count);
+  const ttl = Math.max(1, resetAt - nowSec);
 
-  const response = new Response(String(count), {
+  const response = new Response(JSON.stringify({ count, resetAt }), {
     headers: {
-      "Cache-Control": `s-maxage=${WINDOW_SECONDS}`,
+      "Cache-Control": `s-maxage=${ttl}`,
     },
   });
   // ⚡ Bolt Optimization: Do not await cache.put on the critical path.
@@ -50,14 +106,22 @@ async function checkRateLimitCache(ip: string): Promise<{
   // removing Cache API write latency from every rate-limited request.
   const pendingWrite = cache.put(key, response);
 
-  return { allowed, remaining, pendingWrite };
+  return {
+    allowed,
+    remaining,
+    limit: config.limit,
+    windowSec: config.windowSec,
+    resetAt,
+    pendingWrite,
+  };
 }
 
-function checkRateLimitMemory(ip: string): {
-  allowed: boolean;
-  remaining: number;
-} {
+function checkRateLimitMemory(
+  identity: string,
+  config: RateLimitConfig,
+): RateLimitResult {
   const now = Date.now();
+  const nowSec = Math.floor(now / 1000);
 
   if (++callCount >= SWEEP_INTERVAL) {
     callCount = 0;
@@ -66,39 +130,54 @@ function checkRateLimitMemory(ip: string): {
     }
   }
 
-  const entry = memoryStore.get(ip);
+  const entry = memoryStore.get(identity);
 
   let count: number;
+  let resetAt: number;
   if (entry && entry.expires > now) {
     count = entry.count + 1;
+    resetAt = entry.resetAt;
   } else {
     count = 1;
+    resetAt = nowSec + config.windowSec;
   }
 
-  memoryStore.set(ip, { count, expires: now + WINDOW_SECONDS * 1000 });
+  memoryStore.set(identity, {
+    count,
+    expires: now + config.windowSec * 1000,
+    resetAt,
+  });
 
-  const allowed = count <= LIMIT;
-  const remaining = Math.max(0, LIMIT - count);
-  return { allowed, remaining };
-}
-
-export function rateLimitHeaders(remaining: number): Record<string, string> {
+  const allowed = count <= config.limit;
+  const remaining = Math.max(0, config.limit - count);
   return {
-    "X-RateLimit-Limit": String(LIMIT),
-    "X-RateLimit-Remaining": String(remaining),
-    "X-RateLimit-Window": `${WINDOW_SECONDS}s`,
+    allowed,
+    remaining,
+    limit: config.limit,
+    windowSec: config.windowSec,
+    resetAt,
   };
 }
 
-// Exported for testing only
+export function rateLimitHeaders(
+  result: RateLimitResult,
+): Record<string, string> {
+  return {
+    "X-RateLimit-Limit": String(result.limit),
+    "X-RateLimit-Remaining": String(result.remaining),
+    "X-RateLimit-Window": `${result.windowSec}s`,
+    "X-RateLimit-Reset": String(result.resetAt),
+  };
+}
+
 function _resetCallCount() {
   callCount = 0;
 }
 
 export {
   _resetCallCount,
-  LIMIT as _LIMIT,
+  FREE_CONFIG as _FREE_CONFIG,
   memoryStore as _memoryStore,
+  PRO_CONFIG as _PRO_CONFIG,
   SWEEP_INTERVAL as _SWEEP_INTERVAL,
-  WINDOW_SECONDS as _WINDOW_SECONDS,
 };

--- a/test/rate-limit-middleware.test.ts
+++ b/test/rate-limit-middleware.test.ts
@@ -1,0 +1,240 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetApiKeyTouchCache,
+  generateApiKey,
+} from "../src/auth/api-key.js";
+import { _memoryStore, _resetCallCount } from "../src/rate-limit.js";
+
+// Small Hono test rig around the real rateLimitMiddleware.
+interface Fixture {
+  apiKeyRaw: string;
+  apiKeyHash: string;
+  subscriptionStatus: string | null; // null = no row
+  keyRevoked?: boolean;
+}
+
+function makeMockDb(fixture: Fixture): D1Database {
+  const prepare = (sql: string) => ({
+    bind: (...params: unknown[]) => ({
+      first: async <T>(): Promise<T | null> => {
+        if (sql.includes("FROM api_keys WHERE hash")) {
+          const hash = params[0] as string;
+          if (hash === fixture.apiKeyHash && !fixture.keyRevoked) {
+            return { id: "k1", user_id: "u42" } as T;
+          }
+          return null;
+        }
+        if (sql.includes("FROM subscriptions WHERE user_id")) {
+          if (fixture.subscriptionStatus === null) return null;
+          return { status: fixture.subscriptionStatus } as T;
+        }
+        return null;
+      },
+      run: async () => ({ success: true, meta: { changes: 0 } }),
+    }),
+  });
+  return { prepare } as unknown as D1Database;
+}
+
+async function buildApp() {
+  // Import inside the helper so module-level state can be reset per test.
+  const { rateLimitMiddleware } = await import("../src/index.js");
+  const app = new Hono();
+  app.use(
+    "/ping",
+    rateLimitMiddleware((c, result, headers) =>
+      c.json({ error: "limited", resetAt: result.resetAt }, 429, headers),
+    ),
+  );
+  app.get("/ping", (c) => {
+    const bearer = c.get("bearer" as never) as { userId: string } | undefined;
+    return c.json({ ok: true, bearerUser: bearer?.userId ?? null });
+  });
+  return app;
+}
+
+interface Dispatch {
+  ip: string;
+  bearer?: string;
+}
+
+async function dispatch(
+  app: Hono,
+  db: D1Database,
+  { ip, bearer }: Dispatch,
+): Promise<Response> {
+  const headers: Record<string, string> = { "CF-Connecting-IP": ip };
+  if (bearer) headers.Authorization = `Bearer ${bearer}`;
+  const req = new Request("http://local/ping", { headers });
+  return app.fetch(
+    req,
+    { DB: db } as unknown as Record<string, unknown>,
+    {
+      waitUntil: () => {},
+      passThroughOnException: () => {},
+    } as ExecutionContext,
+  );
+}
+
+describe("rateLimitMiddleware", () => {
+  beforeEach(() => {
+    _memoryStore.clear();
+    _resetCallCount();
+    __resetApiKeyTouchCache();
+    vi.stubGlobal("caches", undefined);
+  });
+
+  it("anon IP bucket blocks after 10 requests", async () => {
+    const app = await buildApp();
+    const db = makeMockDb({
+      apiKeyRaw: "",
+      apiKeyHash: "",
+      subscriptionStatus: null,
+    });
+
+    for (let i = 0; i < 10; i++) {
+      const res = await dispatch(app, db, { ip: "1.2.3.4" });
+      expect(res.status).toBe(200);
+    }
+    const blocked = await dispatch(app, db, { ip: "1.2.3.4" });
+    expect(blocked.status).toBe(429);
+    expect(blocked.headers.get("X-RateLimit-Limit")).toBe("10");
+    expect(blocked.headers.get("X-RateLimit-Window")).toBe("60s");
+    const resetAt = Number(blocked.headers.get("X-RateLimit-Reset"));
+    expect(resetAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
+  });
+
+  it("pro bearer allows 60 and blocks the 61st", async () => {
+    const { raw, hash } = await generateApiKey();
+    const app = await buildApp();
+    const db = makeMockDb({
+      apiKeyRaw: raw,
+      apiKeyHash: hash,
+      subscriptionStatus: "active",
+    });
+
+    for (let i = 0; i < 60; i++) {
+      const res = await dispatch(app, db, { ip: "1.2.3.4", bearer: raw });
+      expect(res.status).toBe(200);
+      expect(res.headers.get("X-RateLimit-Limit")).toBe("60");
+      expect(res.headers.get("X-RateLimit-Window")).toBe("3600s");
+    }
+    const blocked = await dispatch(app, db, { ip: "1.2.3.4", bearer: raw });
+    expect(blocked.status).toBe(429);
+    expect(blocked.headers.get("X-RateLimit-Remaining")).toBe("0");
+    expect(Number(blocked.headers.get("X-RateLimit-Reset"))).toBeGreaterThan(
+      Math.floor(Date.now() / 1000),
+    );
+  });
+
+  it("trialing and past_due statuses are also treated as pro", async () => {
+    const { raw, hash } = await generateApiKey();
+    const app = await buildApp();
+
+    for (const status of ["trialing", "past_due"]) {
+      _memoryStore.clear();
+      const db = makeMockDb({
+        apiKeyRaw: raw,
+        apiKeyHash: hash,
+        subscriptionStatus: status,
+      });
+      const res = await dispatch(app, db, { ip: "1.2.3.4", bearer: raw });
+      expect(res.status).toBe(200);
+      expect(res.headers.get("X-RateLimit-Limit")).toBe("60");
+    }
+  });
+
+  it("canceled subscription drops back to anon (10) limit", async () => {
+    const { raw, hash } = await generateApiKey();
+    const app = await buildApp();
+    const db = makeMockDb({
+      apiKeyRaw: raw,
+      apiKeyHash: hash,
+      subscriptionStatus: "canceled",
+    });
+
+    for (let i = 0; i < 10; i++) {
+      const res = await dispatch(app, db, { ip: "1.2.3.4", bearer: raw });
+      expect(res.status).toBe(200);
+      expect(res.headers.get("X-RateLimit-Limit")).toBe("10");
+    }
+    const blocked = await dispatch(app, db, { ip: "1.2.3.4", bearer: raw });
+    expect(blocked.status).toBe(429);
+  });
+
+  it("free-plan bearer (no subscription row) uses per-IP bucket, so a second IP gets its own quota", async () => {
+    const { raw, hash } = await generateApiKey();
+    const app = await buildApp();
+    const db = makeMockDb({
+      apiKeyRaw: raw,
+      apiKeyHash: hash,
+      subscriptionStatus: null,
+    });
+
+    for (let i = 0; i < 10; i++) {
+      const res = await dispatch(app, db, { ip: "1.1.1.1", bearer: raw });
+      expect(res.status).toBe(200);
+    }
+    const blockedFromIp1 = await dispatch(app, db, {
+      ip: "1.1.1.1",
+      bearer: raw,
+    });
+    expect(blockedFromIp1.status).toBe(429);
+
+    // Same free bearer from a different IP starts fresh — documented semantics.
+    const freshFromIp2 = await dispatch(app, db, {
+      ip: "2.2.2.2",
+      bearer: raw,
+    });
+    expect(freshFromIp2.status).toBe(200);
+    expect(freshFromIp2.headers.get("X-RateLimit-Limit")).toBe("10");
+  });
+
+  it("revoked key falls through to anon per-IP bucket and leaves bearer unset", async () => {
+    const { raw, hash } = await generateApiKey();
+    const app = await buildApp();
+    const db = makeMockDb({
+      apiKeyRaw: raw,
+      apiKeyHash: hash,
+      subscriptionStatus: "active",
+      keyRevoked: true,
+    });
+
+    const res = await dispatch(app, db, { ip: "9.9.9.9", bearer: raw });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("10");
+    const body = (await res.json()) as { bearerUser: string | null };
+    expect(body.bearerUser).toBeNull();
+  });
+
+  it("pro bearer populates c.get('bearer') for downstream handlers", async () => {
+    const { raw, hash } = await generateApiKey();
+    const app = await buildApp();
+    const db = makeMockDb({
+      apiKeyRaw: raw,
+      apiKeyHash: hash,
+      subscriptionStatus: "active",
+    });
+
+    const res = await dispatch(app, db, { ip: "1.2.3.4", bearer: raw });
+    const body = (await res.json()) as { bearerUser: string | null };
+    expect(body.bearerUser).toBe("u42");
+  });
+
+  it("malformed bearer is ignored and request falls through to anon", async () => {
+    const app = await buildApp();
+    const db = makeMockDb({
+      apiKeyRaw: "",
+      apiKeyHash: "",
+      subscriptionStatus: null,
+    });
+
+    const res = await dispatch(app, db, {
+      ip: "1.2.3.4",
+      bearer: "not-a-dmk-key",
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("10");
+  });
+});

--- a/test/rate-limit.test.ts
+++ b/test/rate-limit.test.ts
@@ -1,75 +1,147 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  _LIMIT,
+  _FREE_CONFIG,
   _memoryStore,
+  _PRO_CONFIG,
   _resetCallCount,
   _SWEEP_INTERVAL,
-  _WINDOW_SECONDS,
   checkRateLimit,
+  getRateLimitConfig,
   rateLimitHeaders,
 } from "../src/rate-limit.js";
+
+const FREE = _FREE_CONFIG;
+const PRO = _PRO_CONFIG;
 
 describe("rate-limit", () => {
   beforeEach(() => {
     _memoryStore.clear();
     _resetCallCount();
-    // Ensure caches.default is not available so we hit the in-memory path
     vi.stubGlobal("caches", undefined);
   });
 
-  describe("in-memory fallback (checkRateLimit)", () => {
+  describe("getRateLimitConfig", () => {
+    it("returns the anon bucket for free", () => {
+      expect(getRateLimitConfig("free")).toEqual({ limit: 10, windowSec: 60 });
+    });
+
+    it("returns the pro bucket", () => {
+      expect(getRateLimitConfig("pro")).toEqual({ limit: 60, windowSec: 3600 });
+    });
+  });
+
+  describe("in-memory fallback — free config (anon path, unchanged)", () => {
     it("allows first request and returns correct remaining count", async () => {
-      const result = await checkRateLimit("1.2.3.4");
+      const result = await checkRateLimit("ip:1.2.3.4", FREE);
       expect(result.allowed).toBe(true);
-      expect(result.remaining).toBe(_LIMIT - 1);
+      expect(result.remaining).toBe(FREE.limit - 1);
+      expect(result.limit).toBe(FREE.limit);
+      expect(result.windowSec).toBe(FREE.windowSec);
     });
 
-    it("allows up to LIMIT requests", async () => {
-      for (let i = 1; i <= _LIMIT; i++) {
-        const result = await checkRateLimit("1.2.3.4");
+    it("allows up to the limit", async () => {
+      for (let i = 1; i <= FREE.limit; i++) {
+        const result = await checkRateLimit("ip:1.2.3.4", FREE);
         expect(result.allowed).toBe(true);
-        expect(result.remaining).toBe(_LIMIT - i);
+        expect(result.remaining).toBe(FREE.limit - i);
       }
     });
 
-    it("blocks request LIMIT+1", async () => {
-      for (let i = 0; i < _LIMIT; i++) {
-        await checkRateLimit("1.2.3.4");
+    it("blocks the limit+1 request", async () => {
+      for (let i = 0; i < FREE.limit; i++) {
+        await checkRateLimit("ip:1.2.3.4", FREE);
       }
-      const result = await checkRateLimit("1.2.3.4");
+      const result = await checkRateLimit("ip:1.2.3.4", FREE);
       expect(result.allowed).toBe(false);
       expect(result.remaining).toBe(0);
     });
 
-    it("tracks IPs independently", async () => {
-      for (let i = 0; i < _LIMIT; i++) {
-        await checkRateLimit("1.2.3.4");
+    it("tracks identities independently", async () => {
+      for (let i = 0; i < FREE.limit; i++) {
+        await checkRateLimit("ip:1.2.3.4", FREE);
       }
-      const blocked = await checkRateLimit("1.2.3.4");
+      const blocked = await checkRateLimit("ip:1.2.3.4", FREE);
       expect(blocked.allowed).toBe(false);
 
-      const different = await checkRateLimit("5.6.7.8");
+      const different = await checkRateLimit("ip:5.6.7.8", FREE);
       expect(different.allowed).toBe(true);
-      expect(different.remaining).toBe(_LIMIT - 1);
+      expect(different.remaining).toBe(FREE.limit - 1);
+    });
+
+    it("keeps `user:X` and `ip:X` in separate buckets", async () => {
+      // Pathological: a user id that collides with an IP string must not share
+      // a counter with that IP. The prefix makes the keys globally distinct.
+      for (let i = 0; i < FREE.limit; i++) {
+        await checkRateLimit("ip:abc", FREE);
+      }
+      const ipBlocked = await checkRateLimit("ip:abc", FREE);
+      expect(ipBlocked.allowed).toBe(false);
+
+      const userFresh = await checkRateLimit("user:abc", FREE);
+      expect(userFresh.allowed).toBe(true);
+      expect(userFresh.remaining).toBe(FREE.limit - 1);
     });
 
     it("resets count after window expires", async () => {
       vi.useFakeTimers();
 
-      for (let i = 0; i < _LIMIT; i++) {
-        await checkRateLimit("1.2.3.4");
+      for (let i = 0; i < FREE.limit; i++) {
+        await checkRateLimit("ip:1.2.3.4", FREE);
       }
-      const blocked = await checkRateLimit("1.2.3.4");
+      const blocked = await checkRateLimit("ip:1.2.3.4", FREE);
       expect(blocked.allowed).toBe(false);
 
-      // Advance past the window
-      vi.advanceTimersByTime(_WINDOW_SECONDS * 1000 + 1);
+      vi.advanceTimersByTime(FREE.windowSec * 1000 + 1);
 
-      const afterExpiry = await checkRateLimit("1.2.3.4");
+      const afterExpiry = await checkRateLimit("ip:1.2.3.4", FREE);
       expect(afterExpiry.allowed).toBe(true);
-      expect(afterExpiry.remaining).toBe(_LIMIT - 1);
+      expect(afterExpiry.remaining).toBe(FREE.limit - 1);
 
       vi.useRealTimers();
+    });
+  });
+
+  describe("in-memory fallback — pro config", () => {
+    it("allows 60 requests and blocks the 61st", async () => {
+      for (let i = 1; i <= PRO.limit; i++) {
+        const result = await checkRateLimit("user:u1", PRO);
+        expect(result.allowed).toBe(true);
+        expect(result.remaining).toBe(PRO.limit - i);
+      }
+      const blocked = await checkRateLimit("user:u1", PRO);
+      expect(blocked.allowed).toBe(false);
+      expect(blocked.remaining).toBe(0);
+      expect(blocked.limit).toBe(60);
+      expect(blocked.windowSec).toBe(3600);
+    });
+
+    it("rolls the window at 3600s", async () => {
+      vi.useFakeTimers();
+      for (let i = 0; i < PRO.limit; i++) {
+        await checkRateLimit("user:u1", PRO);
+      }
+      const blocked = await checkRateLimit("user:u1", PRO);
+      expect(blocked.allowed).toBe(false);
+
+      vi.advanceTimersByTime(PRO.windowSec * 1000 + 1);
+
+      const afterExpiry = await checkRateLimit("user:u1", PRO);
+      expect(afterExpiry.allowed).toBe(true);
+      expect(afterExpiry.remaining).toBe(PRO.limit - 1);
+      vi.useRealTimers();
+    });
+
+    it("returns a resetAt in the future", async () => {
+      const before = Math.floor(Date.now() / 1000);
+      const result = await checkRateLimit("user:u1", PRO);
+      expect(result.resetAt).toBeGreaterThanOrEqual(before + PRO.windowSec - 1);
+      expect(result.resetAt).toBeLessThanOrEqual(before + PRO.windowSec + 1);
+    });
+
+    it("keeps resetAt stable within a single window", async () => {
+      const first = await checkRateLimit("user:u1", PRO);
+      const second = await checkRateLimit("user:u1", PRO);
+      expect(second.resetAt).toBe(first.resetAt);
     });
   });
 
@@ -77,14 +149,12 @@ describe("rate-limit", () => {
     it("removes expired entries after SWEEP_INTERVAL calls", async () => {
       vi.useFakeTimers();
 
-      // Seed expired entries from other IPs
       const past = Date.now() - 1;
-      _memoryStore.set("stale-1", { count: 5, expires: past });
-      _memoryStore.set("stale-2", { count: 3, expires: past });
+      _memoryStore.set("stale-1", { count: 5, expires: past, resetAt: 0 });
+      _memoryStore.set("stale-2", { count: 3, expires: past, resetAt: 0 });
 
-      // Make SWEEP_INTERVAL calls to trigger the sweep
       for (let i = 0; i < _SWEEP_INTERVAL; i++) {
-        await checkRateLimit(`10.0.0.${i % 256}`);
+        await checkRateLimit(`ip:10.0.0.${i % 256}`, FREE);
       }
 
       expect(_memoryStore.has("stale-1")).toBe(false);
@@ -98,11 +168,15 @@ describe("rate-limit", () => {
 
       const past = Date.now() - 1;
       const future = Date.now() + 60_000;
-      _memoryStore.set("stale", { count: 5, expires: past });
-      _memoryStore.set("active", { count: 2, expires: future });
+      _memoryStore.set("stale", { count: 5, expires: past, resetAt: 0 });
+      _memoryStore.set("active", {
+        count: 2,
+        expires: future,
+        resetAt: Math.floor(future / 1000),
+      });
 
       for (let i = 0; i < _SWEEP_INTERVAL; i++) {
-        await checkRateLimit(`10.0.0.${i % 256}`);
+        await checkRateLimit(`ip:10.0.0.${i % 256}`, FREE);
       }
 
       expect(_memoryStore.has("stale")).toBe(false);
@@ -116,11 +190,10 @@ describe("rate-limit", () => {
       vi.useFakeTimers();
 
       const past = Date.now() - 1;
-      _memoryStore.set("stale", { count: 5, expires: past });
+      _memoryStore.set("stale", { count: 5, expires: past, resetAt: 0 });
 
-      // Make fewer calls than the interval
       for (let i = 0; i < _SWEEP_INTERVAL - 1; i++) {
-        await checkRateLimit(`10.0.0.${i % 256}`);
+        await checkRateLimit(`ip:10.0.0.${i % 256}`, FREE);
       }
 
       expect(_memoryStore.has("stale")).toBe(true);
@@ -130,15 +203,32 @@ describe("rate-limit", () => {
   });
 
   describe("rateLimitHeaders", () => {
-    it("returns correct header values", () => {
-      const headers = rateLimitHeaders(7);
-      expect(headers["X-RateLimit-Limit"]).toBe(String(_LIMIT));
-      expect(headers["X-RateLimit-Remaining"]).toBe("7");
-      expect(headers["X-RateLimit-Window"]).toBe(`${_WINDOW_SECONDS}s`);
+    it("returns all four headers including X-RateLimit-Reset", async () => {
+      const result = await checkRateLimit("ip:1.2.3.4", FREE);
+      const headers = rateLimitHeaders(result);
+      expect(headers["X-RateLimit-Limit"]).toBe(String(FREE.limit));
+      expect(headers["X-RateLimit-Remaining"]).toBe(String(FREE.limit - 1));
+      expect(headers["X-RateLimit-Window"]).toBe(`${FREE.windowSec}s`);
+      expect(Number(headers["X-RateLimit-Reset"])).toBe(result.resetAt);
+      expect(Number(headers["X-RateLimit-Reset"])).toBeGreaterThan(
+        Math.floor(Date.now() / 1000),
+      );
     });
 
-    it("returns 0 remaining when exhausted", () => {
-      const headers = rateLimitHeaders(0);
+    it("reports the pro window for pro results", async () => {
+      const result = await checkRateLimit("user:u1", PRO);
+      const headers = rateLimitHeaders(result);
+      expect(headers["X-RateLimit-Limit"]).toBe("60");
+      expect(headers["X-RateLimit-Window"]).toBe("3600s");
+    });
+
+    it("returns 0 remaining when exhausted", async () => {
+      for (let i = 0; i < FREE.limit + 1; i++) {
+        await checkRateLimit("ip:1.2.3.4", FREE);
+      }
+      const result = await checkRateLimit("ip:1.2.3.4", FREE);
+      expect(result.remaining).toBe(0);
+      const headers = rateLimitHeaders(result);
       expect(headers["X-RateLimit-Remaining"]).toBe("0");
     });
   });


### PR DESCRIPTION
## Summary

- Pro-authed bearers (valid API key + active/trialing/past_due Stripe subscription) lift to **60 req / 3600 s** keyed on `user:<id>`. Anonymous callers stay at **10 req / 60 s** keyed on `ip:<addr>`.
- Free-authed and revoked bearers fall through to the anon per-IP bucket on purpose — upgrading to Pro is the only way to get the user bucket.
- Extracts a shared `rateLimitMiddleware()` factory; the four `/check`, `/check/score`, `/api/check`, `/api/check/stream` middleware blocks collapse into one. Bearer is resolved once and stashed on context; handlers now read `c.get("bearer")` instead of re-verifying.
- Adds `X-RateLimit-Reset` (unix seconds) alongside the existing `X-RateLimit-Limit / -Remaining / -Window`.

Builds on #149 (hashed API keys + `resolveBearer`) and consumes `getPlanForUser` from #145 unchanged. Closes M3 from `docs/HANDOFF.md`.

## Implementation notes

- `checkRateLimit(identity, config)` replaces the IP-only signature. Cache payload is now JSON `{count, resetAt}` so the window can be variable. Legacy integer-only cache bodies from a warm deploy parse as null and are treated as a fresh window — worst case one caller gets 2× quota during the seconds the old entry ages out.
- Free-authed keying on IP is documented in code above `resolveRateLimitScope`. A free bearer hitting from two IPs gets two separate 10/60 buckets — intentional, matches what anonymous scanners already see.

## Test plan

- [x] `npm test` — 561 tests pass (21 new across `test/rate-limit.test.ts` + `test/rate-limit-middleware.test.ts`)
- [x] `npm run lint` — biome clean
- [x] `npm run typecheck` — tsc clean
- [ ] Manual smoke on preview deploy: anon `/api/check` returns `X-RateLimit-Limit: 10, Window: 60s, Reset: <now+60>`; a Pro bearer gets `Limit: 60, Window: 3600s`; a canceled-sub bearer drops back to 10.

## Out of scope

History/monitoring/bulk UI (M4), email alerts rework (M5), rate-limit override column for manual bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)