### PR TITLE
Phase 4a: scan history view (Pro-gated)

### DIFF
--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -14,7 +14,7 @@ import {
   getDomainByUserAndName,
   getDomainsByUser,
 } from "../db/domains.js";
-import { recordScan } from "../db/scans.js";
+import { getScanHistoryWithProtocols, recordScan } from "../db/scans.js";
 import { getPlanForUser } from "../db/subscriptions.js";
 import {
   acknowledgeApiKeyRetirement,
@@ -28,9 +28,13 @@ import {
   renderApiKeysPage,
   renderDashboardPage,
   renderDomainDetailPage,
+  renderDomainHistoryPage,
   renderSettingsPage,
   toApiKeyListEntry,
 } from "../views/dashboard.js";
+
+const HISTORY_LIMIT_PRO = 30;
+const HISTORY_LIMIT_FREE = 5;
 
 export const dashboardRoutes = new Hono();
 
@@ -131,6 +135,36 @@ dashboardRoutes.get("/domain/:domain", async (c) => {
       scanHistory: history.results.map((r) => ({
         date: new Date(r.scanned_at * 1000).toLocaleDateString(),
         grade: r.grade,
+      })),
+    }),
+  );
+});
+
+// Full scan history for a domain. Pro users see up to 30 entries with a
+// sparkline + protocol-drift matrix; free users get a 5-entry teaser + an
+// upgrade CTA. Route is not hidden for free users — we gate the payload, not
+// the URL, so the upgrade prompt has somewhere to land.
+dashboardRoutes.get("/domain/:domain/history", async (c) => {
+  const session = c.get("user" as never) as SessionPayload;
+  const db = (c.env as { DB: D1Database }).DB;
+  const domainName = c.req.param("domain");
+  const domain = await getDomainByUserAndName(db, session.sub, domainName);
+  if (!domain) {
+    return c.text("Domain not found", 404);
+  }
+  const plan = await getPlanForUser(db, session.sub);
+  const limit = plan === "pro" ? HISTORY_LIMIT_PRO : HISTORY_LIMIT_FREE;
+  const rows = await getScanHistoryWithProtocols(db, domain.id, limit);
+  return c.html(
+    renderDomainHistoryPage({
+      email: session.email,
+      domain: domain.domain,
+      plan,
+      history: rows.map((row) => ({
+        date: new Date(row.scannedAt * 1000).toLocaleDateString(),
+        scannedAt: row.scannedAt,
+        grade: row.grade,
+        protocols: row.protocols,
       })),
     }),
   );

--- a/src/db/scans.ts
+++ b/src/db/scans.ts
@@ -60,3 +60,62 @@ export async function getScanHistory(
     .all<ScanHistoryRow>();
   return result.results;
 }
+
+export type ProtocolStatus = "pass" | "warn" | "fail" | "info" | null;
+
+export interface ScanHistoryWithProtocols {
+  grade: string;
+  scannedAt: number;
+  protocols: {
+    dmarc: ProtocolStatus;
+    spf: ProtocolStatus;
+    dkim: ProtocolStatus;
+    bimi: ProtocolStatus;
+    mta_sts: ProtocolStatus;
+  };
+}
+
+function asStatus(value: unknown): ProtocolStatus {
+  return value === "pass" ||
+    value === "warn" ||
+    value === "fail" ||
+    value === "info"
+    ? value
+    : null;
+}
+
+// Parses the JSON blob in `protocol_results` into a flat per-protocol status
+// map so history views don't have to reach into the orchestrator shape. Any
+// protocol missing or unparseable is returned as null — the view renders that
+// as "—" rather than failing the whole row.
+export async function getScanHistoryWithProtocols(
+  db: D1Database,
+  domainId: number,
+  limit: number,
+): Promise<ScanHistoryWithProtocols[]> {
+  const rows = await getScanHistory(db, domainId, limit);
+  return rows.map((row) => {
+    let parsed: Record<string, { status?: unknown } | undefined> | null = null;
+    if (row.protocol_results) {
+      try {
+        parsed = JSON.parse(row.protocol_results) as Record<
+          string,
+          { status?: unknown } | undefined
+        >;
+      } catch {
+        parsed = null;
+      }
+    }
+    return {
+      grade: row.grade,
+      scannedAt: row.scanned_at,
+      protocols: {
+        dmarc: asStatus(parsed?.dmarc?.status),
+        spf: asStatus(parsed?.spf?.status),
+        dkim: asStatus(parsed?.dkim?.status),
+        bimi: asStatus(parsed?.bimi?.status),
+        mta_sts: asStatus(parsed?.mta_sts?.status),
+      },
+    };
+  });
+}

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -289,6 +289,88 @@ const DASHBOARD_CSS = `
   margin-top: 0.5rem;
   flex-wrap: wrap;
 }
+.sparkline {
+  width: 100%;
+  height: 80px;
+  display: block;
+}
+.sparkline .sparkline-line {
+  fill: none;
+  stroke: var(--clr-accent);
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.sparkline .sparkline-dot {
+  fill: var(--clr-accent);
+}
+.sparkline .sparkline-grid {
+  stroke: var(--clr-border);
+  stroke-width: 1;
+  stroke-dasharray: 2 4;
+}
+.drift-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8125rem;
+}
+.drift-table th,
+.drift-table td {
+  padding: 0.5rem 0.6rem;
+  border-bottom: 1px solid var(--clr-border);
+  text-align: left;
+}
+.drift-table th {
+  font-weight: 600;
+  color: var(--clr-text-muted);
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+  background: var(--clr-bg);
+}
+.drift-table td.drift-date {
+  color: var(--clr-text-muted);
+  white-space: nowrap;
+}
+.drift-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+.drift-dot {
+  display: inline-block;
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 50%;
+  background: var(--clr-text-muted);
+}
+.drift-dot.status-pass { background: var(--clr-pass); }
+.drift-dot.status-warn { background: var(--clr-warn); }
+.drift-dot.status-fail { background: var(--clr-fail); }
+.drift-dot.status-info { background: var(--clr-text-muted); }
+.drift-changed {
+  border-left: 2px solid var(--clr-accent);
+  padding-left: 0.5rem;
+}
+.upgrade-prompt {
+  background: var(--clr-surface);
+  border: 1px solid var(--clr-accent);
+  border-radius: 8px;
+  padding: 1.25rem 1.5rem;
+  margin-top: 1.5rem;
+  text-align: center;
+}
+.upgrade-prompt h2 {
+  color: var(--clr-accent);
+  font-size: 1rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+.upgrade-prompt p {
+  color: var(--clr-text-muted);
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+}
 `;
 
 function dashboardPage(title: string, body: string, email: string): string {
@@ -442,9 +524,176 @@ export function renderDomainDetailPage({
 <div class="section-card">
   <h2>Grade History</h2>
   ${historySection}
+  <div style="margin-top:0.75rem">
+    <a href="/dashboard/domain/${encodeURIComponent(domain)}/history" style="color:var(--clr-accent);font-size:0.875rem;text-decoration:none">See full history &rarr;</a>
+  </div>
 </div>`;
 
   return dashboardPage(`${domain} — dmarc.mx`, body, email);
+}
+
+export type HistoryProtocolStatus = "pass" | "warn" | "fail" | "info" | null;
+
+export interface HistoryScanEntry {
+  date: string;
+  scannedAt: number;
+  grade: string;
+  protocols: {
+    dmarc: HistoryProtocolStatus;
+    spf: HistoryProtocolStatus;
+    dkim: HistoryProtocolStatus;
+    bimi: HistoryProtocolStatus;
+    mta_sts: HistoryProtocolStatus;
+  };
+}
+
+// Higher = better. Matches src/alerts/detector.ts GRADE_RANK. Duplicated here
+// because the detector file is policy; the view is presentation — keeping
+// them decoupled avoids pulling a dep chain through the render path.
+const GRADE_RANK_FOR_SPARKLINE: Record<string, number> = {
+  F: 0,
+  "D-": 1,
+  D: 2,
+  "D+": 3,
+  "C-": 4,
+  C: 5,
+  "C+": 6,
+  "B-": 7,
+  B: 8,
+  "B+": 9,
+  "A-": 10,
+  A: 11,
+  "A+": 12,
+  S: 13,
+};
+
+function renderSparkline(entries: HistoryScanEntry[]): string {
+  if (entries.length === 0) {
+    return `<p style="color:var(--clr-text-muted);font-size:0.875rem;padding:0.75rem 0">No scans yet to chart.</p>`;
+  }
+  const width = 600;
+  const height = 80;
+  const pad = 8;
+  // Chart oldest → newest left-to-right, so reverse the newest-first input.
+  const ordered = [...entries].reverse();
+  const n = ordered.length;
+  const maxRank = 13;
+  const points = ordered.map((entry, i) => {
+    const rank = GRADE_RANK_FOR_SPARKLINE[entry.grade] ?? 0;
+    const x = n === 1 ? width / 2 : pad + (i * (width - pad * 2)) / (n - 1);
+    const y = pad + (1 - rank / maxRank) * (height - pad * 2);
+    return { x, y };
+  });
+  const path = points
+    .map((p, i) => `${i === 0 ? "M" : "L"}${p.x.toFixed(1)},${p.y.toFixed(1)}`)
+    .join(" ");
+  const dots = points
+    .map(
+      (p) =>
+        `<circle class="sparkline-dot" cx="${p.x.toFixed(1)}" cy="${p.y.toFixed(1)}" r="2.5" />`,
+    )
+    .join("");
+  const midY = pad + (height - pad * 2) / 2;
+  return `<svg class="sparkline" viewBox="0 0 ${width} ${height}" preserveAspectRatio="none" role="img" aria-label="Grade trend sparkline">
+  <line class="sparkline-grid" x1="${pad}" y1="${midY}" x2="${width - pad}" y2="${midY}" />
+  <path class="sparkline-line" d="${path}" />
+  ${dots}
+</svg>`;
+}
+
+function statusLabel(status: HistoryProtocolStatus): string {
+  if (status === null) return "—";
+  return status;
+}
+
+function renderDriftCell(
+  status: HistoryProtocolStatus,
+  previous: HistoryProtocolStatus,
+): string {
+  const changed = previous !== null && status !== previous;
+  const cls = `drift-cell${changed ? " drift-changed" : ""}`;
+  const dotCls = status ? `drift-dot status-${status}` : "drift-dot";
+  const title = changed ? ` title="changed from ${previous}"` : "";
+  return `<span class="${cls}"${title}><span class="${dotCls}"></span>${esc(statusLabel(status))}</span>`;
+}
+
+function renderDriftTable(entries: HistoryScanEntry[]): string {
+  if (entries.length === 0) {
+    return `<p style="color:var(--clr-text-muted);font-size:0.875rem;padding:0.75rem 0">No scans yet.</p>`;
+  }
+  // Rows are newest-first. To highlight "changed vs the prior (older) scan",
+  // we compare each row to the NEXT row in the list (which is chronologically
+  // older). The oldest row has no "previous" — its cells never highlight.
+  const rows = entries
+    .map((entry, i) => {
+      const prev: HistoryScanEntry["protocols"] | null =
+        i + 1 < entries.length ? entries[i + 1].protocols : null;
+      const protos = entry.protocols;
+      return `<tr>
+  <td class="drift-date">${esc(entry.date)}</td>
+  <td><span class="inline-grade ${gradeClass(entry.grade)}">${esc(entry.grade)}</span></td>
+  <td>${renderDriftCell(protos.dmarc, prev?.dmarc ?? null)}</td>
+  <td>${renderDriftCell(protos.spf, prev?.spf ?? null)}</td>
+  <td>${renderDriftCell(protos.dkim, prev?.dkim ?? null)}</td>
+  <td>${renderDriftCell(protos.bimi, prev?.bimi ?? null)}</td>
+  <td>${renderDriftCell(protos.mta_sts, prev?.mta_sts ?? null)}</td>
+</tr>`;
+    })
+    .join("");
+  return `<table class="drift-table">
+  <thead>
+    <tr>
+      <th>Scanned</th>
+      <th>Grade</th>
+      <th>DMARC</th>
+      <th>SPF</th>
+      <th>DKIM</th>
+      <th>BIMI</th>
+      <th>MTA-STS</th>
+    </tr>
+  </thead>
+  <tbody>${rows}</tbody>
+</table>`;
+}
+
+export function renderDomainHistoryPage({
+  email,
+  domain,
+  plan,
+  history,
+}: {
+  email: string;
+  domain: string;
+  plan: "free" | "pro";
+  history: HistoryScanEntry[];
+}): string {
+  const sparkline = renderSparkline(history);
+  const drift = renderDriftTable(history);
+
+  const upgradePrompt =
+    plan === "free"
+      ? `<div class="upgrade-prompt">
+  <h2>Upgrade to see the full history</h2>
+  <p>Pro unlocks 30 scans of grade-trend and protocol-drift detail per domain, plus nightly monitoring and higher API rate limits.</p>
+  <a href="/dashboard/billing/subscribe" class="btn">Upgrade to Pro</a>
+</div>`
+      : "";
+
+  const body = `<h1 class="dashboard-title">History — ${esc(domain)}</h1>
+<div class="section-card">
+  <h2>Grade trend</h2>
+  ${sparkline}
+</div>
+<div class="section-card">
+  <h2>Protocol drift</h2>
+  ${drift}
+</div>
+${upgradePrompt}
+<div style="margin-top:1rem">
+  <a href="/dashboard/domain/${encodeURIComponent(domain)}" style="color:var(--clr-accent);font-size:0.875rem;text-decoration:none">&larr; Back to ${esc(domain)}</a>
+</div>`;
+
+  return dashboardPage(`History — ${domain} — dmarc.mx`, body, email);
 }
 
 export function renderAddDomainPage({

--- a/test/dashboard-routes.test.ts
+++ b/test/dashboard-routes.test.ts
@@ -57,7 +57,18 @@ function createMockDB(data: {
     api_key_retirement_acknowledged_at: number | null;
     created_at: number;
   }>;
-  scanHistory?: Array<{ grade: string; scanned_at: number }>;
+  scanHistory?: Array<{
+    grade: string;
+    scanned_at: number;
+    protocol_results?: string | null;
+    score_factors?: string | null;
+    id?: number;
+    domain_id?: number;
+  }>;
+  subscriptions?: Array<{
+    user_id: string;
+    status: string;
+  }>;
   webhooks?: Array<{
     id: number;
     user_id: string;
@@ -81,6 +92,7 @@ function createMockDB(data: {
   const scanHistory = data.scanHistory ?? [];
   const webhooks = data.webhooks ?? [];
   const apiKeys = data.apiKeys ?? [];
+  const subscriptions = data.subscriptions ?? [];
   const writes = data.writes;
 
   const makeStatement = (sql: string, bindings: unknown[]) => ({
@@ -105,6 +117,10 @@ function createMockDB(data: {
         const wh = webhooks.find((w) => w.user_id === bindings[0]);
         return (wh ? { id: wh.id } : null) as T | null;
       }
+      if (sql.includes("SELECT status FROM subscriptions")) {
+        const sub = subscriptions.find((s) => s.user_id === bindings[0]);
+        return (sub ? { status: sub.status } : null) as T | null;
+      }
       return null as T | null;
     },
     all: async <T>() => {
@@ -115,6 +131,22 @@ function createMockDB(data: {
       }
       if (sql.includes("SELECT grade, scanned_at FROM scan_history")) {
         return { results: scanHistory as T[] };
+      }
+      if (sql.includes("SELECT * FROM scan_history")) {
+        const [, limit] = bindings as [number, number];
+        const sorted = [...scanHistory].sort(
+          (a, b) => b.scanned_at - a.scanned_at,
+        );
+        return {
+          results: sorted.slice(0, limit).map((r, i) => ({
+            id: r.id ?? i + 1,
+            domain_id: r.domain_id ?? 1,
+            grade: r.grade,
+            score_factors: r.score_factors ?? null,
+            protocol_results: r.protocol_results ?? null,
+            scanned_at: r.scanned_at,
+          })) as T[],
+        };
       }
       if (sql.includes("SELECT * FROM api_keys WHERE user_id")) {
         return {
@@ -318,6 +350,187 @@ describe("dashboard/routes", () => {
       });
       const body = await res.text();
       expect(body).toContain("Grade History");
+    });
+  });
+
+  describe("GET /dashboard/domain/:domain/history", () => {
+    const domainFixture = {
+      id: 1,
+      user_id: "user_1",
+      domain: "example.com",
+      is_free: 0,
+      scan_frequency: "weekly",
+      last_scanned_at: 1700000000,
+      last_grade: "B",
+      created_at: 1700000000,
+    };
+
+    const makeScan = (
+      at: number,
+      grade: string,
+      statuses: Record<string, string>,
+    ) => ({
+      grade,
+      scanned_at: at,
+      protocol_results: JSON.stringify(
+        Object.fromEntries(
+          Object.entries(statuses).map(([k, v]) => [k, { status: v }]),
+        ),
+      ),
+    });
+
+    it("redirects to /auth/login without a session cookie", async () => {
+      const db = createMockDB({});
+      const app = createTestApp(db);
+      const res = await app.request("/dashboard/domain/example.com/history");
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/auth/login");
+    });
+
+    it("returns 404 when the domain does not belong to the user", async () => {
+      const db = createMockDB({ domains: [] });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/domain/notmine.com/history", {
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("renders the full 30-row table and no upgrade prompt for Pro users", async () => {
+      const scans = Array.from({ length: 12 }, (_, i) =>
+        makeScan(1_700_000_000 + i * 86_400, "B", {
+          dmarc: "pass",
+          spf: "pass",
+          dkim: "pass",
+          bimi: "warn",
+          mta_sts: "pass",
+        }),
+      );
+      const db = createMockDB({
+        domains: [domainFixture],
+        scanHistory: scans,
+        subscriptions: [{ user_id: "user_1", status: "active" }],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/domain/example.com/history", {
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body).toContain("History — example.com");
+      expect(body).toContain("Protocol drift");
+      expect(body).toContain("Grade trend");
+      expect(body).not.toContain("Upgrade to see the full history");
+      // Should render a sparkline SVG
+      expect(body).toContain("sparkline-line");
+      // All 12 scans show up (there's at least 12 distinct status-pass dots
+      // since every scan has multiple pass protocols).
+      const rowCount = (body.match(/class="drift-date"/g) || []).length;
+      expect(rowCount).toBe(12);
+    });
+
+    it("shows an upgrade prompt for free users", async () => {
+      const scans = Array.from({ length: 10 }, (_, i) =>
+        makeScan(1_700_000_000 + i * 86_400, "C", {
+          dmarc: "warn",
+          spf: "pass",
+          dkim: "pass",
+          bimi: "fail",
+          mta_sts: "pass",
+        }),
+      );
+      const db = createMockDB({
+        domains: [domainFixture],
+        scanHistory: scans,
+        // no subscriptions row → free plan
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/domain/example.com/history", {
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body).toContain("Upgrade to see the full history");
+      expect(body).toContain("/dashboard/billing/subscribe");
+      // Free users get only 5 rows even when 10 scans exist.
+      const rowCount = (body.match(/class="drift-date"/g) || []).length;
+      expect(rowCount).toBe(5);
+    });
+
+    it("treats a cancelled subscription as free", async () => {
+      const db = createMockDB({
+        domains: [domainFixture],
+        scanHistory: [
+          makeScan(1_700_000_000, "A", {
+            dmarc: "pass",
+            spf: "pass",
+            dkim: "pass",
+            bimi: "pass",
+            mta_sts: "pass",
+          }),
+        ],
+        subscriptions: [{ user_id: "user_1", status: "canceled" }],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/domain/example.com/history", {
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body).toContain("Upgrade to see the full history");
+    });
+
+    it("handles domains with no scans yet without crashing", async () => {
+      const db = createMockDB({
+        domains: [domainFixture],
+        scanHistory: [],
+        subscriptions: [{ user_id: "user_1", status: "active" }],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/domain/example.com/history", {
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body).toContain("No scans yet to chart");
+      expect(body).toContain("No scans yet.");
+    });
+
+    it("marks protocol-status transitions with drift-changed", async () => {
+      const db = createMockDB({
+        domains: [domainFixture],
+        scanHistory: [
+          // newest first: dmarc regressed pass→fail between the two scans
+          makeScan(1_700_000_100, "F", {
+            dmarc: "fail",
+            spf: "pass",
+            dkim: "pass",
+            bimi: "pass",
+            mta_sts: "pass",
+          }),
+          makeScan(1_700_000_000, "A", {
+            dmarc: "pass",
+            spf: "pass",
+            dkim: "pass",
+            bimi: "pass",
+            mta_sts: "pass",
+          }),
+        ],
+        subscriptions: [{ user_id: "user_1", status: "active" }],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/domain/example.com/history", {
+        headers: { Cookie: cookie },
+      });
+      const body = await res.text();
+      expect(body).toContain("drift-changed");
+      expect(body).toContain('title="changed from pass"');
     });
   });
 

--- a/test/db-scans.test.ts
+++ b/test/db-scans.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   getScanHistory,
+  getScanHistoryWithProtocols,
   recordScan,
   type ScanHistoryRow,
 } from "../src/db/scans.js";
@@ -175,6 +176,69 @@ describe("db/scans", () => {
       });
       const history = await getScanHistory(db, 42);
       expect(history).toHaveLength(0);
+    });
+  });
+
+  describe("getScanHistoryWithProtocols", () => {
+    it("parses protocol_results JSON into a flat status map", async () => {
+      await recordScan(db, {
+        domainId: 42,
+        grade: "B",
+        scoreFactors: null,
+        protocolResults: {
+          dmarc: { status: "pass" },
+          spf: { status: "warn" },
+          dkim: { status: "pass" },
+          bimi: { status: "fail" },
+          mta_sts: { status: "pass" },
+        },
+        scannedAt: 1000,
+      });
+
+      const rows = await getScanHistoryWithProtocols(db, 42, 10);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toEqual({
+        grade: "B",
+        scannedAt: 1000,
+        protocols: {
+          dmarc: "pass",
+          spf: "warn",
+          dkim: "pass",
+          bimi: "fail",
+          mta_sts: "pass",
+        },
+      });
+    });
+
+    it("returns null statuses for unknown protocol shapes", async () => {
+      await recordScan(db, {
+        domainId: 42,
+        grade: "A",
+        scoreFactors: null,
+        protocolResults: { dmarc: { status: "bogus" } }, // unknown value
+        scannedAt: 1000,
+      });
+      const rows = await getScanHistoryWithProtocols(db, 42, 10);
+      expect(rows[0].protocols.dmarc).toBeNull();
+      expect(rows[0].protocols.spf).toBeNull(); // missing key
+    });
+
+    it("yields all-null protocols when protocol_results is null", async () => {
+      await recordScan(db, {
+        domainId: 42,
+        grade: "F",
+        scoreFactors: null,
+        protocolResults: null,
+        scannedAt: 1000,
+      });
+      const rows = await getScanHistoryWithProtocols(db, 42, 10);
+      expect(rows[0].protocols).toEqual({
+        dmarc: null,
+        spf: null,
+        dkim: null,
+        bimi: null,
+        mta_sts: null,
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

- New `/dashboard/domain/:domain/history` route: grade-trend sparkline + protocol-drift matrix driven off the existing `scan_history` table. No schema changes.
- Pro users see 30 scans and the full matrix; free users get a 5-entry teaser plus an upgrade CTA. The route is **not** hidden for free users — the payload is what's gated, so the upgrade prompt has a landing page.
- Helper `getScanHistoryWithProtocols` in `src/db/scans.ts` parses the existing `protocol_results` JSON into a flat per-protocol status map so views don't have to reach into the orchestrator shape.
- Domain detail page now links "See full history →" into the new route.

First of four Phase 4 PRs (history → in-dashboard regressions → bulk scan → public history API). This one establishes the Pro-payload-gating pattern the next three will reuse.

## Test plan

- [x] `npm run lint && npm run typecheck && npm test` — all green (575 tests)
- [x] New tests cover: auth redirect, 404 on unowned domain, Pro full render, free-tier teaser + 5-row cap, `canceled` subscription → free, empty-history render, `drift-changed` highlighting for a pass→fail protocol transition
- [ ] Manual verify after deploy: hit `/dashboard/domain/<owned>/history` as both free and pro; verify sparkline renders and protocol drift highlights when a status actually changed between scans

🤖 Generated with [Claude Code](https://claude.com/claude-code)