### PR TITLE
Phase 4b: regressions surfaced in-dashboard + acknowledge

### DIFF
--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -4,6 +4,11 @@ import { requireAuth } from "../auth/middleware.js";
 import type { SessionPayload } from "../auth/session.js";
 import { dashboardBillingRoutes } from "../billing/routes.js";
 import {
+  acknowledgeAlert,
+  countUnacknowledgedByDomain,
+  listUnacknowledgedForUser,
+} from "../db/alerts.js";
+import {
   createApiKey,
   listApiKeysByUser,
   revokeApiKey,
@@ -45,14 +50,28 @@ dashboardRoutes.use("*", requireAuth);
 // self-host deploy without Stripe env vars still 404s these cleanly.
 dashboardRoutes.route("/billing", dashboardBillingRoutes);
 
-// Domain list
+// Domain list. Surfaces nightly-detected regressions ("Needs attention" section)
+// above the table so logged-in users see them between cron fires without having
+// to wait for the email.
 dashboardRoutes.get("/", async (c) => {
   const session = c.get("user" as never) as SessionPayload;
   const db = (c.env as { DB: D1Database }).DB;
-  const domains = await getDomainsByUser(db, session.sub);
+  const [domains, alerts, unackCounts] = await Promise.all([
+    getDomainsByUser(db, session.sub),
+    listUnacknowledgedForUser(db, session.sub, 20),
+    countUnacknowledgedByDomain(db, session.sub),
+  ]);
   return c.html(
     renderDashboardPage({
       email: session.email,
+      alerts: alerts.map((a) => ({
+        id: a.id,
+        domain: a.domain,
+        alertType: a.alert_type,
+        previousValue: a.previous_value,
+        newValue: a.new_value,
+        createdAt: a.created_at,
+      })),
       domains: domains.map((d) => ({
         domain: d.domain,
         grade: d.last_grade ?? "—",
@@ -61,9 +80,28 @@ dashboardRoutes.get("/", async (c) => {
           ? new Date(d.last_scanned_at * 1000).toLocaleDateString()
           : null,
         isFree: d.is_free === 1,
+        unacknowledgedAlerts: unackCounts.get(d.id) ?? 0,
       })),
     }),
   );
+});
+
+// Dismiss a regression alert. IDOR-safe via SQL: acknowledgeAlert only updates
+// rows whose domain belongs to the session user. Returns 404 (not 500, not 303)
+// for invalid / cross-user / already-acked ids so the caller can distinguish.
+dashboardRoutes.post("/alerts/:id/acknowledge", async (c) => {
+  const session = c.get("user" as never) as SessionPayload;
+  const db = (c.env as { DB: D1Database }).DB;
+  const idParam = c.req.param("id");
+  const alertId = Number.parseInt(idParam, 10);
+  if (!Number.isFinite(alertId) || alertId <= 0) {
+    return c.text("Invalid alert id", 400);
+  }
+  const ok = await acknowledgeAlert(db, session.sub, alertId);
+  if (!ok) {
+    return c.text("Alert not found", 404);
+  }
+  return c.redirect("/dashboard", 303);
 });
 
 // Add-domain form. Simple GET → form; POST → validate + insert.

--- a/src/db/alerts.ts
+++ b/src/db/alerts.ts
@@ -7,6 +7,7 @@ export interface AlertRow {
   previous_value: string | null;
   new_value: string | null;
   notified_via: string | null;
+  acknowledged_at: number | null;
   created_at: number;
 }
 
@@ -71,4 +72,73 @@ export async function markAlertNotified(
     .prepare("UPDATE alerts SET notified_via = ? WHERE id = ?")
     .bind(channel, alertId)
     .run();
+}
+
+// Alert plus its owning domain name, used by the dashboard "Needs attention"
+// section. The JOIN gates the result on user ownership.
+export interface UserAlert extends AlertRow {
+  domain: string;
+}
+
+export async function listUnacknowledgedForUser(
+  db: D1Database,
+  userId: string,
+  limit = 20,
+): Promise<UserAlert[]> {
+  const result = await db
+    .prepare(
+      `SELECT a.*, d.domain
+       FROM alerts a
+       JOIN domains d ON d.id = a.domain_id
+       WHERE d.user_id = ? AND a.acknowledged_at IS NULL
+       ORDER BY a.created_at DESC
+       LIMIT ?`,
+    )
+    .bind(userId, limit)
+    .all<UserAlert>();
+  return result.results;
+}
+
+// IDOR-safe: the UPDATE only fires if the alert's owning domain belongs to
+// the supplied userId. Returns true if a row was updated, false otherwise so
+// the caller can choose between 303 and 404.
+export async function acknowledgeAlert(
+  db: D1Database,
+  userId: string,
+  alertId: number,
+  now: number = Math.floor(Date.now() / 1000),
+): Promise<boolean> {
+  const result = await db
+    .prepare(
+      `UPDATE alerts
+       SET acknowledged_at = ?
+       WHERE id = ?
+         AND acknowledged_at IS NULL
+         AND domain_id IN (SELECT id FROM domains WHERE user_id = ?)`,
+    )
+    .bind(now, alertId, userId)
+    .run();
+  return (result.meta?.changes ?? 0) > 0;
+}
+
+interface UnacknowledgedCountRow {
+  domain_id: number;
+  count: number;
+}
+
+export async function countUnacknowledgedByDomain(
+  db: D1Database,
+  userId: string,
+): Promise<Map<number, number>> {
+  const result = await db
+    .prepare(
+      `SELECT a.domain_id AS domain_id, COUNT(*) AS count
+       FROM alerts a
+       JOIN domains d ON d.id = a.domain_id
+       WHERE d.user_id = ? AND a.acknowledged_at IS NULL
+       GROUP BY a.domain_id`,
+    )
+    .bind(userId)
+    .all<UnacknowledgedCountRow>();
+  return new Map(result.results.map((r) => [r.domain_id, r.count]));
 }

--- a/src/db/migrations/0003_alerts_acknowledged.sql
+++ b/src/db/migrations/0003_alerts_acknowledged.sql
@@ -1,0 +1,8 @@
+-- Phase 4b — track in-product dismissal of grade-drop / protocol-regression
+-- alerts. Independent of `notified_via` (email delivery state). NULL on
+-- existing rows so they appear in the dashboard's "Needs attention" list
+-- until the user dismisses them.
+ALTER TABLE alerts ADD COLUMN acknowledged_at INTEGER;
+CREATE INDEX IF NOT EXISTS idx_alerts_unacked
+  ON alerts(domain_id, created_at)
+  WHERE acknowledged_at IS NULL;

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -40,6 +40,7 @@ CREATE TABLE IF NOT EXISTS alerts (
   previous_value TEXT,
   new_value TEXT,
   notified_via TEXT,
+  acknowledged_at INTEGER,
   created_at INTEGER NOT NULL DEFAULT (unixepoch())
 );
 
@@ -88,6 +89,9 @@ CREATE TABLE IF NOT EXISTS api_keys (
 CREATE INDEX IF NOT EXISTS idx_domains_user_id ON domains(user_id);
 CREATE INDEX IF NOT EXISTS idx_scan_history_domain_id ON scan_history(domain_id);
 CREATE INDEX IF NOT EXISTS idx_alerts_domain_id ON alerts(domain_id);
+CREATE INDEX IF NOT EXISTS idx_alerts_unacked
+  ON alerts(domain_id, created_at)
+  WHERE acknowledged_at IS NULL;
 CREATE INDEX IF NOT EXISTS idx_domains_last_scanned ON domains(last_scanned_at);
 CREATE INDEX IF NOT EXISTS idx_subscriptions_status ON subscriptions(status);
 CREATE INDEX IF NOT EXISTS idx_api_keys_hash ON api_keys(hash);

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -119,6 +119,84 @@ const DASHBOARD_CSS = `
   margin-left: 0.4rem;
   vertical-align: middle;
 }
+.badge-alert {
+  display: inline-block;
+  padding: 0.1rem 0.45rem;
+  background: var(--clr-fail);
+  color: white;
+  border-radius: 4px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-left: 0.4rem;
+  vertical-align: middle;
+}
+.alerts-needs-attention {
+  background: var(--clr-surface);
+  border: 1px solid var(--clr-fail);
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1.5rem;
+}
+.alerts-needs-attention h2 {
+  margin: 0 0 0.75rem 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--clr-fail);
+}
+.alerts-needs-attention ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.alerts-needs-attention li {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0;
+  border-top: 1px solid var(--clr-border);
+  font-size: 0.875rem;
+  flex-wrap: wrap;
+}
+.alerts-needs-attention li:first-child {
+  border-top: none;
+}
+.alerts-needs-attention .alert-domain {
+  font-weight: 600;
+}
+.alerts-needs-attention .alert-domain a {
+  color: var(--clr-accent);
+  text-decoration: none;
+}
+.alerts-needs-attention .alert-domain a:hover {
+  text-decoration: underline;
+}
+.alerts-needs-attention .alert-message {
+  color: var(--clr-text);
+  flex: 1;
+  min-width: 200px;
+}
+.alerts-needs-attention .alert-time {
+  color: var(--clr-text-muted);
+  font-size: 0.75rem;
+}
+.alerts-needs-attention form {
+  margin: 0;
+}
+.alerts-needs-attention .btn-dismiss {
+  background: transparent;
+  border: 1px solid var(--clr-border);
+  color: var(--clr-text-muted);
+  padding: 0.25rem 0.6rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+.alerts-needs-attention .btn-dismiss:hover {
+  border-color: var(--clr-fail);
+  color: var(--clr-fail);
+}
 .grade-badge {
   display: inline-flex;
   align-items: center;
@@ -414,6 +492,16 @@ export interface DashboardDomain {
   frequency: string;
   lastScanned: string | null;
   isFree: boolean;
+  unacknowledgedAlerts?: number;
+}
+
+export interface DashboardAlert {
+  id: number;
+  domain: string;
+  alertType: string;
+  previousValue: string | null;
+  newValue: string | null;
+  createdAt: number;
 }
 
 export interface ScanHistoryEntry {
@@ -421,11 +509,73 @@ export interface ScanHistoryEntry {
   grade: string;
 }
 
+function describeAlert(alert: DashboardAlert): string {
+  const prev = alert.previousValue ?? "";
+  const next = alert.newValue ?? "";
+  if (alert.alertType === "grade_drop") {
+    return `Grade dropped from ${prev || "—"} to ${next || "—"}`;
+  }
+  if (alert.alertType === "protocol_regression") {
+    // Detector writes values shaped as "${proto}:${status}" — strip protocol
+    // names to keep the message scannable, fall back to raw if shape changes.
+    const prevColon = prev.indexOf(":");
+    const nextColon = next.indexOf(":");
+    const proto =
+      prevColon > 0
+        ? prev.slice(0, prevColon)
+        : nextColon > 0
+          ? next.slice(0, nextColon)
+          : "";
+    const prevStatus = prevColon > 0 ? prev.slice(prevColon + 1) : prev;
+    const nextStatus = nextColon > 0 ? next.slice(nextColon + 1) : next;
+    const protoLabel = proto
+      ? proto.toUpperCase().replace(/_/g, "-")
+      : "Protocol";
+    return `${protoLabel} regressed: ${prevStatus || "—"} → ${nextStatus || "—"}`;
+  }
+  return `${alert.alertType}: ${prev} → ${next}`;
+}
+
+function relativeTime(unixSeconds: number, now: number): string {
+  const deltaSec = Math.max(0, now - unixSeconds);
+  if (deltaSec < 60) return "just now";
+  if (deltaSec < 3600) return `${Math.floor(deltaSec / 60)}m ago`;
+  if (deltaSec < 86400) return `${Math.floor(deltaSec / 3600)}h ago`;
+  return `${Math.floor(deltaSec / 86400)}d ago`;
+}
+
+export function renderAlertsSection(
+  alerts: DashboardAlert[],
+  now: number = Math.floor(Date.now() / 1000),
+): string {
+  if (alerts.length === 0) return "";
+  const items = alerts
+    .map((a) => {
+      const domainHref = `/dashboard/domain/${encodeURIComponent(a.domain)}`;
+      const ackHref = `/dashboard/alerts/${a.id}/acknowledge`;
+      return `<li>
+  <span class="alert-domain"><a href="${domainHref}">${esc(a.domain)}</a></span>
+  <span class="alert-message">${esc(describeAlert(a))}</span>
+  <span class="alert-time">${esc(relativeTime(a.createdAt, now))}</span>
+  <form method="post" action="${ackHref}">
+    <button type="submit" class="btn-dismiss">Dismiss</button>
+  </form>
+</li>`;
+    })
+    .join("");
+  return `<section class="alerts-needs-attention" aria-label="Domain regressions needing attention">
+  <h2>Needs attention</h2>
+  <ul>${items}</ul>
+</section>`;
+}
+
 export function renderDashboardPage({
   email,
+  alerts = [],
   domains,
 }: {
   email: string;
+  alerts?: DashboardAlert[];
   domains: DashboardDomain[];
 }): string {
   let tableBody: string;
@@ -437,17 +587,23 @@ export function renderDashboardPage({
 </div>`;
   } else {
     const rows = domains
-      .map(
-        (d) => `<tr>
+      .map((d) => {
+        const alertCount = d.unacknowledgedAlerts ?? 0;
+        const alertBadge =
+          alertCount > 0
+            ? `<span class="badge-alert">${alertCount} alert${alertCount === 1 ? "" : "s"}</span>`
+            : "";
+        return `<tr>
   <td>
     <a href="/dashboard/domain/${encodeURIComponent(d.domain)}">${esc(d.domain)}</a>
     ${d.isFree ? '<span class="badge-free">Free</span>' : ""}
+    ${alertBadge}
   </td>
   <td><span class="inline-grade ${gradeClass(d.grade)}">${esc(d.grade)}</span></td>
   <td>${esc(d.frequency)}</td>
   <td>${d.lastScanned ? esc(d.lastScanned) : '<span style="color:var(--clr-text-muted)">Never</span>'}</td>
-</tr>`,
-      )
+</tr>`;
+      })
       .join("");
 
     tableBody = `<table class="domain-table">
@@ -466,6 +622,7 @@ export function renderDashboardPage({
   return dashboardPage(
     "Domains — dmarc.mx",
     `<h1 class="dashboard-title">Your Domains</h1>
+${renderAlertsSection(alerts)}
 ${tableBody}`,
     email,
   );

--- a/test/dashboard-routes.test.ts
+++ b/test/dashboard-routes.test.ts
@@ -85,6 +85,16 @@ function createMockDB(data: {
     last_used_at: number | null;
     revoked_at: number | null;
   }>;
+  alerts?: Array<{
+    id: number;
+    domain_id: number;
+    alert_type: string;
+    previous_value: string | null;
+    new_value: string | null;
+    notified_via: string | null;
+    acknowledged_at: number | null;
+    created_at: number;
+  }>;
   writes?: Array<{ sql: string; bindings: unknown[] }>;
 }) {
   const domains = data.domains ?? [];
@@ -93,6 +103,7 @@ function createMockDB(data: {
   const webhooks = data.webhooks ?? [];
   const apiKeys = data.apiKeys ?? [];
   const subscriptions = data.subscriptions ?? [];
+  const alerts = data.alerts ?? [];
   const writes = data.writes;
 
   const makeStatement = (sql: string, bindings: unknown[]) => ({
@@ -153,11 +164,61 @@ function createMockDB(data: {
           results: apiKeys.filter((k) => k.user_id === bindings[0]) as T[],
         };
       }
+      if (
+        /acknowledged_at IS NULL[\s\S]*ORDER BY a\.created_at DESC/i.test(sql)
+      ) {
+        const [userId, limit] = bindings as [string, number];
+        const ownedDomainIds = new Set(
+          domains.filter((d) => d.user_id === userId).map((d) => d.id),
+        );
+        const rows = alerts
+          .filter(
+            (a) =>
+              a.acknowledged_at === null && ownedDomainIds.has(a.domain_id),
+          )
+          .sort((a, b) => b.created_at - a.created_at)
+          .slice(0, limit)
+          .map((a) => ({
+            ...a,
+            domain: domains.find((d) => d.id === a.domain_id)?.domain ?? "",
+          }));
+        return { results: rows as T[] };
+      }
+      if (/GROUP BY a\.domain_id/i.test(sql)) {
+        const [userId] = bindings as [string];
+        const ownedDomainIds = new Set(
+          domains.filter((d) => d.user_id === userId).map((d) => d.id),
+        );
+        const counts = new Map<number, number>();
+        for (const a of alerts) {
+          if (a.acknowledged_at !== null) continue;
+          if (!ownedDomainIds.has(a.domain_id)) continue;
+          counts.set(a.domain_id, (counts.get(a.domain_id) ?? 0) + 1);
+        }
+        const rows = [...counts.entries()].map(([domain_id, count]) => ({
+          domain_id,
+          count,
+        }));
+        return { results: rows as T[] };
+      }
       return { results: [] as T[] };
     },
     run: async () => {
       writes?.push({ sql, bindings });
-      return { success: true };
+      if (/^\s*UPDATE alerts\s+SET acknowledged_at/i.test(sql)) {
+        const [now, alertId, userId] = bindings as [number, number, string];
+        const alert = alerts.find((a) => a.id === alertId);
+        if (!alert || alert.acknowledged_at !== null) {
+          return { success: true, meta: { changes: 0 } };
+        }
+        const owner = domains.find((d) => d.id === alert.domain_id);
+        if (!owner || owner.user_id !== userId) {
+          return { success: true, meta: { changes: 0 } };
+        }
+        alert.acknowledged_at = now;
+        return { success: true, meta: { changes: 1 } };
+      }
+      return { success: true, meta: { changes: 1 } };
     },
   });
 
@@ -1174,6 +1235,219 @@ describe("dashboard/routes", () => {
       const deleted = writes.find((w) => w.sql.includes("DELETE FROM domains"));
       expect(deleted).toBeDefined();
       expect(deleted?.bindings).toEqual(["user_1", "example.com"]);
+    });
+  });
+
+  describe("GET /dashboard alerts surface", () => {
+    const userDomain = {
+      id: 1,
+      user_id: "user_1",
+      domain: "example.com",
+      is_free: 0,
+      scan_frequency: "weekly",
+      last_scanned_at: 1700000000,
+      last_grade: "C",
+      created_at: 1700000000,
+    };
+
+    it("renders the Needs attention section when the user has unacknowledged alerts", async () => {
+      const db = createMockDB({
+        domains: [userDomain],
+        alerts: [
+          {
+            id: 11,
+            domain_id: 1,
+            alert_type: "grade_drop",
+            previous_value: "A",
+            new_value: "C",
+            notified_via: null,
+            acknowledged_at: null,
+            created_at: 1_700_000_500,
+          },
+        ],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard", {
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body).toContain("Needs attention");
+      expect(body).toContain("Grade dropped from A to C");
+      expect(body).toContain("/dashboard/alerts/11/acknowledge");
+      // Per-domain badge appears in the table row.
+      expect(body).toContain("badge-alert");
+      expect(body).toContain("1 alert");
+    });
+
+    it("omits the Needs attention section when no alerts exist", async () => {
+      const db = createMockDB({
+        domains: [userDomain],
+        alerts: [],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard", {
+        headers: { Cookie: cookie },
+      });
+      const body = await res.text();
+      expect(body).not.toContain("Needs attention");
+      // Markup-level usage; .badge-alert exists in DASHBOARD_CSS unconditionally.
+      expect(body).not.toContain('class="badge-alert"');
+    });
+
+    it("does not surface another user's alerts", async () => {
+      const db = createMockDB({
+        domains: [
+          userDomain,
+          {
+            id: 2,
+            user_id: "user_2",
+            domain: "other.com",
+            is_free: 0,
+            scan_frequency: "weekly",
+            last_scanned_at: null,
+            last_grade: null,
+            created_at: 1700000000,
+          },
+        ],
+        alerts: [
+          {
+            id: 22,
+            domain_id: 2,
+            alert_type: "grade_drop",
+            previous_value: "A",
+            new_value: "F",
+            notified_via: null,
+            acknowledged_at: null,
+            created_at: 1_700_000_500,
+          },
+        ],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard", {
+        headers: { Cookie: cookie },
+      });
+      const body = await res.text();
+      expect(body).not.toContain("Needs attention");
+      expect(body).not.toContain("/dashboard/alerts/22/acknowledge");
+    });
+  });
+
+  describe("POST /dashboard/alerts/:id/acknowledge", () => {
+    it("redirects to /auth/login without a session cookie", async () => {
+      const db = createMockDB({});
+      const app = createTestApp(db);
+      const res = await app.request("/dashboard/alerts/1/acknowledge", {
+        method: "POST",
+      });
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/auth/login");
+    });
+
+    it("returns 400 when the id is not numeric", async () => {
+      const db = createMockDB({});
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/alerts/abc/acknowledge", {
+        method: "POST",
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("303-redirects to /dashboard for the user's own alert and persists the ack", async () => {
+      const writes: Array<{ sql: string; bindings: unknown[] }> = [];
+      const db = createMockDB({
+        domains: [
+          {
+            id: 1,
+            user_id: "user_1",
+            domain: "example.com",
+            is_free: 0,
+            scan_frequency: "weekly",
+            last_scanned_at: null,
+            last_grade: "C",
+            created_at: 1700000000,
+          },
+        ],
+        alerts: [
+          {
+            id: 42,
+            domain_id: 1,
+            alert_type: "grade_drop",
+            previous_value: "A",
+            new_value: "C",
+            notified_via: null,
+            acknowledged_at: null,
+            created_at: 1_700_000_500,
+          },
+        ],
+        writes,
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/alerts/42/acknowledge", {
+        method: "POST",
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(303);
+      expect(res.headers.get("Location")).toBe("/dashboard");
+      const ack = writes.find((w) =>
+        /UPDATE alerts\s+SET acknowledged_at/i.test(w.sql),
+      );
+      expect(ack).toBeDefined();
+      expect(ack?.bindings[1]).toBe(42); // alertId
+      expect(ack?.bindings[2]).toBe("user_1"); // userId
+    });
+
+    it("returns 404 for another user's alert id (IDOR)", async () => {
+      const db = createMockDB({
+        domains: [
+          {
+            id: 2,
+            user_id: "user_2",
+            domain: "other.com",
+            is_free: 0,
+            scan_frequency: "weekly",
+            last_scanned_at: null,
+            last_grade: null,
+            created_at: 1700000000,
+          },
+        ],
+        alerts: [
+          {
+            id: 99,
+            domain_id: 2,
+            alert_type: "grade_drop",
+            previous_value: "A",
+            new_value: "F",
+            notified_via: null,
+            acknowledged_at: null,
+            created_at: 1_700_000_500,
+          },
+        ],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/alerts/99/acknowledge", {
+        method: "POST",
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 404 for a nonexistent alert id (no 500, no redirect to dashboard)", async () => {
+      const db = createMockDB({});
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/alerts/99999/acknowledge", {
+        method: "POST",
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(404);
     });
   });
 });

--- a/test/db-alerts.test.ts
+++ b/test/db-alerts.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   type AlertRow,
+  acknowledgeAlert,
+  countUnacknowledgedByDomain,
+  listUnacknowledgedForUser,
   listUnsentAlerts,
   markAlertNotified,
   recordAlert,
@@ -30,17 +33,75 @@ function makeD1Mock(): D1Database {
             previous_value: prevVal,
             new_value: newVal,
             notified_via: null,
+            acknowledged_at: null,
             created_at: createdAt,
           });
-        } else if (/^UPDATE alerts SET notified_via/i.test(sql)) {
+          return { success: true, meta: { changes: 1 } };
+        }
+        if (/^UPDATE alerts SET notified_via/i.test(sql)) {
           const [channel, id] = params as [string, number];
           const row = alertStore.get(id);
           if (row) alertStore.set(id, { ...row, notified_via: channel });
+          return { success: true, meta: { changes: row ? 1 : 0 } };
         }
-        return { success: true };
+        if (/^\s*UPDATE alerts\s+SET acknowledged_at/i.test(sql)) {
+          const [now, alertId, userId] = params as [number, number, string];
+          const row = alertStore.get(alertId);
+          if (!row || row.acknowledged_at !== null) {
+            return { success: true, meta: { changes: 0 } };
+          }
+          const ownerDomain = domainStore.get(row.domain_id);
+          if (!ownerDomain || ownerDomain.user_id !== userId) {
+            return { success: true, meta: { changes: 0 } };
+          }
+          alertStore.set(alertId, { ...row, acknowledged_at: now });
+          return { success: true, meta: { changes: 1 } };
+        }
+        return { success: true, meta: { changes: 0 } };
       },
       all: async <T>(): Promise<{ results: T[] }> => {
-        if (/FROM alerts[\s\S]*JOIN domains/i.test(sql)) {
+        // listUnacknowledgedForUser: filters on user_id + acknowledged_at
+        if (
+          /acknowledged_at IS NULL[\s\S]*ORDER BY a\.created_at DESC/i.test(sql)
+        ) {
+          const [userId, limit] = params as [string, number];
+          const rows = [...alertStore.values()]
+            .filter((a) => {
+              const d = domainStore.get(a.domain_id);
+              return (
+                a.acknowledged_at === null &&
+                d !== undefined &&
+                d.user_id === userId
+              );
+            })
+            .sort((a, b) => b.created_at - a.created_at)
+            .slice(0, limit)
+            .map((a) => ({
+              ...a,
+              domain: domainStore.get(a.domain_id)?.domain ?? "",
+            }));
+          return { results: rows as T[] };
+        }
+        // countUnacknowledgedByDomain: GROUP BY a.domain_id
+        if (/GROUP BY a\.domain_id/i.test(sql)) {
+          const [userId] = params as [string];
+          const counts = new Map<number, number>();
+          for (const a of alertStore.values()) {
+            if (a.acknowledged_at !== null) continue;
+            const d = domainStore.get(a.domain_id);
+            if (!d || d.user_id !== userId) continue;
+            counts.set(a.domain_id, (counts.get(a.domain_id) ?? 0) + 1);
+          }
+          const rows = [...counts.entries()].map(([domain_id, count]) => ({
+            domain_id,
+            count,
+          }));
+          return { results: rows as T[] };
+        }
+        // listUnsentAlerts (legacy): filters on notified_via
+        if (
+          /notified_via IS NULL[\s\S]*ORDER BY a\.created_at ASC/i.test(sql)
+        ) {
           const [limit] = params as [number];
           const rows = [...alertStore.values()]
             .filter((a) => a.notified_via === null)
@@ -93,6 +154,7 @@ describe("db/alerts", () => {
       expect(row.previous_value).toBe("A");
       expect(row.new_value).toBe("C");
       expect(row.notified_via).toBeNull();
+      expect(row.acknowledged_at).toBeNull();
       expect(row.created_at).toBe(1_700_000_000);
     });
 
@@ -179,6 +241,151 @@ describe("db/alerts", () => {
 
       expect(alertStore.get(1)?.notified_via).toBe("email");
       expect(alertStore.get(2)?.notified_via).toBeNull();
+    });
+  });
+
+  describe("listUnacknowledgedForUser", () => {
+    it("returns only the requesting user's unacknowledged alerts, newest first", async () => {
+      await recordAlert(db, {
+        domainId: 7, // user_1
+        type: "grade_drop",
+        previousValue: "A",
+        newValue: "B",
+        createdAt: 100,
+      });
+      await recordAlert(db, {
+        domainId: 7,
+        type: "grade_drop",
+        previousValue: "B",
+        newValue: "C",
+        createdAt: 200,
+      });
+      await recordAlert(db, {
+        domainId: 9, // user_2 — must NOT appear for user_1
+        type: "grade_drop",
+        previousValue: "A",
+        newValue: "F",
+        createdAt: 300,
+      });
+
+      const rows = await listUnacknowledgedForUser(db, "user_1");
+      expect(rows.map((r) => r.id)).toEqual([2, 1]); // DESC by created_at
+      expect(rows.every((r) => r.domain === "example.com")).toBe(true);
+    });
+
+    it("excludes already-acknowledged alerts", async () => {
+      await recordAlert(db, {
+        domainId: 7,
+        type: "grade_drop",
+        previousValue: "A",
+        newValue: "B",
+        createdAt: 100,
+      });
+      await acknowledgeAlert(db, "user_1", 1, 999);
+
+      const rows = await listUnacknowledgedForUser(db, "user_1");
+      expect(rows).toEqual([]);
+    });
+
+    it("respects the limit", async () => {
+      for (let i = 0; i < 5; i++) {
+        await recordAlert(db, {
+          domainId: 7,
+          type: "grade_drop",
+          previousValue: "A",
+          newValue: "B",
+          createdAt: 100 + i,
+        });
+      }
+      const rows = await listUnacknowledgedForUser(db, "user_1", 2);
+      expect(rows).toHaveLength(2);
+    });
+  });
+
+  describe("acknowledgeAlert", () => {
+    beforeEach(async () => {
+      await recordAlert(db, {
+        domainId: 7, // user_1
+        type: "grade_drop",
+        previousValue: "A",
+        newValue: "C",
+        createdAt: 100,
+      });
+    });
+
+    it("returns true and sets acknowledged_at on first call", async () => {
+      const ok = await acknowledgeAlert(db, "user_1", 1, 555);
+      expect(ok).toBe(true);
+      expect(alertStore.get(1)?.acknowledged_at).toBe(555);
+    });
+
+    it("is idempotent: second call returns false without overwriting timestamp", async () => {
+      await acknowledgeAlert(db, "user_1", 1, 555);
+      const second = await acknowledgeAlert(db, "user_1", 1, 999);
+      expect(second).toBe(false);
+      expect(alertStore.get(1)?.acknowledged_at).toBe(555);
+    });
+
+    it("returns false for another user's alert id (IDOR)", async () => {
+      const ok = await acknowledgeAlert(db, "user_2", 1, 555);
+      expect(ok).toBe(false);
+      expect(alertStore.get(1)?.acknowledged_at).toBeNull();
+    });
+
+    it("returns false for a nonexistent alert id", async () => {
+      const ok = await acknowledgeAlert(db, "user_1", 999, 555);
+      expect(ok).toBe(false);
+    });
+  });
+
+  describe("countUnacknowledgedByDomain", () => {
+    it("groups unacknowledged alerts by domain id and excludes other users", async () => {
+      await recordAlert(db, {
+        domainId: 7,
+        type: "grade_drop",
+        previousValue: "A",
+        newValue: "B",
+        createdAt: 100,
+      });
+      await recordAlert(db, {
+        domainId: 7,
+        type: "grade_drop",
+        previousValue: "B",
+        newValue: "C",
+        createdAt: 200,
+      });
+      await recordAlert(db, {
+        domainId: 9, // user_2's domain — must not appear
+        type: "grade_drop",
+        previousValue: "A",
+        newValue: "F",
+        createdAt: 300,
+      });
+
+      const counts = await countUnacknowledgedByDomain(db, "user_1");
+      expect(counts.get(7)).toBe(2);
+      expect(counts.has(9)).toBe(false);
+    });
+
+    it("excludes acknowledged alerts from the count", async () => {
+      await recordAlert(db, {
+        domainId: 7,
+        type: "grade_drop",
+        previousValue: "A",
+        newValue: "B",
+        createdAt: 100,
+      });
+      await recordAlert(db, {
+        domainId: 7,
+        type: "grade_drop",
+        previousValue: "B",
+        newValue: "C",
+        createdAt: 200,
+      });
+      await acknowledgeAlert(db, "user_1", 1, 999);
+
+      const counts = await countUnacknowledgedByDomain(db, "user_1");
+      expect(counts.get(7)).toBe(1);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds a **"Needs attention"** section to `/dashboard` listing unacknowledged grade-drop / protocol-regression alerts (already detected by Phase 2b's nightly cron). Each entry has a Dismiss button.
- Adds a per-domain **alert count badge** in the domain table row.
- New IDOR-safe `POST /dashboard/alerts/:id/acknowledge` route. The acknowledge UPDATE only fires if the alert's domain belongs to the session user.
- Schema gains `alerts.acknowledged_at INTEGER` (NULL on existing rows, so older alerts surface until dismissed). `notified_via` (email state) and `acknowledged_at` (in-product state) are independent.

Free-tier feature (retention), no Pro gate.

## Architecture notes

- **Schema dual-applied:** `src/db/schema.sql` updated for fresh DBs; `src/db/migrations/0003_alerts_acknowledged.sql` ALTERs existing prod D1. Matches the Phase 2c pattern (`0002_email_alerts.sql`).
- **No new detector or table** — extends the existing `alerts` table and reads from the detectors already wired in `src/cron/rescan.ts`.
- **No CSRF token** — matches every other dashboard POST (add-domain, scan, delete, settings); SameSite session cookie only.
- **DMarcus untouched** — the section header doesn't render the mascot. The grade-keyed mascot already lives on the report page; an alert is about a *transition*, not the current grade, so adding a worried/scared mascot here would compete visually.

## Out of scope

- Email pipeline (`src/alerts/dispatcher.ts`) — independent.
- New tables.
- `src/analyzers/mta-sts.ts` redirect mode — regressed twice via #58/#92, untouched.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 600 passing (added 12 new cases across `db-alerts.test.ts` and `dashboard-routes.test.ts` covering IDOR, idempotency, ownership, badge rendering, 400 on bad id, 404 on cross-user id)
- [x] Local Wrangler smoke: schema applies cleanly; `PRAGMA table_info(alerts)` shows new column; `/dashboard` 302s to `/auth/login` as expected; public `/` 200s.

## Post-merge step (one-time)

After Cloudflare auto-deploys, apply the migration to remote D1:

```
npx wrangler d1 execute dmarcheck-db --remote --file=src/db/migrations/0003_alerts_acknowledged.sql
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)