### PR TITLE
Phase 4c: bulk scan (Pro-gated, 100-domain cap)

### DIFF
--- a/src/api/bulk-scan.ts
+++ b/src/api/bulk-scan.ts
@@ -1,0 +1,195 @@
+import { createDomain, getDomainByUserAndName } from "../db/domains.js";
+import { recordScan } from "../db/scans.js";
+import { scan as defaultScan } from "../orchestrator.js";
+import { normalizeDomain } from "../shared/domain.js";
+
+// Phase 4c — bulk scan core. Two callers (POST /api/bulk-scan with bearer
+// auth, POST /dashboard/bulk with session auth) share this logic; both must
+// already have proven the requesting user is on the Pro plan before invoking.
+
+export const BULK_TOTAL_CAP = 100;
+export const BULK_IN_BAND_CAP = 30;
+export const BULK_BATCH_SIZE = 10;
+
+export type BulkResultStatus = "scanned" | "queued" | "error" | "invalid";
+
+export interface BulkResultEntry {
+  // The normalized domain when valid; the raw input when invalid.
+  domain: string;
+  status: BulkResultStatus;
+  // Set when status === "scanned".
+  grade?: string;
+  // Set when status === "error" or "invalid". String-only — never echoes raw
+  // user input verbatim, so this field is safe for both HTML and JSON callers.
+  error?: string;
+}
+
+export interface BulkScanResponse {
+  accepted: number;
+  rejected: number;
+  results: BulkResultEntry[];
+}
+
+interface ScanLike {
+  grade: string;
+  breakdown: { factors: unknown };
+  protocols: unknown;
+}
+
+export interface ProcessBulkScanInput {
+  db: D1Database;
+  userId: string;
+  rawDomains: string[];
+  // Injectable for tests — defaults to the orchestrator's `scan`.
+  scanFn?: (domain: string) => Promise<ScanLike>;
+  now?: number;
+  // Knobs for tests; defaults match the production caps above.
+  inBandCap?: number;
+  batchSize?: number;
+}
+
+export interface BulkCapExceededError {
+  capExceeded: true;
+  submitted: number;
+  cap: number;
+}
+
+export type ProcessBulkScanOutcome = BulkScanResponse | BulkCapExceededError;
+
+export function isCapExceeded(
+  outcome: ProcessBulkScanOutcome,
+): outcome is BulkCapExceededError {
+  return (outcome as BulkCapExceededError).capExceeded === true;
+}
+
+// Splits input into normalized-valid + invalid + dedup, then dispatches up to
+// `inBandCap` for synchronous scanning and the rest into the cron queue (a
+// `domains` row with last_scanned_at = NULL — `getDueDomains` picks those
+// up first because of `NULLS FIRST`).
+export async function processBulkScan(
+  input: ProcessBulkScanInput,
+): Promise<ProcessBulkScanOutcome> {
+  const scanFn = input.scanFn ?? defaultScan;
+  const inBandCap = input.inBandCap ?? BULK_IN_BAND_CAP;
+  const batchSize = input.batchSize ?? BULK_BATCH_SIZE;
+
+  if (input.rawDomains.length > BULK_TOTAL_CAP) {
+    return {
+      capExceeded: true,
+      submitted: input.rawDomains.length,
+      cap: BULK_TOTAL_CAP,
+    };
+  }
+
+  // Normalize + dedupe in input order. Invalid entries become result rows
+  // immediately so the caller sees one row per submitted line.
+  const seenValid = new Set<string>();
+  const seenInvalid = new Set<string>();
+  const valid: string[] = [];
+  const invalidResults: BulkResultEntry[] = [];
+
+  for (const raw of input.rawDomains) {
+    const trimmed = typeof raw === "string" ? raw.trim() : "";
+    if (trimmed === "") continue;
+    const normalized = normalizeDomain(trimmed);
+    if (!normalized) {
+      // Echo the raw input back so the user can fix it in the form. Capped at
+      // 253 chars (the longest a valid domain could be) to bound JSON payload.
+      const safe = trimmed.slice(0, 253);
+      if (seenInvalid.has(safe)) continue;
+      seenInvalid.add(safe);
+      invalidResults.push({
+        domain: safe,
+        status: "invalid",
+        error: "Not a valid domain",
+      });
+      continue;
+    }
+    if (seenValid.has(normalized)) continue;
+    seenValid.add(normalized);
+    valid.push(normalized);
+  }
+
+  const inBand = valid.slice(0, inBandCap);
+  const queued = valid.slice(inBandCap);
+
+  const inBandResults: BulkResultEntry[] = [];
+  for (let i = 0; i < inBand.length; i += batchSize) {
+    const batch = inBand.slice(i, i + batchSize);
+    const outcomes = await Promise.allSettled(
+      batch.map((domain) => scanOne(input.db, input.userId, domain, scanFn)),
+    );
+    for (let j = 0; j < outcomes.length; j++) {
+      const outcome = outcomes[j];
+      const domain = batch[j];
+      if (outcome.status === "fulfilled") {
+        inBandResults.push(outcome.value);
+      } else {
+        inBandResults.push({
+          domain,
+          status: "error",
+          error: "Scan failed",
+        });
+      }
+    }
+  }
+
+  const queuedResults: BulkResultEntry[] = [];
+  for (const domain of queued) {
+    try {
+      await ensureDomainRow(input.db, input.userId, domain);
+      queuedResults.push({ domain, status: "queued" });
+    } catch {
+      queuedResults.push({
+        domain,
+        status: "error",
+        error: "Could not queue domain",
+      });
+    }
+  }
+
+  // Stable order: invalid first (so the user sees them), then in-band, then
+  // queued. This matches what the dashboard form will render top-to-bottom.
+  const results = [...invalidResults, ...inBandResults, ...queuedResults];
+  const accepted = results.filter(
+    (r) => r.status === "scanned" || r.status === "queued",
+  ).length;
+  const rejected = results.length - accepted;
+  return { accepted, rejected, results };
+}
+
+async function scanOne(
+  db: D1Database,
+  userId: string,
+  domain: string,
+  scanFn: (domain: string) => Promise<ScanLike>,
+): Promise<BulkResultEntry> {
+  const owned = await ensureDomainRow(db, userId, domain);
+  const result = await scanFn(domain);
+  await recordScan(db, {
+    domainId: owned.id,
+    grade: result.grade,
+    scoreFactors: result.breakdown.factors,
+    protocolResults: result.protocols,
+  });
+  return { domain, status: "scanned", grade: result.grade };
+}
+
+// Idempotent watchlist insert: returns the existing row if present, otherwise
+// creates one (Pro plan, weekly cadence) and re-fetches to get the row id. We
+// look up after insert rather than relying on D1's last_row_id because the
+// helper is async and other concurrent inserts could race the cursor.
+async function ensureDomainRow(
+  db: D1Database,
+  userId: string,
+  domain: string,
+): Promise<{ id: number }> {
+  const existing = await getDomainByUserAndName(db, userId, domain);
+  if (existing) return { id: existing.id };
+  await createDomain(db, { userId, domain, isFree: false });
+  const created = await getDomainByUserAndName(db, userId, domain);
+  if (!created) {
+    throw new Error("Domain row missing after insert");
+  }
+  return { id: created.id };
+}

--- a/src/api/catalog.ts
+++ b/src/api/catalog.ts
@@ -15,24 +15,17 @@ export interface ApiCatalog {
 }
 
 export function buildApiCatalog(origin: string = CANONICAL_ORIGIN): ApiCatalog {
+  const sharedRefs = {
+    "service-desc": [
+      { href: `${origin}/openapi.json`, type: "application/openapi+json" },
+    ],
+    "service-doc": [{ href: `${origin}/docs/api`, type: "text/html" }],
+    status: [{ href: `${origin}/health` }],
+  };
   return {
     linkset: [
-      {
-        anchor: `${origin}/api/check`,
-        "service-desc": [
-          {
-            href: `${origin}/openapi.json`,
-            type: "application/openapi+json",
-          },
-        ],
-        "service-doc": [
-          {
-            href: `${origin}/docs/api`,
-            type: "text/html",
-          },
-        ],
-        status: [{ href: `${origin}/health` }],
-      },
+      { anchor: `${origin}/api/check`, ...sharedRefs },
+      { anchor: `${origin}/api/bulk-scan`, ...sharedRefs },
     ],
   };
 }

--- a/src/api/openapi.ts
+++ b/src/api/openapi.ts
@@ -118,6 +118,78 @@ export const OPENAPI_DOCUMENT = {
         },
       },
     },
+    "/api/bulk-scan": {
+      post: {
+        summary: "Bulk scan up to 100 domains (Pro)",
+        description:
+          "Bearer-authenticated, Pro-only. The first 30 domains are scanned synchronously in batches of 10; the rest are added to the watchlist and picked up by the next nightly cron. Each entry is normalized via the same rules as `/api/check`; invalid entries are reported per-row rather than rejecting the whole batch.",
+        operationId: "bulkScanDomains",
+        security: [{ bearerAuth: [] }],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["domains"],
+                properties: {
+                  domains: {
+                    type: "array",
+                    minItems: 1,
+                    maxItems: 100,
+                    items: { type: "string", maxLength: 253 },
+                  },
+                },
+              },
+              example: { domains: ["example.com", "another.org"] },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "Bulk scan dispatched",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/BulkScanResponse" },
+              },
+            },
+          },
+          "400": {
+            description:
+              "Malformed body, non-string entries, or `domains.length > 100`",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Error" },
+              },
+            },
+          },
+          "401": {
+            description: "Bearer token missing or invalid",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Error" },
+              },
+            },
+          },
+          "402": {
+            description: "Bearer is on the Free plan; upgrade required",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Error" },
+              },
+            },
+          },
+          "429": {
+            description: "Rate limit exceeded",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Error" },
+              },
+            },
+          },
+        },
+      },
+    },
     "/api/check/stream": {
       get: {
         summary: "Stream scan results as Server-Sent Events",
@@ -242,6 +314,15 @@ export const OPENAPI_DOCUMENT = {
     },
   },
   components: {
+    securitySchemes: {
+      bearerAuth: {
+        type: "http",
+        scheme: "bearer",
+        bearerFormat: "dmk_<32-hex>",
+        description:
+          "API key generated at /dashboard/settings/api-keys. Sent as `Authorization: Bearer dmk_…`.",
+      },
+    },
     schemas: {
       Status: statusEnum,
       Validation: validation,
@@ -249,6 +330,31 @@ export const OPENAPI_DOCUMENT = {
         type: "object",
         required: ["error"],
         properties: { error: { type: "string" } },
+      },
+      BulkScanResultEntry: {
+        type: "object",
+        required: ["domain", "status"],
+        properties: {
+          domain: { type: "string" },
+          status: {
+            type: "string",
+            enum: ["scanned", "queued", "error", "invalid"],
+          },
+          grade: { type: "string" },
+          error: { type: "string" },
+        },
+      },
+      BulkScanResponse: {
+        type: "object",
+        required: ["accepted", "rejected", "results"],
+        properties: {
+          accepted: { type: "integer" },
+          rejected: { type: "integer" },
+          results: {
+            type: "array",
+            items: { $ref: "#/components/schemas/BulkScanResultEntry" },
+          },
+        },
       },
       DmarcResult: {
         type: "object",

--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -1,4 +1,10 @@
 import { Hono } from "hono";
+import {
+  BULK_IN_BAND_CAP,
+  BULK_TOTAL_CAP,
+  isCapExceeded,
+  processBulkScan,
+} from "../api/bulk-scan.js";
 import { generateApiKey } from "../auth/api-key.js";
 import { requireAuth } from "../auth/middleware.js";
 import type { SessionPayload } from "../auth/session.js";
@@ -31,6 +37,7 @@ import { normalizeDomain } from "../shared/domain.js";
 import {
   renderAddDomainPage,
   renderApiKeysPage,
+  renderBulkScanPage,
   renderDashboardPage,
   renderDomainDetailPage,
   renderDomainHistoryPage,
@@ -143,6 +150,82 @@ dashboardRoutes.post("/domain/add", async (c) => {
     isFree: false,
   });
   return c.redirect(`/dashboard/domain/${encodeURIComponent(normalized)}`, 303);
+});
+
+// Bulk scan (Pro). The route is reachable for free users so the upgrade CTA
+// has somewhere to land — same gate-the-payload-not-the-route pattern as the
+// scan-history page from PR #153.
+dashboardRoutes.get("/bulk", async (c) => {
+  const session = c.get("user" as never) as SessionPayload;
+  const db = (c.env as { DB: D1Database }).DB;
+  const plan = await getPlanForUser(db, session.sub);
+  return c.html(
+    renderBulkScanPage({
+      email: session.email,
+      plan,
+      submitted: null,
+      results: null,
+      error: null,
+      totalCap: BULK_TOTAL_CAP,
+      inBandCap: BULK_IN_BAND_CAP,
+    }),
+  );
+});
+
+dashboardRoutes.post("/bulk", async (c) => {
+  const session = c.get("user" as never) as SessionPayload;
+  const db = (c.env as { DB: D1Database }).DB;
+  const plan = await getPlanForUser(db, session.sub);
+  if (plan !== "pro") {
+    return c.html(
+      renderBulkScanPage({
+        email: session.email,
+        plan,
+        submitted: null,
+        results: null,
+        error: "Bulk scan is a Pro feature.",
+        totalCap: BULK_TOTAL_CAP,
+        inBandCap: BULK_IN_BAND_CAP,
+      }),
+      402,
+    );
+  }
+  const body = await c.req.parseBody();
+  const raw = typeof body.domains === "string" ? body.domains : "";
+  const lines = raw
+    .split(/[\r\n,]+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  const outcome = await processBulkScan({
+    db,
+    userId: session.sub,
+    rawDomains: lines,
+  });
+  if (isCapExceeded(outcome)) {
+    return c.html(
+      renderBulkScanPage({
+        email: session.email,
+        plan,
+        submitted: lines.length,
+        results: null,
+        error: `Too many domains: ${outcome.submitted} submitted, max ${outcome.cap}.`,
+        totalCap: BULK_TOTAL_CAP,
+        inBandCap: BULK_IN_BAND_CAP,
+      }),
+      400,
+    );
+  }
+  return c.html(
+    renderBulkScanPage({
+      email: session.email,
+      plan,
+      submitted: lines.length,
+      results: outcome,
+      error: null,
+      totalCap: BULK_TOTAL_CAP,
+      inBandCap: BULK_IN_BAND_CAP,
+    }),
+  );
 });
 
 // Domain detail

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,12 @@ import type {
   ScanResult,
   SpfResult,
 } from "./analyzers/types.js";
-import { API_CATALOG_JSON } from "./api/catalog.js";
+import {
+  BULK_IN_BAND_CAP,
+  isCapExceeded,
+  processBulkScan,
+} from "./api/bulk-scan.js";
+import { API_CATALOG_JSON, CANONICAL_ORIGIN } from "./api/catalog.js";
 import { OPENAPI_JSON } from "./api/openapi.js";
 import { type BearerIdentity, resolveBearer } from "./auth/api-key.js";
 import { authRoutes } from "./auth/routes.js";
@@ -348,6 +353,18 @@ app.use(
 
 app.use(
   "/api/check",
+  rateLimitMiddleware((c, result, headers) =>
+    c.json({ error: blockedMessage(result) }, { status: 429, headers }),
+  ),
+);
+
+// Bulk scan also runs N analyzers in-band per request — same rate-limit
+// posture as /api/check (Pro bearer → user bucket; everyone else → IP).
+// TODO(phase-4-pr3-followup): once per-plan limits expose a "weight" knob,
+// charge bulk requests proportionally to the in-band scan count instead of
+// counting as a single request.
+app.use(
+  "/api/bulk-scan",
   rateLimitMiddleware((c, result, headers) =>
     c.json({ error: blockedMessage(result) }, { status: 429, headers }),
   ),
@@ -744,6 +761,69 @@ app.get("/api/check", async (c) => {
     const message = err instanceof Error ? err.message : "Internal error";
     return c.json({ error: message }, 500);
   }
+});
+
+// Bulk scan — Pro-only, bearer-authenticated. Up to BULK_TOTAL_CAP submitted;
+// the first BULK_IN_BAND_CAP are scanned synchronously in batches and the
+// rest are queued by inserting `domains` rows for the next cron pickup. Per-
+// entry results let the caller distinguish scanned/queued/invalid/error.
+app.post("/api/bulk-scan", async (c) => {
+  const bearer =
+    (c.get("bearer" as never) as BearerIdentity | undefined) ?? null;
+  if (!bearer) {
+    return c.json(
+      {
+        error:
+          "Bearer token required. Generate one at /dashboard/settings/api-keys.",
+      },
+      401,
+    );
+  }
+  const db = (c.env as { DB?: D1Database }).DB;
+  if (!db) {
+    return c.json({ error: "Database not configured" }, 500);
+  }
+  const plan = await getPlanForUser(db, bearer.userId);
+  if (plan !== "pro") {
+    return c.json(
+      {
+        error: "Bulk scan requires a Pro plan.",
+        upgrade: `${CANONICAL_ORIGIN}/dashboard/billing/subscribe`,
+      },
+      402,
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+  const rawDomains = (body as { domains?: unknown })?.domains;
+  if (!Array.isArray(rawDomains)) {
+    return c.json({ error: "Body must be { domains: string[] }" }, 400);
+  }
+  if (!rawDomains.every((d): d is string => typeof d === "string")) {
+    return c.json({ error: "All domains must be strings" }, 400);
+  }
+
+  const outcome = await processBulkScan({
+    db,
+    userId: bearer.userId,
+    rawDomains,
+  });
+  if (isCapExceeded(outcome)) {
+    return c.json(
+      {
+        error: `Too many domains: ${outcome.submitted} > ${outcome.cap}`,
+        cap: outcome.cap,
+        in_band_cap: BULK_IN_BAND_CAP,
+      },
+      400,
+    );
+  }
+  return c.json(outcome);
 });
 
 // Fire-and-forget: look up the (user, domain) pair and record a scan_history

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -367,6 +367,61 @@ const DASHBOARD_CSS = `
   margin-top: 0.5rem;
   flex-wrap: wrap;
 }
+.bulk-textarea {
+  display: block;
+  width: 100%;
+  min-height: 12rem;
+  padding: 0.75rem;
+  border: 1px solid var(--clr-border);
+  border-radius: 6px;
+  background: var(--clr-bg);
+  color: var(--clr-text);
+  font-family: monospace;
+  font-size: 0.875rem;
+  box-sizing: border-box;
+  resize: vertical;
+}
+.bulk-results-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+.bulk-results-table th,
+.bulk-results-table td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--clr-border);
+  text-align: left;
+}
+.bulk-results-table tr:last-child td {
+  border-bottom: none;
+}
+.bulk-status {
+  display: inline-block;
+  padding: 0.1rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.bulk-status.scanned { color: var(--clr-pass); background: var(--clr-pass-bg); }
+.bulk-status.queued { color: var(--clr-text-muted); background: var(--clr-bg); border: 1px solid var(--clr-border); }
+.bulk-status.invalid { color: var(--clr-warn); background: var(--clr-warn-bg); }
+.bulk-status.error { color: var(--clr-fail); background: var(--clr-fail-bg); }
+.bulk-summary {
+  font-size: 0.875rem;
+  color: var(--clr-text-muted);
+  margin-bottom: 1rem;
+}
+.bulk-error {
+  background: var(--clr-fail-bg);
+  color: var(--clr-fail);
+  border: 1px solid var(--clr-fail);
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  font-size: 0.875rem;
+}
 .sparkline {
   width: 100%;
   height: 80px;
@@ -470,6 +525,7 @@ function dashboardPage(title: string, body: string, email: string): string {
   <a href="/" class="nav-logo">${generateCreature("sm")} dmarc.mx</a>
   <div class="nav-links">
     <a href="/dashboard">Domains</a>
+    <a href="/dashboard/bulk">Bulk Scan</a>
     <a href="/dashboard/settings">Settings</a>
   </div>
   <div class="nav-user">
@@ -891,6 +947,119 @@ ${errorBlock}
 </form>`;
 
   return dashboardPage("Add Domain — dmarc.mx", body, email);
+}
+
+export interface BulkResultRow {
+  domain: string;
+  status: "scanned" | "queued" | "error" | "invalid";
+  grade?: string;
+  error?: string;
+}
+
+export interface BulkRenderResults {
+  accepted: number;
+  rejected: number;
+  results: BulkResultRow[];
+}
+
+export function renderBulkScanPage({
+  email,
+  plan,
+  submitted,
+  results,
+  error,
+  totalCap,
+  inBandCap,
+}: {
+  email: string;
+  plan: "free" | "pro";
+  submitted: number | null;
+  results: BulkRenderResults | null;
+  error: string | null;
+  totalCap: number;
+  inBandCap: number;
+}): string {
+  if (plan !== "pro") {
+    const body = `<h1 class="dashboard-title">Bulk Scan</h1>
+<div class="upgrade-prompt">
+  <h2>Pro feature</h2>
+  <p>Bulk scan accepts up to ${totalCap} domains per request and runs the first ${inBandCap} immediately. Available on the Pro plan.</p>
+  <a href="/dashboard/billing/subscribe" class="btn">Upgrade to Pro</a>
+</div>
+${error ? `<div class="bulk-error">${esc(error)}</div>` : ""}`;
+    return dashboardPage("Bulk Scan — dmarc.mx", body, email);
+  }
+
+  const errorBlock = error ? `<div class="bulk-error">${esc(error)}</div>` : "";
+
+  const resultsBlock = results
+    ? `<div class="section-card">
+  <h2>Results</h2>
+  <p class="bulk-summary">
+    ${submitted ?? results.results.length} submitted —
+    <strong>${results.accepted}</strong> accepted,
+    <strong>${results.rejected}</strong> rejected.
+    First ${inBandCap} scanned in-band; the rest queued for the next nightly cron pass.
+  </p>
+  ${
+    results.results.length === 0
+      ? `<p class="bulk-summary">No domains parsed from the submission.</p>`
+      : `<table class="bulk-results-table">
+    <thead>
+      <tr>
+        <th>Domain</th>
+        <th>Status</th>
+        <th>Grade / Error</th>
+      </tr>
+    </thead>
+    <tbody>${results.results.map(renderBulkRow).join("")}</tbody>
+  </table>`
+  }
+</div>`
+    : "";
+
+  const body = `<h1 class="dashboard-title">Bulk Scan</h1>
+<p class="bulk-summary">
+  Paste up to <strong>${totalCap}</strong> domains (one per line, or comma-separated). The first
+  <strong>${inBandCap}</strong> will be scanned immediately; the rest queue for the next cron pass.
+</p>
+${errorBlock}
+<form method="POST" action="/dashboard/bulk" class="settings-section">
+  <label for="bulk-input" style="display:block;font-size:0.875rem;color:var(--clr-text-muted);margin-bottom:0.4rem">Domains</label>
+  <textarea
+    id="bulk-input"
+    class="bulk-textarea"
+    name="domains"
+    placeholder="example.com&#10;another.org&#10;corp.example"
+    autocapitalize="none"
+    autocorrect="off"
+    spellcheck="false"
+    required
+  ></textarea>
+  <div class="action-row">
+    <button type="submit" class="btn">Scan</button>
+    <a href="/dashboard" class="btn btn-secondary">Cancel</a>
+  </div>
+</form>
+${resultsBlock}`;
+
+  return dashboardPage("Bulk Scan — dmarc.mx", body, email);
+}
+
+function renderBulkRow(row: BulkResultRow): string {
+  const detail =
+    row.status === "scanned" && row.grade
+      ? `<span class="inline-grade ${gradeClass(row.grade)}">${esc(row.grade)}</span>`
+      : row.error
+        ? esc(row.error)
+        : row.status === "queued"
+          ? '<span style="color:var(--clr-text-muted)">Queued for cron</span>'
+          : "";
+  return `<tr>
+  <td><a href="/dashboard/domain/${encodeURIComponent(row.domain)}">${esc(row.domain)}</a></td>
+  <td><span class="bulk-status ${row.status}">${row.status}</span></td>
+  <td>${detail}</td>
+</tr>`;
 }
 
 export function renderSettingsPage({

--- a/test/agent-discovery.test.ts
+++ b/test/agent-discovery.test.ts
@@ -60,13 +60,18 @@ describe("/.well-known/api-catalog", () => {
         status: Array<{ href: string }>;
       }>;
     };
-    expect(body.linkset).toHaveLength(1);
-    const [entry] = body.linkset;
-    expect(entry.anchor).toBe("https://dmarc.mx/api/check");
-    expect(entry["service-desc"][0].href).toBe("https://dmarc.mx/openapi.json");
-    expect(entry["service-desc"][0].type).toBe("application/openapi+json");
-    expect(entry["service-doc"][0].href).toBe("https://dmarc.mx/docs/api");
-    expect(entry.status[0].href).toBe("https://dmarc.mx/health");
+    expect(body.linkset).toHaveLength(2);
+    const anchors = body.linkset.map((e) => e.anchor);
+    expect(anchors).toContain("https://dmarc.mx/api/check");
+    expect(anchors).toContain("https://dmarc.mx/api/bulk-scan");
+    for (const entry of body.linkset) {
+      expect(entry["service-desc"][0].href).toBe(
+        "https://dmarc.mx/openapi.json",
+      );
+      expect(entry["service-desc"][0].type).toBe("application/openapi+json");
+      expect(entry["service-doc"][0].href).toBe("https://dmarc.mx/docs/api");
+      expect(entry.status[0].href).toBe("https://dmarc.mx/health");
+    }
   });
 });
 
@@ -85,6 +90,7 @@ describe("/openapi.json", () => {
     expect(doc.openapi).toBe("3.1.0");
     for (const path of [
       "/api/check",
+      "/api/bulk-scan",
       "/api/check/stream",
       "/check",
       "/health",
@@ -94,6 +100,7 @@ describe("/openapi.json", () => {
     }
     expect(doc.components.schemas.ScanResult).toBeDefined();
     expect(doc.components.schemas.DmarcResult).toBeDefined();
+    expect(doc.components.schemas.BulkScanResponse).toBeDefined();
   });
 });
 

--- a/test/bulk-scan-route.test.ts
+++ b/test/bulk-scan-route.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// resolveBearer is stubbed before importing app to keep the route's bearer
+// signal independent of api-key cryptography in this test file.
+let bearerStub: { userId: string; keyId: string } | null = null;
+
+vi.mock("../src/auth/api-key.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/auth/api-key.js")>(
+    "../src/auth/api-key.js",
+  );
+  return {
+    ...actual,
+    resolveBearer: vi.fn(async () => bearerStub),
+  };
+});
+
+// scan() calls real DNS otherwise — stub it so tests don't depend on the
+// network or the orchestrator's compatibility flags.
+vi.mock("../src/orchestrator.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/orchestrator.js")>(
+    "../src/orchestrator.js",
+  );
+  return {
+    ...actual,
+    scan: vi.fn(async (domain: string) => ({
+      domain,
+      timestamp: "2026-04-19T00:00:00.000Z",
+      grade: "B",
+      breakdown: {
+        grade: "B",
+        tier: "B",
+        tierReason: "test",
+        modifier: 0,
+        modifierLabel: "",
+        factors: [{ name: "dmarc", status: "pass", weight: 1 }],
+        recommendations: [],
+        protocolSummaries: {},
+      },
+      summary: {
+        mx_records: 0,
+        mx_providers: [],
+        dmarc_policy: "none",
+      },
+      protocols: {
+        mx: { status: "info" },
+        dmarc: { status: "pass" },
+        spf: { status: "pass" },
+        dkim: { status: "pass" },
+        bimi: { status: "pass" },
+        mta_sts: { status: "pass" },
+      },
+    })),
+  };
+});
+
+const { app } = await import("../src/index.js");
+
+interface FakeDomain {
+  id: number;
+  user_id: string;
+  domain: string;
+  is_free: number;
+  scan_frequency: string;
+  last_scanned_at: number | null;
+  last_grade: string | null;
+}
+
+interface FakeSubscription {
+  user_id: string;
+  status: string;
+}
+
+let domainStore: FakeDomain[];
+let subStore: FakeSubscription[];
+let nextId: number;
+
+// Minimal D1 mock supporting subscriptions lookup, domain CRUD, and the
+// recordScan batch (INSERT scan_history + UPDATE domains).
+function makeDb(): D1Database {
+  type Bound = {
+    sql: string;
+    params: unknown[];
+    run: () => Promise<{ success: true; meta: { changes: number } }>;
+    first: <T>() => Promise<T | null>;
+    all: <T>() => Promise<{ results: T[] }>;
+  };
+
+  const applyWrite = async (sql: string, params: unknown[]) => {
+    if (/^INSERT INTO domains/i.test(sql)) {
+      const [userId, domain, isFree, frequency] = params as [
+        string,
+        string,
+        number,
+        string,
+      ];
+      domainStore.push({
+        id: nextId++,
+        user_id: userId,
+        domain,
+        is_free: isFree,
+        scan_frequency: frequency,
+        last_scanned_at: null,
+        last_grade: null,
+      });
+    } else if (/^UPDATE domains SET last_grade/i.test(sql)) {
+      const [grade, scannedAt, domainId] = params as [string, number, number];
+      const row = domainStore.find((d) => d.id === domainId);
+      if (row) {
+        row.last_grade = grade;
+        row.last_scanned_at = scannedAt;
+      }
+    }
+    return { success: true as const, meta: { changes: 1 } };
+  };
+
+  const makeBound = (sql: string, params: unknown[]): Bound => ({
+    sql,
+    params,
+    run: () => applyWrite(sql, params),
+    first: async <T>() => {
+      if (sql.includes("SELECT status FROM subscriptions")) {
+        const sub = subStore.find((s) => s.user_id === params[0]);
+        return (sub ? { status: sub.status } : null) as T | null;
+      }
+      if (/SELECT \* FROM domains WHERE user_id = \? AND domain/i.test(sql)) {
+        return (domainStore.find(
+          (d) => d.user_id === params[0] && d.domain === params[1],
+        ) ?? null) as T | null;
+      }
+      return null as T | null;
+    },
+    all: async <T>() => ({ results: [] as T[] }),
+  });
+
+  return {
+    prepare: (sql: string) => ({
+      bind: (...params: unknown[]) => makeBound(sql, params),
+    }),
+    batch: async (stmts: Bound[]) => {
+      const out = [];
+      for (const stmt of stmts) {
+        out.push(await stmt.run());
+      }
+      return out;
+    },
+  } as unknown as D1Database;
+}
+
+function fetchBulk(body: unknown, init: RequestInit = {}) {
+  return app.request(
+    "/api/bulk-scan",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...(init.headers ?? {}) },
+      body: typeof body === "string" ? body : JSON.stringify(body),
+      ...init,
+    },
+    {
+      DB: makeDb(),
+      RATE_LIMIT_KV: undefined,
+    } as unknown as Record<string, unknown>,
+    {
+      waitUntil: () => {},
+      passThroughOnException: () => {},
+    } as ExecutionContext,
+  );
+}
+
+beforeEach(() => {
+  domainStore = [];
+  subStore = [];
+  nextId = 1;
+  bearerStub = null;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/bulk-scan", () => {
+  it("returns 401 when no bearer is presented", async () => {
+    const res = await fetchBulk({ domains: ["example.com"] });
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/bearer/i);
+  });
+
+  it("returns 402 for a free-plan bearer (Pro gate)", async () => {
+    bearerStub = { userId: "user_free", keyId: "k1" };
+    // No subscription row → free plan.
+    const res = await fetchBulk({ domains: ["example.com"] });
+    expect(res.status).toBe(402);
+    const body = (await res.json()) as { error: string; upgrade?: string };
+    expect(body.error).toMatch(/Pro/i);
+    expect(body.upgrade).toContain("/dashboard/billing/subscribe");
+  });
+
+  it("returns 200 with results for a Pro bearer (happy path)", async () => {
+    bearerStub = { userId: "user_pro", keyId: "k1" };
+    subStore.push({ user_id: "user_pro", status: "active" });
+    const res = await fetchBulk({ domains: ["a.example", "b.example"] });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      accepted: number;
+      rejected: number;
+      results: Array<{ domain: string; status: string; grade?: string }>;
+    };
+    expect(body.accepted).toBe(2);
+    expect(body.rejected).toBe(0);
+    expect(body.results.map((r) => r.status).sort()).toEqual([
+      "scanned",
+      "scanned",
+    ]);
+    expect(body.results.every((r) => r.grade === "B")).toBe(true);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    bearerStub = { userId: "user_pro", keyId: "k1" };
+    subStore.push({ user_id: "user_pro", status: "active" });
+    const res = await fetchBulk("not json", {});
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/Invalid JSON/i);
+  });
+
+  it("returns 400 when body lacks a `domains` array", async () => {
+    bearerStub = { userId: "user_pro", keyId: "k1" };
+    subStore.push({ user_id: "user_pro", status: "active" });
+    const res = await fetchBulk({ wrong: "shape" });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/domains/i);
+  });
+
+  it("returns 400 when entries are not strings", async () => {
+    bearerStub = { userId: "user_pro", keyId: "k1" };
+    subStore.push({ user_id: "user_pro", status: "active" });
+    const res = await fetchBulk({ domains: ["ok.example", 123] });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/strings/i);
+  });
+
+  it("returns 400 with cap details when domains.length > 100", async () => {
+    bearerStub = { userId: "user_pro", keyId: "k1" };
+    subStore.push({ user_id: "user_pro", status: "active" });
+    const tooMany = Array.from({ length: 101 }, (_, i) => `d${i}.example`);
+    const res = await fetchBulk({ domains: tooMany });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      error: string;
+      cap: number;
+      in_band_cap: number;
+    };
+    expect(body.cap).toBe(100);
+    expect(body.in_band_cap).toBe(30);
+    expect(body.error).toMatch(/101.*100/);
+  });
+
+  it("treats a cancelled subscription as free (returns 402)", async () => {
+    bearerStub = { userId: "user_was_pro", keyId: "k1" };
+    subStore.push({ user_id: "user_was_pro", status: "canceled" });
+    const res = await fetchBulk({ domains: ["example.com"] });
+    expect(res.status).toBe(402);
+  });
+});

--- a/test/bulk-scan.test.ts
+++ b/test/bulk-scan.test.ts
@@ -1,0 +1,301 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  BULK_IN_BAND_CAP,
+  BULK_TOTAL_CAP,
+  isCapExceeded,
+  processBulkScan,
+} from "../src/api/bulk-scan.js";
+
+interface DomainRow {
+  id: number;
+  user_id: string;
+  domain: string;
+  is_free: number;
+  scan_frequency: string;
+  last_scanned_at: number | null;
+  last_grade: string | null;
+}
+
+interface ScanHistoryRow {
+  domain_id: number;
+  grade: string;
+  scanned_at: number;
+}
+
+let domainStore: DomainRow[];
+let scanHistory: ScanHistoryRow[];
+let nextId: number;
+
+// recordScan uses db.batch([prepare(...).bind(...), prepare(...).bind(...)]).
+// To make that resolve in tests, .bind() returns a thunk that captures sql +
+// params and `batch` invokes each thunk's `run`. .first() also reads from the
+// captured sql/params.
+function makeDb(): D1Database {
+  type BoundStmt = {
+    sql: string;
+    params: unknown[];
+    run: () => Promise<{ success: true; meta: { changes: number } }>;
+    first: <T>() => Promise<T | null>;
+  };
+
+  const applyWrite = async (sql: string, params: unknown[]) => {
+    if (/^INSERT INTO domains/i.test(sql)) {
+      const [userId, domain, isFree, frequency] = params as [
+        string,
+        string,
+        number,
+        string,
+      ];
+      domainStore.push({
+        id: nextId++,
+        user_id: userId,
+        domain,
+        is_free: isFree,
+        scan_frequency: frequency,
+        last_scanned_at: null,
+        last_grade: null,
+      });
+    } else if (/^INSERT INTO scan_history/i.test(sql)) {
+      const [domainId, grade, , , scannedAt] = params as [
+        number,
+        string,
+        string,
+        string,
+        number,
+      ];
+      scanHistory.push({ domain_id: domainId, grade, scanned_at: scannedAt });
+    } else if (/^UPDATE domains SET last_grade/i.test(sql)) {
+      const [grade, scannedAt, domainId] = params as [string, number, number];
+      const row = domainStore.find((d) => d.id === domainId);
+      if (row) {
+        row.last_grade = grade;
+        row.last_scanned_at = scannedAt;
+      }
+    }
+    return { success: true as const, meta: { changes: 1 } };
+  };
+
+  const makeBound = (sql: string, params: unknown[]): BoundStmt => ({
+    sql,
+    params,
+    run: () => applyWrite(sql, params),
+    first: async <T>() => {
+      if (/SELECT \* FROM domains WHERE user_id = \? AND domain/i.test(sql)) {
+        return (domainStore.find(
+          (d) => d.user_id === params[0] && d.domain === params[1],
+        ) ?? null) as T | null;
+      }
+      return null as T | null;
+    },
+  });
+
+  return {
+    prepare: (sql: string) => ({
+      bind: (...params: unknown[]) => makeBound(sql, params),
+    }),
+    batch: async (stmts: BoundStmt[]) => {
+      const out = [];
+      for (const stmt of stmts) {
+        out.push(await stmt.run());
+      }
+      return out;
+    },
+  } as unknown as D1Database;
+}
+
+const okScan = (domain: string) => ({
+  grade: "B",
+  breakdown: { factors: [{ name: "dmarc", status: "pass" }] },
+  protocols: { dmarc: { status: "pass" } },
+  domain,
+});
+
+beforeEach(() => {
+  domainStore = [];
+  scanHistory = [];
+  nextId = 1;
+});
+
+describe("processBulkScan", () => {
+  it("rejects when more than BULK_TOTAL_CAP domains submitted", async () => {
+    const tooMany = Array.from(
+      { length: BULK_TOTAL_CAP + 1 },
+      (_, i) => `d${i}.example`,
+    );
+    const out = await processBulkScan({
+      db: makeDb(),
+      userId: "user_1",
+      rawDomains: tooMany,
+      scanFn: vi.fn(async (d) => okScan(d)),
+    });
+    expect(isCapExceeded(out)).toBe(true);
+    if (isCapExceeded(out)) {
+      expect(out.cap).toBe(BULK_TOTAL_CAP);
+      expect(out.submitted).toBe(BULK_TOTAL_CAP + 1);
+    }
+  });
+
+  it("returns one invalid entry per malformed input, dedup'd", async () => {
+    const scanFn = vi.fn(async (d: string) => okScan(d));
+    const out = await processBulkScan({
+      db: makeDb(),
+      userId: "user_1",
+      rawDomains: ["not a domain", "not a domain", "  ", "@@@"],
+      scanFn,
+    });
+    if (isCapExceeded(out)) throw new Error("unexpected cap");
+    expect(out.results.filter((r) => r.status === "invalid")).toHaveLength(2);
+    expect(out.accepted).toBe(0);
+    expect(scanFn).not.toHaveBeenCalled();
+  });
+
+  it("scans valid domains in-band (status=scanned, with grade)", async () => {
+    const scanFn = vi.fn(async (d: string) => okScan(d));
+    const out = await processBulkScan({
+      db: makeDb(),
+      userId: "user_1",
+      rawDomains: ["a.example", "b.example", "c.example"],
+      scanFn,
+    });
+    if (isCapExceeded(out)) throw new Error("unexpected cap");
+    expect(out.accepted).toBe(3);
+    expect(out.rejected).toBe(0);
+    const scanned = out.results.filter((r) => r.status === "scanned");
+    expect(scanned).toHaveLength(3);
+    expect(scanned.every((r) => r.grade === "B")).toBe(true);
+    expect(scanHistory).toHaveLength(3);
+    expect(domainStore).toHaveLength(3);
+    expect(domainStore.every((d) => d.is_free === 0)).toBe(true);
+  });
+
+  it("queues anything beyond inBandCap and flips status=queued", async () => {
+    const scanFn = vi.fn(async (d: string) => okScan(d));
+    const submitted = Array.from({ length: 35 }, (_, i) => `d${i}.example`);
+    const out = await processBulkScan({
+      db: makeDb(),
+      userId: "user_1",
+      rawDomains: submitted,
+      scanFn,
+      inBandCap: 30,
+      batchSize: 10,
+    });
+    if (isCapExceeded(out)) throw new Error("unexpected cap");
+    expect(out.accepted).toBe(35);
+    expect(out.rejected).toBe(0);
+    const scanned = out.results.filter((r) => r.status === "scanned");
+    const queued = out.results.filter((r) => r.status === "queued");
+    expect(scanned).toHaveLength(30);
+    expect(queued).toHaveLength(5);
+    // Queued entries land as watchlist rows with last_scanned_at = null so the
+    // cron picks them up on the next pass (NULLS FIRST in getDueDomains).
+    for (const q of queued) {
+      const row = domainStore.find((d) => d.domain === q.domain);
+      expect(row).toBeDefined();
+      expect(row?.last_scanned_at).toBeNull();
+    }
+    expect(scanHistory).toHaveLength(30);
+  });
+
+  it("isolates per-domain scan failures", async () => {
+    const scanFn = vi.fn(async (d: string) => {
+      if (d === "broken.example") throw new Error("DNS exploded");
+      return okScan(d);
+    });
+    const out = await processBulkScan({
+      db: makeDb(),
+      userId: "user_1",
+      rawDomains: ["a.example", "broken.example", "c.example"],
+      scanFn,
+      batchSize: 10,
+    });
+    if (isCapExceeded(out)) throw new Error("unexpected cap");
+    const scanned = out.results.filter((r) => r.status === "scanned");
+    const errors = out.results.filter((r) => r.status === "error");
+    expect(scanned.map((r) => r.domain).sort()).toEqual([
+      "a.example",
+      "c.example",
+    ]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].domain).toBe("broken.example");
+    expect(out.accepted).toBe(2);
+    expect(out.rejected).toBe(1);
+  });
+
+  it("reuses an existing watchlist row instead of creating a duplicate", async () => {
+    domainStore.push({
+      id: 99,
+      user_id: "user_1",
+      domain: "already.example",
+      is_free: 0,
+      scan_frequency: "weekly",
+      last_scanned_at: 1700000000,
+      last_grade: "A",
+    });
+    const out = await processBulkScan({
+      db: makeDb(),
+      userId: "user_1",
+      rawDomains: ["already.example"],
+      scanFn: async (d) => okScan(d),
+    });
+    if (isCapExceeded(out)) throw new Error("unexpected cap");
+    expect(
+      domainStore.filter(
+        (d) => d.user_id === "user_1" && d.domain === "already.example",
+      ),
+    ).toHaveLength(1);
+    expect(scanHistory).toHaveLength(1);
+    expect(scanHistory[0].domain_id).toBe(99);
+  });
+
+  it("normalizes input and dedupes (case + whitespace)", async () => {
+    const scanFn = vi.fn(async (d: string) => okScan(d));
+    const out = await processBulkScan({
+      db: makeDb(),
+      userId: "user_1",
+      rawDomains: [
+        "Example.com",
+        "EXAMPLE.com",
+        "example.com",
+        "  example.com  ",
+      ],
+      scanFn,
+    });
+    if (isCapExceeded(out)) throw new Error("unexpected cap");
+    const scanned = out.results.filter((r) => r.status === "scanned");
+    expect(scanned).toHaveLength(1);
+    expect(scanned[0].domain).toBe("example.com");
+    expect(scanFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("processes the full inBandCap when exactly at the limit", async () => {
+    const scanFn = vi.fn(async (d: string) => okScan(d));
+    const submitted = Array.from(
+      { length: BULK_IN_BAND_CAP },
+      (_, i) => `d${i}.example`,
+    );
+    const out = await processBulkScan({
+      db: makeDb(),
+      userId: "user_1",
+      rawDomains: submitted,
+      scanFn,
+      batchSize: 10,
+    });
+    if (isCapExceeded(out)) throw new Error("unexpected cap");
+    expect(out.accepted).toBe(BULK_IN_BAND_CAP);
+    expect(scanFn).toHaveBeenCalledTimes(BULK_IN_BAND_CAP);
+    expect(out.results.every((r) => r.status === "scanned")).toBe(true);
+  });
+
+  it("returns empty results for an empty submission", async () => {
+    const out = await processBulkScan({
+      db: makeDb(),
+      userId: "user_1",
+      rawDomains: [],
+      scanFn: vi.fn(),
+    });
+    if (isCapExceeded(out)) throw new Error("unexpected cap");
+    expect(out.accepted).toBe(0);
+    expect(out.rejected).toBe(0);
+    expect(out.results).toEqual([]);
+  });
+});

--- a/test/dashboard-routes.test.ts
+++ b/test/dashboard-routes.test.ts
@@ -205,6 +205,9 @@ function createMockDB(data: {
     },
     run: async () => {
       writes?.push({ sql, bindings });
+      // Phase 4b — IDOR-scoped acknowledge UPDATE that the route's POST flow
+      // sends. The mock applies it only when the alert's owning domain
+      // belongs to the supplied user_id, mirroring the SQL.
       if (/^\s*UPDATE alerts\s+SET acknowledged_at/i.test(sql)) {
         const [now, alertId, userId] = bindings as [number, number, string];
         const alert = alerts.find((a) => a.id === alertId);
@@ -217,6 +220,28 @@ function createMockDB(data: {
         }
         alert.acknowledged_at = now;
         return { success: true, meta: { changes: 1 } };
+      }
+      // Phase 4c — apply INSERT INTO domains so processBulkScan's "create
+      // then re-fetch" pattern (avoids relying on last_row_id) finds the new
+      // row when it does the SELECT lookup right after.
+      if (/^INSERT INTO domains/i.test(sql)) {
+        const [userId, domain, isFree, frequency] = bindings as [
+          string,
+          string,
+          number,
+          string,
+        ];
+        domains.push({
+          id:
+            domains.length > 0 ? Math.max(...domains.map((d) => d.id)) + 1 : 1,
+          user_id: userId,
+          domain,
+          is_free: isFree,
+          scan_frequency: frequency,
+          last_scanned_at: null,
+          last_grade: null,
+          created_at: 1700000000,
+        });
       }
       return { success: true, meta: { changes: 1 } };
     },
@@ -1276,7 +1301,6 @@ describe("dashboard/routes", () => {
       expect(body).toContain("Needs attention");
       expect(body).toContain("Grade dropped from A to C");
       expect(body).toContain("/dashboard/alerts/11/acknowledge");
-      // Per-domain badge appears in the table row.
       expect(body).toContain("badge-alert");
       expect(body).toContain("1 alert");
     });
@@ -1448,6 +1472,127 @@ describe("dashboard/routes", () => {
         headers: { Cookie: cookie },
       });
       expect(res.status).toBe(404);
+    });
+  });
+
+  describe("GET /dashboard/bulk", () => {
+    it("redirects to /auth/login without a session cookie", async () => {
+      const db = createMockDB({});
+      const app = createTestApp(db);
+      const res = await app.request("/dashboard/bulk");
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/auth/login");
+    });
+
+    it("renders an upgrade prompt for free users", async () => {
+      const db = createMockDB({});
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/bulk", {
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body).toContain("Pro feature");
+      expect(body).toContain("Upgrade to Pro");
+      expect(body).toContain("/dashboard/billing/subscribe");
+      // Form must NOT render for free users.
+      expect(body).not.toContain('name="domains"');
+    });
+
+    it("renders the bulk-scan textarea for Pro users", async () => {
+      const db = createMockDB({
+        subscriptions: [{ user_id: "user_1", status: "active" }],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/bulk", {
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body).toContain("Bulk Scan");
+      expect(body).toContain('name="domains"');
+      expect(body).not.toContain("Pro feature");
+    });
+  });
+
+  describe("POST /dashboard/bulk", () => {
+    it("redirects to /auth/login without a session cookie", async () => {
+      const db = createMockDB({});
+      const app = createTestApp(db);
+      const res = await app.request("/dashboard/bulk", { method: "POST" });
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/auth/login");
+    });
+
+    it("returns 402 for free users (gates the action, not the route)", async () => {
+      const db = createMockDB({});
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/bulk", {
+        method: "POST",
+        headers: {
+          Cookie: cookie,
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: "domains=example.com",
+      });
+      expect(res.status).toBe(402);
+      const body = await res.text();
+      expect(body).toContain("Bulk scan is a Pro feature.");
+    });
+
+    it("renders results with status badges for a Pro submission", async () => {
+      const db = createMockDB({
+        subscriptions: [{ user_id: "user_1", status: "active" }],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      // 32 valid domains → 30 scanned, 2 queued.
+      const inputDomains = Array.from(
+        { length: 32 },
+        (_, i) => `d${i}.example`,
+      ).join("\n");
+      const body = new URLSearchParams({ domains: inputDomains });
+      const res = await app.request("/dashboard/bulk", {
+        method: "POST",
+        headers: {
+          Cookie: cookie,
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: body.toString(),
+      });
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain('class="bulk-status scanned"');
+      expect(html).toContain('class="bulk-status queued"');
+      expect(html).toContain("Results");
+      expect(html).toMatch(/32 submitted/);
+    });
+
+    it("returns 400 when more than 100 domains are submitted", async () => {
+      const db = createMockDB({
+        subscriptions: [{ user_id: "user_1", status: "active" }],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const inputDomains = Array.from(
+        { length: 101 },
+        (_, i) => `d${i}.example`,
+      ).join("\n");
+      const body = new URLSearchParams({ domains: inputDomains });
+      const res = await app.request("/dashboard/bulk", {
+        method: "POST",
+        headers: {
+          Cookie: cookie,
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: body.toString(),
+      });
+      expect(res.status).toBe(400);
+      const html = await res.text();
+      expect(html).toContain("Too many domains");
     });
   });
 });


### PR DESCRIPTION
## Summary

- New `POST /api/bulk-scan` (bearer-auth, JSON) and `GET`/`POST /dashboard/bulk` (session-auth, HTML form). Both share `src/api/bulk-scan.ts` so the API and dashboard see the same shape.
- Up to **100 domains** per submission. First **30** scanned in-band as 3 batches of 10 via `Promise.allSettled`; the rest become `domains` rows with `last_scanned_at = NULL` so the nightly cron's `NULLS FIRST` ordering picks them up next pass.
- Per-entry result shape: `{domain, status: \"scanned\"|\"queued\"|\"error\"|\"invalid\", grade?, error?}` — one row per submitted line, including `invalid` for input that fails `normalizeDomain`.
- Pro gate: API returns **402** with an `upgrade` URL for free bearers; dashboard renders an inline upgrade prompt (gates payload, not route — same pattern as Phase 4a history).

## Architecture notes

- **Shared core, two thin wrappers:** `processBulkScan({db, userId, rawDomains, scanFn?, inBandCap?, batchSize?})`. The `scanFn` is injectable so tests don't touch DNS or the orchestrator's compatibility flags.
- **OpenAPI 3.1:** new `/api/bulk-scan` path with `bearerAuth` security scheme, `BulkScanResponse` + `BulkScanResultEntry` schemas, and the full 401/402/400/429 response set documented.
- **API catalog:** added a second anchor (`/api/bulk-scan`) sharing the existing service-desc/service-doc/status refs (factored into a `sharedRefs` const).
- **Rate limiting:** 1 bulk request = 1 unit against the Phase 3d per-plan bucket. `TODO(phase-4-pr3-followup)` breadcrumb on the middleware to charge proportionally to in-band scan count once per-plan limits expose a weight knob.
- **DMarcus / theme:** new nav link \"Bulk Scan\". Reuses the `.upgrade-prompt` CSS already shipped by Phase 4a (no duplicate rule). Result table uses `.bulk-status scanned|queued|invalid|error` badges keyed off existing `--clr-pass`/`--clr-warn`/`--clr-fail` vars.

## Deviations from the brief (flagged)

- **Brief said free users on `/dashboard/bulk` should redirect to billing.** Switched to an inline upgrade teaser (matches the Phase 4a \"gate the payload, not the route\" pattern). Same end state, fewer round-trips.
- **No new rate-limit semantics for bulk** — the brief allowed shipping behind the existing bearer quota with a TODO breadcrumb. #152 is merged so the per-plan bucket is in effect, but charging by work-units is a follow-up.

## Out of scope

- Cron rescan changes — already picks up NULL-`last_scanned_at` rows correctly.
- Email pipeline.
- `src/analyzers/mta-sts.ts` redirect mode (regressed twice, untouched).

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 624 passing (+17 new):
  - `test/bulk-scan.test.ts` (9): cap, dedupe, in-band/queued split, per-domain failure isolation, watchlist row reuse, normalization, exact-cap edge, empty input
  - `test/bulk-scan-route.test.ts` (8): no bearer → 401, free → 402, pro happy path, invalid JSON → 400, missing array → 400, non-string entries → 400, 101 domains → 400 with cap details, cancelled subscription → 402
  - `test/dashboard-routes.test.ts` (+5): GET free → upgrade prompt, GET pro → textarea, POST free → 402, POST pro → results badges + summary, POST 101 → 400
  - `test/agent-discovery.test.ts` updated for the second linkset anchor + `BulkScanResponse` schema
- [x] Local Wrangler smoke: `POST /api/bulk-scan` → 401 without bearer, `GET /dashboard/bulk` → 302 to login, `/openapi.json` lists the new path + schema, no server errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)