### PR TITLE
🎨 Palette: [a11y] Associate helper text to form inputs on dashboard

### DIFF
--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -1019,7 +1019,7 @@ ${error ? `<div class="bulk-error">${esc(error)}</div>` : ""}`;
     : "";
 
   const body = `<h1 class="dashboard-title">Bulk Scan</h1>
-<p class="bulk-summary">
+<p id="bulk-help" class="bulk-summary">
   Paste up to <strong>${totalCap}</strong> domains (one per line, or comma-separated). The first
   <strong>${inBandCap}</strong> will be scanned immediately; the rest queue for the next cron pass.
 </p>
@@ -1035,6 +1035,7 @@ ${errorBlock}
     autocorrect="off"
     spellcheck="false"
     required
+    aria-describedby="bulk-help"
   ></textarea>
   <div class="action-row">
     <button type="submit" class="btn">Scan</button>
@@ -1261,10 +1262,10 @@ ${retirementBanner}
 ${justCreatedBanner}
 <div class="settings-section">
   <h2>Generate a new key</h2>
-  <p>Bearer tokens authenticate <code>/api/check</code> requests. Free and Pro plans share key generation; Pro users get higher per-key rate limits.</p>
+  <p id="api-keys-help">Bearer tokens authenticate <code>/api/check</code> requests. Free and Pro plans share key generation; Pro users get higher per-key rate limits.</p>
   <form method="POST" action="/dashboard/settings/api-keys/generate">
     <label for="api-key-name" style="display:block;font-size:0.875rem;color:var(--clr-text-muted);margin-bottom:0.4rem">Label (optional)</label>
-    <input id="api-key-name" class="settings-input" type="text" name="name" placeholder="ci-pipeline" maxlength="60" autocapitalize="none" autocorrect="off" spellcheck="false">
+    <input id="api-key-name" class="settings-input" type="text" name="name" placeholder="ci-pipeline" maxlength="60" autocapitalize="none" autocorrect="off" spellcheck="false" aria-describedby="api-keys-help">
     <div class="action-row">
       <button type="submit" class="btn">Generate API Key</button>
       <a href="/dashboard/settings" class="btn btn-secondary">Back to Settings</a>


### PR DESCRIPTION
## 💡 What

Improved the accessibility of the Bulk Scan and API Key generation forms in the dashboard.

## 🎯 Why

Screen readers do not automatically read paragraphs placed above or below form inputs when the input is focused. To ensure users using assistive technologies hear crucial instructions (like the domain cap limit for bulk scans or the API key purpose), the instructional paragraphs need to be explicitly associated with the input fields.

## 📸 Before/After

This is a structural HTML change for screen readers only; there are no visual regressions or modifications to the UI presentation.

## ♿ Accessibility

Added `aria-describedby` attributes to `<textarea>` and `<input>` elements, linking them directly to the `id` of the paragraphs containing helper text. This complies with ARIA standards for providing contextual help to form controls.

---
*PR created automatically by Jules for task [7171930812779569066](https://jules.google.com/task/7171930812779569066) started by @schmug*