### PR TITLE
⚡ Bolt: Batch sequential SSE events to reduce latency

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -437,21 +437,20 @@ app.get("/api/check/stream", async (c) => {
         "bimi",
         "mta_sts",
       ];
+      // ⚡ Bolt Optimization: Batch multiple sequential SSE events into a single
+      // stream.write() call for cached result replays. This avoids ~7
+      // async microtask yields and reduces latency significantly on this hot path.
+      let batchedSSE = "";
       for (const id of protocolIds) {
         const html = protocolRenderers[id](cached.protocols[id]);
-        await stream.writeSSE({
-          event: "protocol",
-          data: JSON.stringify({ id, html }),
-        });
+        batchedSSE += `event: protocol\ndata: ${JSON.stringify({ id, html })}\n\n`;
       }
-      await stream.writeSSE({
-        event: "done",
-        data: JSON.stringify({
-          grade: cached.grade,
-          headerHtml: renderReportHeader(cached),
-          footerHtml: renderReportFooter(cached),
-        }),
-      });
+      batchedSSE += `event: done\ndata: ${JSON.stringify({
+        grade: cached.grade,
+        headerHtml: renderReportHeader(cached),
+        footerHtml: renderReportFooter(cached),
+      })}\n\n`;
+      await stream.write(batchedSSE);
       return;
     }
 


### PR DESCRIPTION
💡 **What**: Replaced the sequential `await stream.writeSSE()` loop for cached result replays in `/api/check/stream` with a single, manually concatenated `batchedSSE` string and one `await stream.write()` call.
🎯 **Why**: In Hono's streaming implementation, each `writeSSE()` triggers asynchronous I/O and microtask yields. For cached replays where all data is available immediately, emitting 7 separate chunks sequentially is an unnecessary bottleneck.
📊 **Impact**: Avoids ~7 async microtask yields on the critical path, significantly reducing the "time to last byte" for cached scans and increasing overall throughput for the worker.
🔬 **Measurement**: Verify by running `pnpm test` (all tests passing) and `pnpm lint`. The optimization logic guarantees that the emitted payload conforms exactly to the SSE specification since it concatenates the exact same output.

---
*PR created automatically by Jules for task [12168474045725873483](https://jules.google.com/task/12168474045725873483) started by @schmug*