### PR TITLE
feat(legal): ship Privacy Policy; remove TOS placeholder pending LLC

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,22 +77,16 @@ import {
   renderLearnMtaSts,
   renderLearnSpf,
 } from "./views/learn.js";
-import {
-  renderLegalIndex,
-  renderPrivacyPage,
-  renderTermsPage,
-} from "./views/legal.js";
+import { renderPrivacyPage } from "./views/legal.js";
 import {
   renderApiDocsMarkdown,
   renderErrorMarkdown,
   renderLandingMarkdown,
   renderLearnHubMarkdown,
-  renderLegalIndexMarkdown,
   renderPricingMarkdown,
   renderPrivacyMarkdown,
   renderReportMarkdown,
   renderScoringRubricMarkdown,
-  renderTermsMarkdown,
 } from "./views/markdown.js";
 import { renderPricingPage } from "./views/pricing.js";
 import { JS } from "./views/scripts.js";
@@ -680,6 +674,7 @@ const SITEMAP_URLS: Array<{ loc: string; priority: string }> = [
   { loc: "https://dmarc.mx/", priority: "1.0" },
   { loc: "https://dmarc.mx/pricing", priority: "0.9" },
   { loc: "https://dmarc.mx/scoring", priority: "0.8" },
+  { loc: "https://dmarc.mx/legal/privacy", priority: "0.3" },
   { loc: "https://dmarc.mx/learn", priority: "0.7" },
   { loc: "https://dmarc.mx/learn/dmarc", priority: "0.8" },
   { loc: "https://dmarc.mx/learn/spf", priority: "0.8" },
@@ -729,21 +724,9 @@ app.get("/learn/dkim", (c) => c.html(renderLearnDkim()));
 app.get("/learn/bimi", (c) => c.html(renderLearnBimi()));
 app.get("/learn/mta-sts", (c) => c.html(renderLearnMtaSts()));
 
-// Pricing and legal pages ship with placeholder copy (see
-// src/views/pricing.ts + src/views/legal.ts). Real copy lands in a follow-up
-// PR before launch. `noindex` on the HTML plus omission from sitemap.xml
-// keeps them out of search while placeholder.
 app.get("/pricing", (c) => {
   if (wantsMarkdown(c)) return markdownResponse(c, renderPricingMarkdown());
   return c.html(renderPricingPage());
-});
-app.get("/legal", (c) => {
-  if (wantsMarkdown(c)) return markdownResponse(c, renderLegalIndexMarkdown());
-  return c.html(renderLegalIndex());
-});
-app.get("/legal/terms", (c) => {
-  if (wantsMarkdown(c)) return markdownResponse(c, renderTermsMarkdown());
-  return c.html(renderTermsPage());
 });
 app.get("/legal/privacy", (c) => {
   if (wantsMarkdown(c)) return markdownResponse(c, renderPrivacyMarkdown());

--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -46,7 +46,7 @@ interface PageOptions {
   /** Pre-stringified JSON for a `<script type="application/ld+json">` block. */
   jsonLd?: string;
   /** When true, emits `<meta name="robots" content="noindex,follow">`. Used
-   * for placeholder pages (e.g. /pricing, /legal) whose copy isn't final. */
+   * for placeholder pages whose copy isn't final. */
   noindex?: boolean;
 }
 
@@ -173,7 +173,7 @@ export function renderLandingPage(): string {
         <span>curl</span> https://dmarc.mx/api/check?domain=dmarc.mx
       </div>
       <div class="learn-link"><a href="/scoring">How is my score calculated?</a> &middot; <a href="https://www.cloudflare.com/learning/email-security/dmarc-dkim-spf/" target="_blank" rel="noopener">What is email security? &#8599;</a></div>
-      <div class="learn-link"><a href="/pricing">Pricing</a> &middot; <a href="/legal/terms">Terms</a> &middot; <a href="/legal/privacy">Privacy</a></div>
+      <div class="learn-link"><a href="/pricing">Pricing</a> &middot; <a href="/legal/privacy">Privacy</a></div>
       <div class="foss-callout">
         <a href="https://github.com/schmug/dmarcheck" class="foss-link">
           <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
@@ -651,7 +651,7 @@ export function renderScoringRubric(): string {
     <a href="/" class="rubric-cta">Scan a domain &rarr;</a>
   </div>
 
-  <div class="learn-link" style="text-align:center"><a href="/pricing">Pricing</a> &middot; <a href="/legal/terms">Terms</a> &middot; <a href="/legal/privacy">Privacy</a></div>
+  <div class="learn-link" style="text-align:center"><a href="/pricing">Pricing</a> &middot; <a href="/legal/privacy">Privacy</a></div>
 
   <div class="foss-callout">
     <a href="https://github.com/schmug/dmarcheck" class="foss-link">

--- a/src/views/legal.ts
+++ b/src/views/legal.ts
@@ -1,125 +1,139 @@
 import { generateCreature } from "./components.js";
 import { page } from "./html.js";
 
-// Placeholder Terms of Service and Privacy Policy. Real legal text is
-// escalate-only (see HANDOFF Escalate list) and lands in a follow-up PR
-// before launch. `noindex` keeps the placeholders out of search.
+// Voice: first person ("I") throughout. DMarcus is used as the operator
+// placeholder until the LLC is formed; at that point "DMarcus"/"I" flip to
+// the entity name and "we".
 
-const PLACEHOLDER_NOTE = `<div class="bd-card placeholder-banner" role="note" aria-label="Preview notice">
-    <div class="bd-card-body">
-      <strong>Preview &mdash; legal text pending.</strong> This page is a placeholder while final TOS and Privacy Policy text are drafted and reviewed. It's noindexed, not linked from search, and not a contract. <a href="/">Return home &rarr;</a>
-    </div>
-  </div>`;
-
-export function renderLegalIndex(): string {
-  const body = `<main class="breakdown">
-  <div class="report-nav">
-    <a href="/">${generateCreature("sm")} Home</a>
-  </div>
-  <h1 class="rubric-title">Legal</h1>
-  <p class="rubric-intro">Terms, privacy, and contact info for the hosted service at <code>dmarc.mx</code>. The self-hosted OSS project is governed separately by its <a href="https://github.com/schmug/dmarcheck/blob/main/LICENSE">MIT license</a>.</p>
-
-  ${PLACEHOLDER_NOTE}
-
-  <div class="bd-card">
-    <div class="bd-card-body">
-      <ul>
-        <li><a href="/legal/terms">Terms of Service</a> &mdash; governs your use of the hosted service</li>
-        <li><a href="/legal/privacy">Privacy Policy</a> &mdash; what we collect, why, and how long we keep it</li>
-        <li>Security disclosure: <a href="https://github.com/schmug/dmarcheck/blob/main/SECURITY.md">SECURITY.md</a></li>
-        <li>Source code and license: <a href="https://github.com/schmug/dmarcheck">github.com/schmug/dmarcheck</a></li>
-      </ul>
-    </div>
-  </div>
-</main>`;
-
-  return page({
-    title: "Legal — dmarcheck",
-    path: "/legal",
-    description:
-      "Legal information for the dmarcheck hosted service: Terms of Service, Privacy Policy, and security disclosure.",
-    noindex: true,
-    body,
-  });
-}
-
-export function renderTermsPage(): string {
-  const body = `<main class="breakdown">
-  <div class="report-nav">
-    <a href="/legal">${generateCreature("sm")} Legal</a>
-  </div>
-  <h1 class="rubric-title">Terms of Service</h1>
-  <p class="rubric-intro"><em>[PLACEHOLDER] &mdash; final text pending attorney review.</em></p>
-
-  ${PLACEHOLDER_NOTE}
-
-  <div class="bd-card">
-    <div class="bd-card-title">Outline</div>
-    <div class="bd-card-body">
-      <ol>
-        <li>Scope &mdash; hosted service at <code>dmarc.mx</code>. The OSS project is MIT-licensed separately.</li>
-        <li>Acceptable use &mdash; no abusive scanning, no circumventing rate limits, no use to harm third parties.</li>
-        <li>Accounts &mdash; one human per account, accurate contact info.</li>
-        <li>Billing &mdash; [PLACEHOLDER: cadence, refunds, taxes].</li>
-        <li>Data &mdash; domain names and scan results are stored per the Privacy Policy.</li>
-        <li>Warranty disclaimer &mdash; service is provided "as is".</li>
-        <li>Limitation of liability &mdash; [PLACEHOLDER].</li>
-        <li>Termination &mdash; either side may terminate; data export on request.</li>
-        <li>Changes &mdash; we'll notify in-app or by email before material changes.</li>
-        <li>Governing law &mdash; [PLACEHOLDER].</li>
-      </ol>
-      <p class="tier-text" style="margin-top:12px"><em>[PLACEHOLDER] This outline is not legally binding. Final Terms replace this text before launch.</em></p>
-    </div>
-  </div>
-
-  <p class="tier-text"><a href="/legal">&larr; Back to legal index</a></p>
-</main>`;
-
-  return page({
-    title: "Terms of Service — dmarcheck",
-    path: "/legal/terms",
-    description:
-      "Terms of Service for the dmarcheck hosted service. (Placeholder text pending final legal review.)",
-    noindex: true,
-    body,
-  });
-}
+const LAST_UPDATED = "2026-04-23";
 
 export function renderPrivacyPage(): string {
   const body = `<main class="breakdown">
   <div class="report-nav">
-    <a href="/legal">${generateCreature("sm")} Legal</a>
+    <a href="/">${generateCreature("sm")} Home</a>
   </div>
   <h1 class="rubric-title">Privacy Policy</h1>
-  <p class="rubric-intro"><em>[PLACEHOLDER] &mdash; final text pending review.</em></p>
-
-  ${PLACEHOLDER_NOTE}
+  <p class="rubric-intro"><em>Last updated: ${LAST_UPDATED}</em></p>
 
   <div class="bd-card">
-    <div class="bd-card-title">Outline</div>
+    <div class="bd-card-title">Who I am</div>
     <div class="bd-card-body">
-      <ul>
-        <li><strong>What we collect</strong> &mdash; domain names you scan, scan results, your account email (Pro), billing metadata via Stripe (Pro), error telemetry via Sentry.</li>
-        <li><strong>Why</strong> &mdash; to run the service, save your history, send alerts you asked for, debug outages.</li>
-        <li><strong>Retention</strong> &mdash; [PLACEHOLDER duration].</li>
-        <li><strong>Sharing</strong> &mdash; we do not sell your data. Subprocessors: Cloudflare (hosting), WorkOS (auth), Stripe (billing), Resend/Cloudflare Email (transactional email), Sentry (errors).</li>
-        <li><strong>Your rights</strong> &mdash; export, delete, opt out of alerts, contact support.</li>
-        <li><strong>Cookies</strong> &mdash; only functional (session, theme preference). No third-party advertising trackers.</li>
-        <li><strong>Contact</strong> &mdash; [PLACEHOLDER email].</li>
-      </ul>
-      <p class="tier-text" style="margin-top:12px"><em>[PLACEHOLDER] This outline is not a binding policy. Final Privacy Policy replaces this text before launch.</em></p>
+      <p class="tier-text">DMarcus runs <strong>dmarcheck</strong> &mdash; the hosted email-security scanner at <code>dmarc.mx</code>. The self-hosted OSS project (<a href="https://github.com/schmug/dmarcheck">github.com/schmug/dmarcheck</a>) is yours to run under MIT; this policy covers the hosted service only.</p>
     </div>
   </div>
 
-  <p class="tier-text"><a href="/legal">&larr; Back to legal index</a></p>
+  <div class="bd-card">
+    <div class="bd-card-title">What I collect</div>
+    <div class="bd-card-body">
+      <p class="tier-text">When you use <code>dmarc.mx</code>:</p>
+      <ul>
+        <li><strong>The domain you scan</strong> and its public DNS records.</li>
+        <li><strong>Your IP address</strong>, briefly, for rate limiting.</li>
+        <li><strong>Your email address</strong> &mdash; only if you have a Pro account. I need it to log you in, send alerts you asked for, and contact you about your account.</li>
+        <li><strong>Your subscription state</strong> from Stripe: subscription ID, plan, status, period end. Stripe holds the actual payment method; I never see your card number.</li>
+        <li><strong>Scan history and watchlist</strong> &mdash; only if you have a Pro account and added domains yourself.</li>
+        <li><strong>Error telemetry</strong> via Sentry, when the service crashes.</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="bd-card">
+    <div class="bd-card-title">Why</div>
+    <div class="bd-card-body">
+      <ul>
+        <li>Scan &rarr; show you the result.</li>
+        <li>IP address &rarr; stop one caller from drowning everyone.</li>
+        <li>Email &rarr; log you in, send alerts you asked for, contact you about billing.</li>
+        <li>Stripe subscription state &rarr; run Pro features, let you cancel.</li>
+        <li>Scan history and watchlist &rarr; run the Pro features you paid for.</li>
+        <li>Error telemetry &rarr; fix bugs.</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="bd-card">
+    <div class="bd-card-title">How long I keep it</div>
+    <div class="bd-card-body">
+      <ul>
+        <li><strong>Free, anonymous scans:</strong> not stored after the scan completes.</li>
+        <li><strong>Pro scan history and watchlist:</strong> kept while your account is active. Deleted within 30 days of account closure or on request.</li>
+        <li><strong>Account email:</strong> same as above.</li>
+        <li><strong>Stripe billing records:</strong> Stripe retains these to comply with US financial-record law (typically 7 years). I delete my local copy on account closure.</li>
+        <li><strong>Error telemetry:</strong> 90 days, then purged by Sentry.</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="bd-card">
+    <div class="bd-card-title">Who I share it with</div>
+    <div class="bd-card-body">
+      <p class="tier-text">I use a short list of subprocessors to run the service. <strong>I'm not using this to train AI, selling your data, or sending it to advertisers.</strong></p>
+      <ul>
+        <li><strong>Cloudflare</strong> &mdash; hosting, DNS, edge compute, D1 database</li>
+        <li><strong>WorkOS</strong> &mdash; account login</li>
+        <li><strong>Stripe</strong> &mdash; billing</li>
+        <li><strong>Cloudflare Email Sending</strong> &mdash; alerts, receipts, login links</li>
+        <li><strong>Sentry</strong> &mdash; error telemetry</li>
+      </ul>
+      <p class="tier-text" style="margin-top:12px">If I add or swap a subprocessor, I'll update this list and email Pro users at least 14 days ahead.</p>
+    </div>
+  </div>
+
+  <div class="bd-card">
+    <div class="bd-card-title">Your rights</div>
+    <div class="bd-card-body">
+      <ul>
+        <li><strong>Export your data</strong> &mdash; email <a href="mailto:support@dmarc.mx">support@dmarc.mx</a> and I'll send your scan history and watchlist as JSON within 30 days.</li>
+        <li><strong>Delete your account</strong> &mdash; one click from the dashboard. Everything I hold gets removed within 30 days. Stripe keeps its own billing records per law.</li>
+        <li><strong>Stop getting emails</strong> &mdash; unsubscribe from any email footer, or toggle alerts off in your dashboard.</li>
+        <li><strong>Ask a question</strong> &mdash; <a href="mailto:support@dmarc.mx">support@dmarc.mx</a>.</li>
+      </ul>
+      <p class="tier-text" style="margin-top:12px">If you're in the EU/UK, California, or any jurisdiction with statutory privacy rights (GDPR, UK GDPR, CCPA/CPRA, etc.), you have the full set of rights that law gives you. Nothing here overrides a statutory right.</p>
+    </div>
+  </div>
+
+  <div class="bd-card">
+    <div class="bd-card-title">Cookies</div>
+    <div class="bd-card-body">
+      <ul>
+        <li><strong>Session cookie</strong> when you log in (required).</li>
+        <li><strong>Theme preference</strong> (light/dark) in <code>localStorage</code>.</li>
+      </ul>
+      <p class="tier-text" style="margin-top:12px">That's the whole list. No advertising cookies, no third-party tracking.</p>
+    </div>
+  </div>
+
+  <div class="bd-card">
+    <div class="bd-card-title">Children</div>
+    <div class="bd-card-body">
+      <p class="tier-text">dmarcheck isn't aimed at anyone under 13. If you're under 13, please don't sign up.</p>
+    </div>
+  </div>
+
+  <div class="bd-card">
+    <div class="bd-card-title">Changes</div>
+    <div class="bd-card-body">
+      <p class="tier-text">If I change how I handle your data in a way that affects you materially, I'll email Pro users at least 14 days ahead. The "Last updated" date tracks minor edits.</p>
+    </div>
+  </div>
+
+  <div class="bd-card">
+    <div class="bd-card-title">Contact</div>
+    <div class="bd-card-body">
+      <p class="tier-text"><a href="mailto:support@dmarc.mx">support@dmarc.mx</a></p>
+    </div>
+  </div>
+
+  <div style="text-align:center;margin-top:2rem;margin-bottom:1rem">
+    <a href="/" class="rubric-cta">Scan a domain &rarr;</a>
+  </div>
 </main>`;
 
   return page({
     title: "Privacy Policy — dmarcheck",
     path: "/legal/privacy",
     description:
-      "Privacy Policy for the dmarcheck hosted service. (Placeholder text pending final review.)",
-    noindex: true,
+      "How dmarcheck collects, uses, and retains your data. Short, first-person, no dark patterns.",
     body,
   });
 }

--- a/src/views/markdown.ts
+++ b/src/views/markdown.ts
@@ -298,66 +298,86 @@ Continuous monitoring for the domains you actually care about.
 - **Where's my data stored, and for how long?** Cloudflare D1 (US region). Scan results retained while your account is active; deleted on request or within 30 days of account closure. Full detail: <${MD_SITE}/legal/privacy>.
 - **Pro API rate limits?** 60 requests/hour per API key. Anonymous IP limit stays at 10/min. Need more? Email support@dmarc.mx.
 
-See [Terms](${MD_SITE}/legal/terms) and [Privacy](${MD_SITE}/legal/privacy). Questions? support@dmarc.mx.
-`;
-}
-
-export function renderLegalIndexMarkdown(): string {
-  return `# Legal
-
-> **Preview — legal text pending.** This page is a placeholder while final TOS and Privacy Policy text are drafted and reviewed.
-
-Terms, privacy, and contact info for the hosted service at ${MD_SITE}. The self-hosted OSS project is governed by its [MIT license](https://github.com/schmug/dmarcheck/blob/main/LICENSE).
-
-- [Terms of Service](${MD_SITE}/legal/terms)
-- [Privacy Policy](${MD_SITE}/legal/privacy)
-- Security disclosure: <https://github.com/schmug/dmarcheck/blob/main/SECURITY.md>
-- Source & license: <https://github.com/schmug/dmarcheck>
-`;
-}
-
-export function renderTermsMarkdown(): string {
-  return `# Terms of Service
-
-> **Preview — legal text pending.** Final Terms replace this text before launch. This outline is not legally binding.
-
-_[PLACEHOLDER]_ — final text pending attorney review.
-
-## Outline
-
-1. Scope — hosted service at ${MD_SITE}. The OSS project is MIT-licensed separately.
-2. Acceptable use — no abusive scanning, no circumventing rate limits, no use to harm third parties.
-3. Accounts — one human per account, accurate contact info.
-4. Billing — _[PLACEHOLDER: cadence, refunds, taxes]._
-5. Data — domain names and scan results are stored per the Privacy Policy.
-6. Warranty disclaimer — service is provided "as is".
-7. Limitation of liability — _[PLACEHOLDER]._
-8. Termination — either side may terminate; data export on request.
-9. Changes — notify in-app or by email before material changes.
-10. Governing law — _[PLACEHOLDER]._
-
-[Back to legal index](${MD_SITE}/legal)
+See [Privacy](${MD_SITE}/legal/privacy). Questions? support@dmarc.mx.
 `;
 }
 
 export function renderPrivacyMarkdown(): string {
   return `# Privacy Policy
 
-> **Preview — legal text pending.** Final Privacy Policy replaces this text before launch. This outline is not a binding policy.
+_Last updated: 2026-04-23_
 
-_[PLACEHOLDER]_ — final text pending review.
+## Who I am
 
-## Outline
+DMarcus runs **dmarcheck** — the hosted email-security scanner at ${MD_SITE}. The self-hosted OSS project (<https://github.com/schmug/dmarcheck>) is yours to run under MIT; this policy covers the hosted service only.
 
-- **What we collect** — domain names you scan, scan results, your account email (Pro), billing metadata via Stripe (Pro), error telemetry via Sentry.
-- **Why** — to run the service, save your history, send alerts you asked for, debug outages.
-- **Retention** — _[PLACEHOLDER duration]._
-- **Sharing** — we do not sell your data. Subprocessors: Cloudflare (hosting), WorkOS (auth), Stripe (billing), Resend/Cloudflare Email (transactional email), Sentry (errors).
-- **Your rights** — export, delete, opt out of alerts, contact support.
-- **Cookies** — only functional (session, theme preference). No third-party advertising trackers.
-- **Contact** — _[PLACEHOLDER email]._
+## What I collect
 
-[Back to legal index](${MD_SITE}/legal)
+When you use ${MD_SITE}:
+
+- **The domain you scan** and its public DNS records.
+- **Your IP address**, briefly, for rate limiting.
+- **Your email address** — only if you have a Pro account. I need it to log you in, send alerts you asked for, and contact you about your account.
+- **Your subscription state** from Stripe: subscription ID, plan, status, period end. Stripe holds the actual payment method; I never see your card number.
+- **Scan history and watchlist** — only if you have a Pro account and added domains yourself.
+- **Error telemetry** via Sentry, when the service crashes.
+
+## Why
+
+- Scan → show you the result.
+- IP address → stop one caller from drowning everyone.
+- Email → log you in, send alerts you asked for, contact you about billing.
+- Stripe subscription state → run Pro features, let you cancel.
+- Scan history and watchlist → run the Pro features you paid for.
+- Error telemetry → fix bugs.
+
+## How long I keep it
+
+- **Free, anonymous scans:** not stored after the scan completes.
+- **Pro scan history and watchlist:** kept while your account is active. Deleted within 30 days of account closure or on request.
+- **Account email:** same as above.
+- **Stripe billing records:** Stripe retains these to comply with US financial-record law (typically 7 years). I delete my local copy on account closure.
+- **Error telemetry:** 90 days, then purged by Sentry.
+
+## Who I share it with
+
+I use a short list of subprocessors to run the service. **I'm not using this to train AI, selling your data, or sending it to advertisers.**
+
+- **Cloudflare** — hosting, DNS, edge compute, D1 database
+- **WorkOS** — account login
+- **Stripe** — billing
+- **Cloudflare Email Sending** — alerts, receipts, login links
+- **Sentry** — error telemetry
+
+If I add or swap a subprocessor, I'll update this list and email Pro users at least 14 days ahead.
+
+## Your rights
+
+- **Export your data** — email support@dmarc.mx and I'll send your scan history and watchlist as JSON within 30 days.
+- **Delete your account** — one click from the dashboard. Everything I hold gets removed within 30 days. Stripe keeps its own billing records per law.
+- **Stop getting emails** — unsubscribe from any email footer, or toggle alerts off in your dashboard.
+- **Ask a question** — support@dmarc.mx.
+
+If you're in the EU/UK, California, or any jurisdiction with statutory privacy rights (GDPR, UK GDPR, CCPA/CPRA, etc.), you have the full set of rights that law gives you. Nothing here overrides a statutory right.
+
+## Cookies
+
+- **Session cookie** when you log in (required).
+- **Theme preference** (light/dark) in \`localStorage\`.
+
+That's the whole list. No advertising cookies, no third-party tracking.
+
+## Children
+
+dmarcheck isn't aimed at anyone under 13. If you're under 13, please don't sign up.
+
+## Changes
+
+If I change how I handle your data in a way that affects you materially, I'll email Pro users at least 14 days ahead. The "Last updated" date tracks minor edits.
+
+## Contact
+
+support@dmarc.mx
 `;
 }
 

--- a/src/views/pricing.ts
+++ b/src/views/pricing.ts
@@ -155,7 +155,7 @@ export function renderPricingPage(): string {
     <a href="/" class="rubric-cta">Scan a domain &rarr;</a>
   </div>
 
-  <div class="learn-link" style="text-align:center">See <a href="/legal/terms">Terms</a> and <a href="/legal/privacy">Privacy</a>. Questions? <a href="mailto:support@dmarc.mx">support@dmarc.mx</a></div>
+  <div class="learn-link" style="text-align:center">See <a href="/legal/privacy">Privacy</a>. Questions? <a href="mailto:support@dmarc.mx">support@dmarc.mx</a></div>
 </main>`;
 
   return page({

--- a/test/pricing-legal.test.ts
+++ b/test/pricing-legal.test.ts
@@ -11,88 +11,8 @@ beforeEach(() => {
   _memoryStore.clear();
 });
 
-const LEGAL_PLACEHOLDER_ROUTES: Array<{
-  path: string;
-  canonical: string;
-  title: string;
-}> = [
-  {
-    path: "/legal",
-    canonical: "https://dmarc.mx/legal",
-    title: "Legal",
-  },
-  {
-    path: "/legal/terms",
-    canonical: "https://dmarc.mx/legal/terms",
-    title: "Terms of Service",
-  },
-  {
-    path: "/legal/privacy",
-    canonical: "https://dmarc.mx/legal/privacy",
-    title: "Privacy Policy",
-  },
-];
-
-describe("legal placeholder pages", () => {
-  for (const { path, canonical, title } of LEGAL_PLACEHOLDER_ROUTES) {
-    it(`GET ${path} returns HTML with noindex meta`, async () => {
-      const res = await app.request(path);
-      expect(res.status).toBe(200);
-      expect(res.headers.get("Content-Type")).toMatch(/^text\/html/);
-      const html = await res.text();
-      expect(html).toContain('<meta name="robots" content="noindex,follow">');
-      expect(html).toContain(`<link rel="canonical" href="${canonical}">`);
-      expect(html).toContain(title);
-    });
-
-    it(`GET ${path} with Accept: text/markdown returns markdown`, async () => {
-      const res = await app.request(path, {
-        headers: { Accept: "text/markdown" },
-      });
-      expect(res.status).toBe(200);
-      expect(res.headers.get("Content-Type")).toBe(
-        "text/markdown; charset=utf-8",
-      );
-      const body = await res.text();
-      expect(body).toContain("#");
-    });
-
-    it(`GET ${path}?format=md returns markdown`, async () => {
-      const res = await app.request(`${path}?format=md`);
-      expect(res.status).toBe(200);
-      expect(res.headers.get("Content-Type")).toBe(
-        "text/markdown; charset=utf-8",
-      );
-    });
-  }
-
-  it("/legal indexes terms and privacy", async () => {
-    const res = await app.request("/legal");
-    const html = await res.text();
-    expect(html).toContain('href="/legal/terms"');
-    expect(html).toContain('href="/legal/privacy"');
-  });
-
-  it("legal pages surface a clear preview banner", async () => {
-    for (const { path } of LEGAL_PLACEHOLDER_ROUTES) {
-      const res = await app.request(path);
-      const html = await res.text();
-      expect(html.toLowerCase()).toContain("pending");
-      expect(html.toLowerCase()).toContain("preview");
-    }
-  });
-
-  it("sitemap.xml does NOT list placeholder /legal routes", async () => {
-    const res = await app.request("/sitemap.xml");
-    const body = await res.text();
-    expect(body).not.toContain("<loc>https://dmarc.mx/legal</loc>");
-    expect(body).not.toContain("<loc>https://dmarc.mx/legal/terms</loc>");
-    expect(body).not.toContain("<loc>https://dmarc.mx/legal/privacy</loc>");
-  });
-});
-
-describe("pricing page (live copy)", () => {
-  it("GET /pricing returns indexable HTML (no noindex)", async () => {
+describe("pricing page", () => {
+  it("GET /pricing returns indexable HTML", async () => {
     const res = await app.request("/pricing");
     expect(res.status).toBe(200);
     expect(res.headers.get("Content-Type")).toMatch(/^text\/html/);
@@ -109,13 +29,6 @@ describe("pricing page (live copy)", () => {
     expect(html).toContain("$19/mo");
     expect(html).toContain("Nightly DMARC, SPF, DKIM, BIMI");
     expect(html).toContain("MTA-STS");
-  });
-
-  it("does not contain placeholder markers", async () => {
-    const res = await app.request("/pricing");
-    const html = await res.text();
-    expect(html).not.toMatch(/\[PLACEHOLDER/);
-    expect(html.toLowerCase()).not.toContain("copy pending");
   });
 
   it("links upgrade CTA to /dashboard/billing/subscribe", async () => {
@@ -162,25 +75,129 @@ describe("pricing page (live copy)", () => {
   });
 });
 
+describe("privacy policy", () => {
+  it("GET /legal/privacy returns indexable HTML", async () => {
+    const res = await app.request("/legal/privacy");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toMatch(/^text\/html/);
+    const html = await res.text();
+    expect(html).not.toContain('name="robots"');
+    expect(html).toContain(
+      '<link rel="canonical" href="https://dmarc.mx/legal/privacy">',
+    );
+    expect(html).toContain("Privacy Policy");
+  });
+
+  it("uses first-person voice and names DMarcus as operator", async () => {
+    const res = await app.request("/legal/privacy");
+    const html = await res.text();
+    expect(html).toContain("DMarcus");
+    expect(html).toContain("Who I am");
+    expect(html).toContain("What I collect");
+    expect(html).toContain("How long I keep it");
+  });
+
+  it("contains the anti-AI-training trust line", async () => {
+    const res = await app.request("/legal/privacy");
+    const html = await res.text();
+    expect(html.toLowerCase()).toContain("not using this to train ai");
+  });
+
+  it("lists the five subprocessors", async () => {
+    const res = await app.request("/legal/privacy");
+    const html = await res.text();
+    for (const proc of [
+      "Cloudflare",
+      "WorkOS",
+      "Stripe",
+      "Cloudflare Email Sending",
+      "Sentry",
+    ]) {
+      expect(html).toContain(proc);
+    }
+  });
+
+  it("does not contain placeholder markers or pending banners", async () => {
+    const res = await app.request("/legal/privacy");
+    const html = await res.text();
+    expect(html).not.toMatch(/\[PLACEHOLDER/);
+    expect(html.toLowerCase()).not.toContain("legal text pending");
+    expect(html.toLowerCase()).not.toContain("copy pending");
+    expect(html.toLowerCase()).not.toContain("coming soon");
+  });
+
+  it("links support@dmarc.mx as the contact", async () => {
+    const res = await app.request("/legal/privacy");
+    const html = await res.text();
+    expect(html).toContain('href="mailto:support@dmarc.mx"');
+  });
+
+  it("markdown rendering honors Accept: text/markdown", async () => {
+    const res = await app.request("/legal/privacy", {
+      headers: { Accept: "text/markdown" },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe(
+      "text/markdown; charset=utf-8",
+    );
+    const body = await res.text();
+    expect(body).toContain("# Privacy Policy");
+    expect(body).toContain("DMarcus");
+    expect(body).not.toMatch(/\[PLACEHOLDER/);
+  });
+
+  it("sitemap.xml lists /legal/privacy", async () => {
+    const res = await app.request("/sitemap.xml");
+    const body = await res.text();
+    expect(body).toContain("<loc>https://dmarc.mx/legal/privacy</loc>");
+  });
+});
+
+describe("removed legal routes (terms + index)", () => {
+  it("GET /legal/terms returns 404", async () => {
+    const res = await app.request("/legal/terms");
+    expect(res.status).toBe(404);
+  });
+
+  it("GET /legal returns 404", async () => {
+    const res = await app.request("/legal");
+    expect(res.status).toBe(404);
+  });
+
+  it("sitemap.xml does not list /legal/terms or /legal index", async () => {
+    const res = await app.request("/sitemap.xml");
+    const body = await res.text();
+    expect(body).not.toContain("<loc>https://dmarc.mx/legal/terms</loc>");
+    expect(body).not.toContain("<loc>https://dmarc.mx/legal</loc>");
+  });
+});
+
 describe("site footer links", () => {
-  it("landing footer links to /pricing, /legal/terms, /legal/privacy", async () => {
+  it("landing footer links to /pricing and /legal/privacy only", async () => {
     const res = await app.request("/");
     const html = await res.text();
     expect(html).toContain('href="/pricing"');
-    expect(html).toContain('href="/legal/terms"');
     expect(html).toContain('href="/legal/privacy"');
+    expect(html).not.toContain('href="/legal/terms"');
   });
 
-  it("scoring page footer links to /pricing and /legal/*", async () => {
+  it("scoring page footer links to /pricing and /legal/privacy only", async () => {
     const res = await app.request("/scoring");
     const html = await res.text();
     expect(html).toContain('href="/pricing"');
-    expect(html).toContain('href="/legal/terms"');
     expect(html).toContain('href="/legal/privacy"');
+    expect(html).not.toContain('href="/legal/terms"');
   });
 
-  it("indexable pages (/, /scoring, /pricing) stay free of noindex", async () => {
-    for (const path of ["/", "/scoring", "/pricing"]) {
+  it("pricing page footer references Privacy only (not Terms)", async () => {
+    const res = await app.request("/pricing");
+    const html = await res.text();
+    expect(html).toContain('href="/legal/privacy"');
+    expect(html).not.toContain('href="/legal/terms"');
+  });
+
+  it("indexable pages (/, /scoring, /pricing, /legal/privacy) stay free of noindex", async () => {
+    for (const path of ["/", "/scoring", "/pricing", "/legal/privacy"]) {
       const res = await app.request(path);
       const html = await res.text();
       expect(html).not.toContain('name="robots"');


### PR DESCRIPTION
## Summary

Ships a real Privacy Policy at /legal/privacy and removes the Terms placeholder entirely. TOS is on pause until the operator LLC is formed; once that happens, the TOS is a one-file addition and /legal gets re-added as an index.

### Why no TOS yet

TOS is a contract — it names a counterparty. Without an LLC, that's you personally and the liability cap doesn't shield you. The Privacy Policy has no such constraint; it's an operator-disclosure document that any operator (incorporated or not) can publish.

### Privacy highlights

- First-person voice throughout ("Who I am", "What I collect") — matches the indie framing
- **DMarcus** used as the operator placeholder. One-line swap to the LLC name post-formation.
- Five subprocessors named (Cloudflare, WorkOS, Stripe, Cloudflare Email Sending, Sentry)
- Explicit: **"I'm not using this to train AI, selling your data, or sending it to advertisers."**
- Retention windows for every data type (scan results 30d post-closure, error telemetry 90d, etc.)
- GDPR/UK-GDPR/CCPA rights carve-out — statutory rights supersede the policy
- Indexable, added to sitemap

### Routes removed

- `GET /legal` → 404
- `GET /legal/terms` → 404

Footer links across landing, scoring, and pricing now show "Pricing · Privacy" only.

### Not in this PR

- TOS text (gated on LLC formation — you're handling that separately)
- Cloudflare Web Analytics beacon mention (wait until the beacon actually ships; then it's one line)
- README hosted-tier pitch (separate discussion)

## Test plan

- [x] `npm run lint` + `npm run typecheck` green
- [x] `npm test` — 658/658 passing across 41 files
- [x] Preview verified: /legal/privacy renders all 10 sections, no robots meta, canonical correct, first-person voice intact; /legal and /legal/terms return 404
- [x] Markdown content negotiation verified (`Accept: text/markdown` → 200, `text/markdown; charset=utf-8`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)