### PR TITLE
docs(readme): advertise hosted tier alongside self-host, side-by-side

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ Meet **DMarcus**, the @ creature who guards your inbox.
 
 **Live at [dmarc.mx](https://dmarc.mx)**
 
+## Three ways to use dmarcheck
+
+|  | Where | What you get |
+|---|---|---|
+| **Free scanner** | [dmarc.mx](https://dmarc.mx) | Unlimited on-demand scans, JSON API, 10 req/min per IP |
+| **Pro — $19/mo** | [dmarc.mx/pricing](https://dmarc.mx/pricing) | Nightly monitoring (25 domains), email alerts on grade drops, saved history, bulk scan, 60 req/hour API key |
+| **Self-host** | this repo | Clone, `wrangler deploy`, run your own. MIT-licensed. Pro features activate when you configure D1 / WorkOS / Stripe bindings — optional, see [below](#optional-paid-tier-env-vars). |
+
+The hosted tier at `dmarc.mx` exists for people who'd rather pay than run it. Everything is MIT and there is no crippled-OSS / paid-premium split.
+
 ## Features
 
 - **DMARC** — Policy parsing, validation, reporting URI checks
@@ -155,9 +165,7 @@ with `npx wrangler d1 migrations apply dmarcheck-db --remote`.
 
 ### Optional: paid-tier env vars
 
-The free scanner, dashboard, and API work without any of the following. They
-only activate on the hosted tier at `dmarc.mx`; self-host deploys can ignore
-them entirely. Set any of these as wrangler secrets (`wrangler secret put NAME`):
+These unlock the same Pro features the hosted tier at `dmarc.mx` offers — see the [three ways to use dmarcheck](#three-ways-to-use-dmarcheck) table up top. They're all optional: the free scanner, dashboard, and API work without any of them. Set any as wrangler secrets (`wrangler secret put NAME`):
 
 | Secret | Purpose |
 |--------|---------|
@@ -174,6 +182,7 @@ end-to-end for self-hosters who only want the free scanner.
 - [Hono](https://hono.dev) — lightweight web framework for Cloudflare Workers
 - TypeScript + `node:dns` via `nodejs_compat`
 - Rate limited via Cloudflare Cache API (no extra bindings needed)
+- Pro features (auth, billing, history, cron) use Cloudflare D1 + WorkOS + Stripe. The hosted tier at `dmarc.mx` runs on the same code and same stack — no private fork.
 
 ## License
 


### PR DESCRIPTION
## Summary

Makes the Pro hosted tier visible in the README without burying the self-host story. Three-way table up top (Free / Pro / Self-host) means a repo visitor learns the shape of the offering in 5 seconds instead of scrolling to the buried "Optional: paid-tier env vars" subsection.

### What changed

- **New "Three ways to use dmarcheck" section** just below the tagline: table with Free scanner (dmarc.mx), Pro \$19/mo (link to /pricing), Self-host (this repo, MIT, full feature parity with optional D1/WorkOS/Stripe bindings)
- **Trust line** under the table: *"The hosted tier at \`dmarc.mx\` exists for people who'd rather pay than run it. Everything is MIT and there is no crippled-OSS / paid-premium split."*
- **Cross-link** from the existing "Optional: paid-tier env vars" subsection back up to the new table
- **One line in Stack** explicitly stating the hosted tier runs on the same code and same stack \u2014 no private fork

### What I deliberately did not do

- No marketing verbs. Sysadmin audience is allergic.
- No "UPGRADE NOW" / no "MOST POPULAR" badge / no feature-matrix checkmarks \u2014 kept the table factual.
- No mention of DMarcus-as-operator or the LLC situation. Internal detail.
- No changes to Features / API / Grading / Self-Hosting sections. They're dev-facing and fine as-is.

### Notes on the $19 price in the repo

The README embeds "\$19/mo" directly. If the price changes later, it's one edit here plus the existing `src/views/pricing.ts` / `renderPricingMarkdown()` updates. Happy to swap for "paid tier" with only a link to /pricing if you want to decouple \u2014 say the word.

## Test plan

- [x] `git diff` reviewed \u2014 pure docs change, 12 insertions / 3 deletions
- [x] GitHub anchor links verified: `#three-ways-to-use-dmarcheck` and `#optional-paid-tier-env-vars` both match the auto-generated anchors for their headings
- [x] No code touched, so no lint/typecheck/test impact

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)