### PR TITLE
feat(analytics): inject Cloudflare Web Analytics beacon on public HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,10 +164,13 @@ them entirely. Set any of these as wrangler secrets (`wrangler secret put NAME`)
 | `STRIPE_SECRET_KEY` | Stripe API key for Checkout + Portal calls |
 | `STRIPE_WEBHOOK_SECRET` | Signing secret for the `/webhooks/stripe` endpoint |
 | `STRIPE_PRICE_ID_PRO` | Price ID for the Pro plan offered via Checkout |
+| `CF_ANALYTICS_TOKEN` | Cloudflare Web Analytics beacon token (32-char lowercase hex). Injects a cookieless beacon on public HTML pages; skipped on `/dashboard/*`, `/auth/*`, `/webhooks/*`. Leave unset to disable. |
 
-If any of the three are missing, `isBillingEnabled` returns false and all
+If any of the three Stripe secrets are missing, `isBillingEnabled` returns false and all
 paid-tier routes return 404. This keeps a fresh `wrangler deploy` working
-end-to-end for self-hosters who only want the free scanner.
+end-to-end for self-hosters who only want the free scanner. `CF_ANALYTICS_TOKEN`
+is independent — set it only if you want to send analytics to your own
+Cloudflare Web Analytics dashboard.
 
 ## Stack
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -15,4 +15,10 @@ export interface Env {
   STRIPE_SECRET_KEY?: string;
   STRIPE_WEBHOOK_SECRET?: string;
   STRIPE_PRICE_ID_PRO?: string;
+  // Cloudflare Web Analytics token. Optional: when unset, the beacon script
+  // is not injected. Set this on the hosted deploy (wrangler secret) to turn
+  // on analytics. The token itself is non-secret (ends up in public HTML)
+  // but lives here so self-host forks don't accidentally ship data to the
+  // hosted tier's dashboard.
+  CF_ANALYTICS_TOKEN?: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,6 +160,16 @@ const AGENT_DISCOVERY_LINK_HEADER = [
 // over `frame-ancestors`, which would defeat this allowlist.
 const EMBED_ALLOWED_ORIGINS = ["https://cortech.online"];
 
+// Paths that skip Cloudflare Web Analytics beacon injection. Dashboard and
+// auth pages can expose user-specific URL patterns (e.g. domain names in
+// the path); we deliberately keep those out of analytics even though the
+// beacon itself is cookieless.
+const ANALYTICS_SKIP_PATH_PREFIXES = ["/dashboard", "/auth", "/webhooks"];
+
+// Cloudflare Web Analytics tokens are 32-char lowercase hex. Guard against
+// a misconfigured env var injecting arbitrary strings into HTML.
+const CF_ANALYTICS_TOKEN_RE = /^[a-f0-9]{32}$/;
+
 app.use("*", async (c, next) => {
   await next();
   c.res.headers.set("X-Content-Type-Options", "nosniff");
@@ -187,6 +197,29 @@ app.use("*", async (c, next) => {
         "Cache-Control",
         "public, max-age=0, s-maxage=300, stale-while-revalidate=600",
       );
+    }
+
+    // Inject the Cloudflare Web Analytics beacon on public HTML pages.
+    // Skipped when the token isn't configured (self-host default) and on
+    // auth/dashboard/webhook paths whose URLs can carry user-specific detail.
+    // Our HTML responses are already buffered strings (never streamed), so a
+    // simple `</body>` replace is both correct and keeps tests in the Node
+    // pool runnable without HTMLRewriter.
+    const token = (c.env as Env | undefined)?.CF_ANALYTICS_TOKEN;
+    const path = c.req.path;
+    const isAnalyticsEligible =
+      token &&
+      CF_ANALYTICS_TOKEN_RE.test(token) &&
+      !ANALYTICS_SKIP_PATH_PREFIXES.some((p) => path.startsWith(p));
+    if (isAnalyticsEligible) {
+      const beacon = `<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token":"${token}"}'></script>`;
+      const body = await c.res.text();
+      const injected = body.replace("</body>", `${beacon}</body>`);
+      c.res = new Response(injected, {
+        status: c.res.status,
+        statusText: c.res.statusText,
+        headers: c.res.headers,
+      });
     }
   } else {
     // `frame-ancestors` does not inherit from `default-src`, so it must be

--- a/test/cf-analytics.test.ts
+++ b/test/cf-analytics.test.ts
@@ -32,10 +32,17 @@ describe("Cloudflare Web Analytics beacon injection", () => {
         expect(html).toContain(BEACON_SRC);
         expect(html).toContain(`"token":"${VALID_TOKEN}"`);
         // Beacon must sit just before </body> so DOM is available before
-        // the script parses performance metrics.
-        expect(html).toMatch(
-          new RegExp(`${BEACON_SRC}[^<]*</script>\\s*</body>`),
-        );
+        // the script parses performance metrics. String indices avoid a
+        // regex built from BEACON_SRC (CodeQL: js/incomplete-hostname-regexp).
+        const beaconIdx = html.lastIndexOf(BEACON_SRC);
+        const bodyCloseIdx = html.lastIndexOf("</body>");
+        expect(beaconIdx).toBeGreaterThan(-1);
+        expect(bodyCloseIdx).toBeGreaterThan(beaconIdx);
+        // Nothing but the closing </script> should sit between the beacon
+        // src and </body>.
+        const between = html.slice(beaconIdx, bodyCloseIdx);
+        expect(between).toContain("</script>");
+        expect(between).not.toContain("<div");
       });
     }
 

--- a/test/cf-analytics.test.ts
+++ b/test/cf-analytics.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { app } from "../src/index.js";
+import { _memoryStore } from "../src/rate-limit.js";
+
+vi.mock("../src/dns/client.js", () => ({
+  queryTxt: vi.fn().mockResolvedValue(null),
+  queryMx: vi.fn().mockResolvedValue(null),
+}));
+
+beforeEach(() => {
+  _memoryStore.clear();
+});
+
+const VALID_TOKEN = "4fd7e22413e84811bd71ed466613bb26";
+const BEACON_SRC = "static.cloudflareinsights.com/beacon.min.js";
+
+// Hono's request() signature is (input, init, env). We only care about
+// CF_ANALYTICS_TOKEN — everything else is left undefined so the route
+// handlers see the same shape as a self-host deploy.
+const envWithToken = { CF_ANALYTICS_TOKEN: VALID_TOKEN };
+const envBlank = {};
+
+describe("Cloudflare Web Analytics beacon injection", () => {
+  describe("with CF_ANALYTICS_TOKEN set", () => {
+    const publicPaths = ["/", "/scoring", "/pricing", "/learn", "/learn/dmarc"];
+
+    for (const path of publicPaths) {
+      it(`injects beacon on ${path}`, async () => {
+        const res = await app.request(path, {}, envWithToken);
+        expect(res.status).toBe(200);
+        const html = await res.text();
+        expect(html).toContain(BEACON_SRC);
+        expect(html).toContain(`"token":"${VALID_TOKEN}"`);
+        // Beacon must sit just before </body> so DOM is available before
+        // the script parses performance metrics.
+        expect(html).toMatch(
+          new RegExp(`${BEACON_SRC}[^<]*</script>\\s*</body>`),
+        );
+      });
+    }
+
+    it("injects exactly one beacon script", async () => {
+      const res = await app.request("/", {}, envWithToken);
+      const html = await res.text();
+      const matches = html.match(/static\.cloudflareinsights\.com/g);
+      expect(matches).toHaveLength(1);
+    });
+
+    const skipPaths = [
+      "/dashboard",
+      "/dashboard/settings",
+      "/auth/login",
+      "/webhooks/stripe",
+    ];
+
+    for (const path of skipPaths) {
+      it(`does NOT inject beacon on ${path}`, async () => {
+        const res = await app.request(path, {}, envWithToken);
+        // These routes may 4xx/5xx (no auth, no Stripe config), but whatever
+        // HTML comes back must NOT carry the beacon.
+        const contentType = res.headers.get("content-type") ?? "";
+        if (contentType.includes("text/html")) {
+          const html = await res.text();
+          expect(html).not.toContain(BEACON_SRC);
+        }
+      });
+    }
+
+    it("does NOT inject beacon on JSON API responses", async () => {
+      const res = await app.request(
+        "/api/check?domain=dmarc.mx",
+        {},
+        envWithToken,
+      );
+      const body = await res.text();
+      expect(body).not.toContain(BEACON_SRC);
+    });
+  });
+
+  describe("with CF_ANALYTICS_TOKEN unset (self-host default)", () => {
+    const publicPaths = ["/", "/scoring", "/pricing", "/learn"];
+
+    for (const path of publicPaths) {
+      it(`omits beacon on ${path}`, async () => {
+        const res = await app.request(path, {}, envBlank);
+        expect(res.status).toBe(200);
+        const html = await res.text();
+        expect(html).not.toContain(BEACON_SRC);
+      });
+    }
+  });
+
+  describe("with malformed CF_ANALYTICS_TOKEN", () => {
+    const badTokens = [
+      "not-a-token",
+      "UPPERCASE0123456789ABCDEF01234567",
+      "short",
+      "<script>alert(1)</script>",
+      "4fd7e22413e84811bd71ed466613bb26-injected",
+    ];
+
+    for (const token of badTokens) {
+      it(`omits beacon when token is ${JSON.stringify(token).slice(0, 40)}`, async () => {
+        const res = await app.request("/", {}, { CF_ANALYTICS_TOKEN: token });
+        const html = await res.text();
+        expect(html).not.toContain(BEACON_SRC);
+        // Also verify we never passed the bad string through
+        expect(html).not.toContain(token);
+      });
+    }
+  });
+
+  describe("CSP already permits the beacon origin", () => {
+    it("script-src allows static.cloudflareinsights.com on HTML responses", async () => {
+      const res = await app.request("/", {}, envWithToken);
+      const csp = res.headers.get("content-security-policy") ?? "";
+      expect(csp).toContain("https://static.cloudflareinsights.com");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Wires Cloudflare Web Analytics manually. Automatic injection doesn't work for Worker responses (the edge HTML rewriter that does auto-injection runs on traditional origin-proxied traffic, not on Worker-generated responses — verified by curling the live HTML on main and seeing zero \`cloudflareinsights\` references).

### What ships

- Optional \`CF_ANALYTICS_TOKEN\` env var (32-char lowercase hex). Unset = no beacon. Keeps self-host deploys from shipping data to the hosted tier's dashboard.
- Beacon injected via string replace on \`</body>\` in the existing response middleware. Guarded by content-type \`text/html\`, token presence, token regex, and skip-path check.
- **Skip paths:** \`/dashboard/*\`, \`/auth/*\`, \`/webhooks/*\`. User-specific URL patterns never reach analytics.
- **Token validation:** \`/^[a-f0-9]{32}$/\`. Guards against a misconfigured env var injecting arbitrary strings into HTML.
- **CSP already permits** \`https://static.cloudflareinsights.com\` in \`script-src\` — no CSP change needed.

### Tests (21 new)

- Injection on \`/\`, \`/scoring\`, \`/pricing\`, \`/learn\`, \`/learn/dmarc\`
- Exactly-one-beacon-per-page
- Skip on \`/dashboard\`, \`/dashboard/settings\`, \`/auth/login\`, \`/webhooks/stripe\`
- No injection on JSON API responses
- No injection when token is unset
- No injection when token is malformed (5 variants including \`<script>alert(1)</script>\`)
- CSP allowance smoke check

Full suite: 680/680 green.

### Production activation — deliberately a separate step

I did **not** include a \`wrangler secret put CF_ANALYTICS_TOKEN\` step in this PR. The beacon should only start running in production once the Privacy Policy (PR #169) lands and a follow-up PR adds \"Cloudflare Web Analytics\" to the subprocessor list. Sequence:

1. Merge PR #169 (Privacy Policy)
2. Open a small follow-up PR adding one line to the subprocessor list + one line to "What I collect"
3. Merge this analytics PR
4. Run \`npx wrangler secret put CF_ANALYTICS_TOKEN\` with token \`4fd7e22413e84811bd71ed466613bb26\` — beacon goes live
5. Verify with \`curl -sS https://dmarc.mx/ | grep cloudflareinsights\`

The code is safe to merge in any order — without the secret, the beacon stays off.

### Why token-as-env-var vs. hard-coded

The token is non-secret (it ends up in public HTML) but an env var is still the right shape: a self-hoster who forks the repo never ships data to \`dmarc.mx\`'s dashboard. Matches the pattern used for \`STRIPE_*\` secrets.

## Test plan

- [x] \`npm run lint\` green
- [x] \`npm run typecheck\` green
- [x] \`npm test\` — 680/680 passing across 42 files
- [x] Token regex validated against 5 malicious inputs
- [x] Skip paths verified against \`/dashboard\`, \`/auth\`, \`/webhooks\`
- [ ] Production activation (manual \`wrangler secret put\` after privacy PR lands)

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)