### PR TITLE
feat(legal): disclose Cloudflare Web Analytics in Privacy Policy

### DIFF
--- a/src/views/legal.ts
+++ b/src/views/legal.ts
@@ -5,7 +5,7 @@ import { page } from "./html.js";
 // placeholder until the LLC is formed; at that point "DMarcus"/"I" flip to
 // the entity name and "we".
 
-const LAST_UPDATED = "2026-04-23";
+const LAST_UPDATED = "2026-04-24";
 
 export function renderPrivacyPage(): string {
   const body = `<main class="breakdown">
@@ -33,6 +33,7 @@ export function renderPrivacyPage(): string {
         <li><strong>Your subscription state</strong> from Stripe: subscription ID, plan, status, period end. Stripe holds the actual payment method; I never see your card number.</li>
         <li><strong>Scan history and watchlist</strong> &mdash; only if you have a Pro account and added domains yourself.</li>
         <li><strong>Error telemetry</strong> via Sentry, when the service crashes.</li>
+        <li><strong>Anonymized page views</strong> via Cloudflare Web Analytics &mdash; cookieless beacon, no cross-site tracking, no per-user profile. Skipped on <code>/dashboard/*</code>, <code>/auth/*</code>, and webhook endpoints.</li>
       </ul>
     </div>
   </div>
@@ -47,6 +48,7 @@ export function renderPrivacyPage(): string {
         <li>Stripe subscription state &rarr; run Pro features, let you cancel.</li>
         <li>Scan history and watchlist &rarr; run the Pro features you paid for.</li>
         <li>Error telemetry &rarr; fix bugs.</li>
+        <li>Page views &rarr; know which pages are worth improving.</li>
       </ul>
     </div>
   </div>
@@ -60,6 +62,7 @@ export function renderPrivacyPage(): string {
         <li><strong>Account email:</strong> same as above.</li>
         <li><strong>Stripe billing records:</strong> Stripe retains these to comply with US financial-record law (typically 7 years). I delete my local copy on account closure.</li>
         <li><strong>Error telemetry:</strong> 90 days, then purged by Sentry.</li>
+        <li><strong>Page views (Cloudflare Web Analytics):</strong> aggregated only, no per-user record to delete.</li>
       </ul>
     </div>
   </div>
@@ -69,7 +72,7 @@ export function renderPrivacyPage(): string {
     <div class="bd-card-body">
       <p class="tier-text">I use a short list of subprocessors to run the service. <strong>I'm not using this to train AI, selling your data, or sending it to advertisers.</strong></p>
       <ul>
-        <li><strong>Cloudflare</strong> &mdash; hosting, DNS, edge compute, D1 database</li>
+        <li><strong>Cloudflare</strong> &mdash; hosting, DNS, edge compute, D1 database, Web Analytics</li>
         <li><strong>WorkOS</strong> &mdash; account login</li>
         <li><strong>Stripe</strong> &mdash; billing</li>
         <li><strong>Cloudflare Email Sending</strong> &mdash; alerts, receipts, login links</li>

--- a/src/views/markdown.ts
+++ b/src/views/markdown.ts
@@ -305,7 +305,7 @@ See [Privacy](${MD_SITE}/legal/privacy). Questions? support@dmarc.mx.
 export function renderPrivacyMarkdown(): string {
   return `# Privacy Policy
 
-_Last updated: 2026-04-23_
+_Last updated: 2026-04-24_
 
 ## Who I am
 
@@ -321,6 +321,7 @@ When you use ${MD_SITE}:
 - **Your subscription state** from Stripe: subscription ID, plan, status, period end. Stripe holds the actual payment method; I never see your card number.
 - **Scan history and watchlist** — only if you have a Pro account and added domains yourself.
 - **Error telemetry** via Sentry, when the service crashes.
+- **Anonymized page views** via Cloudflare Web Analytics — cookieless beacon, no cross-site tracking, no per-user profile. Skipped on \`/dashboard/*\`, \`/auth/*\`, and webhook endpoints.
 
 ## Why
 
@@ -330,6 +331,7 @@ When you use ${MD_SITE}:
 - Stripe subscription state → run Pro features, let you cancel.
 - Scan history and watchlist → run the Pro features you paid for.
 - Error telemetry → fix bugs.
+- Page views → know which pages are worth improving.
 
 ## How long I keep it
 
@@ -338,12 +340,13 @@ When you use ${MD_SITE}:
 - **Account email:** same as above.
 - **Stripe billing records:** Stripe retains these to comply with US financial-record law (typically 7 years). I delete my local copy on account closure.
 - **Error telemetry:** 90 days, then purged by Sentry.
+- **Page views (Cloudflare Web Analytics):** aggregated only, no per-user record to delete.
 
 ## Who I share it with
 
 I use a short list of subprocessors to run the service. **I'm not using this to train AI, selling your data, or sending it to advertisers.**
 
-- **Cloudflare** — hosting, DNS, edge compute, D1 database
+- **Cloudflare** — hosting, DNS, edge compute, D1 database, Web Analytics
 - **WorkOS** — account login
 - **Stripe** — billing
 - **Cloudflare Email Sending** — alerts, receipts, login links

--- a/test/pricing-legal.test.ts
+++ b/test/pricing-legal.test.ts
@@ -117,6 +117,15 @@ describe("privacy policy", () => {
     }
   });
 
+  it("discloses Cloudflare Web Analytics in 'What I collect' and subprocessor list", async () => {
+    const res = await app.request("/legal/privacy");
+    const html = await res.text();
+    expect(html).toContain("Cloudflare Web Analytics");
+    expect(html).toContain("cookieless beacon");
+    // Subprocessor line folds Web Analytics into the Cloudflare entry
+    expect(html).toMatch(/Cloudflare[^<]*Web Analytics/);
+  });
+
   it("does not contain placeholder markers or pending banners", async () => {
     const res = await app.request("/legal/privacy");
     const html = await res.text();


### PR DESCRIPTION
## Summary

Follow-up to #171. The beacon-injection code is merged but inert until the \`CF_ANALYTICS_TOKEN\` wrangler secret is set. This PR adds the disclosure that has to land **before** the secret goes in, so analytics never runs without disclosure.

### Changes

- "What I collect" gets a new bullet: *"Anonymized page views via Cloudflare Web Analytics — cookieless beacon, no cross-site tracking, no per-user profile. Skipped on /dashboard/\*, /auth/\*, and webhook endpoints."*
- "Why" gets: *"Page views → know which pages are worth improving."*
- "How long I keep it" gets: *"Page views (Cloudflare Web Analytics): aggregated only, no per-user record to delete."*
- Subprocessor line folds "Web Analytics" into the existing Cloudflare entry (same vendor — not adding a new third party).
- Last updated bumps to 2026-04-24
- Test: subprocessor test now also checks the CF Web Analytics disclosure and cookieless framing

### Activation sequence after this merges

\`\`\`
npx wrangler secret put CF_ANALYTICS_TOKEN
# paste: 4fd7e22413e84811bd71ed466613bb26
\`\`\`

Then verify live:
\`\`\`
curl -sS https://dmarc.mx/ | grep cloudflareinsights
\`\`\`

## Test plan

- [x] \`npm run lint\` + \`npm run typecheck\` green
- [x] \`npm test\` — 680/680 passing across 42 files
- [x] HTML + markdown renderers updated in lockstep

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)