### PR TITLE
feat(webhooks,billing): ship outbound webhook dispatch + Stripe promo codes

### DIFF
--- a/src/billing/stripe.ts
+++ b/src/billing/stripe.ts
@@ -1,3 +1,4 @@
+import { constantTimeEqualHex, hmacSha256Hex } from "../shared/hmac.js";
 import type { BillingEnv } from "./feature-flag.js";
 
 // Minimal Stripe client built on the Workers Fetch API. We avoid the official
@@ -96,37 +97,6 @@ function parseSignatureHeader(header: string): ParsedSignature {
   return out;
 }
 
-async function hmacSha256Hex(secret: string, payload: string): Promise<string> {
-  const key = await crypto.subtle.importKey(
-    "raw",
-    new TextEncoder().encode(secret),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"],
-  );
-  const sig = await crypto.subtle.sign(
-    "HMAC",
-    key,
-    new TextEncoder().encode(payload),
-  );
-  return bytesToHex(new Uint8Array(sig));
-}
-
-function bytesToHex(bytes: Uint8Array): string {
-  let out = "";
-  for (const b of bytes) out += b.toString(16).padStart(2, "0");
-  return out;
-}
-
-function constantTimeEqualHex(a: string, b: string): boolean {
-  if (a.length !== b.length) return false;
-  let diff = 0;
-  for (let i = 0; i < a.length; i++) {
-    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
-  }
-  return diff === 0;
-}
-
 // Thin POST helper for Checkout / Portal / Customer calls.
 export async function stripeRequest<T>(
   env: BillingEnv,
@@ -190,6 +160,10 @@ export async function createCheckoutSession(
     customer: input.customerId,
     "line_items[0][price]": env.STRIPE_PRICE_ID_PRO,
     "line_items[0][quantity]": "1",
+    // Renders the "Add promotion code" link on the hosted Checkout page so
+    // operator-issued coupons (e.g. founder/free-Pro grants) can be redeemed
+    // without us minting one-off price IDs.
+    allow_promotion_codes: "true",
     success_url: input.successUrl,
     cancel_url: input.cancelUrl,
     // Stripe copies this onto the created subscription; lets the webhook

--- a/src/cron/rescan.ts
+++ b/src/cron/rescan.ts
@@ -9,6 +9,7 @@ import { recordAlert } from "../db/alerts.js";
 import { type Domain, getDueDomains } from "../db/domains.js";
 import { recordScan } from "../db/scans.js";
 import { scan as defaultScan } from "../orchestrator.js";
+import { fireScanCompletedWebhook } from "../webhooks/triggers.js";
 
 export interface RescanResult {
   scanned: number;
@@ -92,6 +93,13 @@ async function rescanOne(
     scoreFactors: result.breakdown.factors,
     protocolResults: result.protocols,
     scannedAt: deps.now,
+  });
+
+  await fireScanCompletedWebhook(deps.db, domain.user_id, {
+    domain: domain.domain,
+    grade: result.grade,
+    scanId: domain.id,
+    trigger: "cron",
   });
 
   const alerts: AlertPayload[] = [];

--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -32,6 +32,7 @@ import {
   getUserById,
   setEmailAlertsEnabled,
 } from "../db/users.js";
+import { getRecentDeliveriesForUser } from "../db/webhook-deliveries.js";
 import { scan } from "../orchestrator.js";
 import { normalizeDomain } from "../shared/domain.js";
 import {
@@ -44,6 +45,11 @@ import {
   renderSettingsPage,
   toApiKeyListEntry,
 } from "../views/dashboard.js";
+import { dispatchWebhook } from "../webhooks/dispatcher.js";
+import {
+  fireBulkScanWebhooks,
+  fireScanCompletedWebhook,
+} from "../webhooks/triggers.js";
 
 const HISTORY_LIMIT_PRO = 30;
 const HISTORY_LIMIT_FREE = 5;
@@ -215,6 +221,10 @@ dashboardRoutes.post("/bulk", async (c) => {
       400,
     );
   }
+  c.executionCtx.waitUntil(
+    fireBulkScanWebhooks(db, session.sub, outcome.results, "dashboard"),
+  );
+
   return c.html(
     renderBulkScanPage({
       email: session.email,
@@ -312,6 +322,15 @@ dashboardRoutes.post("/domain/:domain/scan", async (c) => {
     protocolResults: result.protocols,
   });
 
+  c.executionCtx.waitUntil(
+    fireScanCompletedWebhook(db, session.sub, {
+      domain: owned.domain,
+      grade: result.grade,
+      scanId: owned.id,
+      trigger: "dashboard",
+    }),
+  );
+
   return c.redirect(`/dashboard/domain/${encodeURIComponent(domainName)}`, 303);
 });
 
@@ -341,6 +360,26 @@ dashboardRoutes.get("/settings", async (c) => {
     .first<{ url: string }>();
   const plan = await getPlanForUser(db, session.sub);
   const env = c.env as { STRIPE_SECRET_KEY?: string };
+  const deliveries = await getRecentDeliveriesForUser(db, session.sub, 10);
+  const testParam = c.req.query("test");
+  let testFlash: {
+    ok: boolean;
+    statusCode: number | null;
+    error: string | null;
+  } | null = null;
+  if (testParam === "ok" || testParam === "fail") {
+    // Latest delivery row for this user is always the test we just ran (POST
+    // /webhook/test always inserts one). Pull it back so the flash carries the
+    // real status code without us needing to round-trip query params.
+    const latest = deliveries[0] ?? null;
+    if (latest) {
+      testFlash = {
+        ok: latest.ok === 1,
+        statusCode: latest.status_code,
+        error: latest.error,
+      };
+    }
+  }
   return c.html(
     renderSettingsPage({
       email: user.email,
@@ -349,6 +388,14 @@ dashboardRoutes.get("/settings", async (c) => {
       billingEnabled: Boolean(env.STRIPE_SECRET_KEY),
       emailAlertsEnabled: user.email_alerts_enabled === 1,
       showRetirementBanner: user.api_key_retirement_acknowledged_at === null,
+      recentDeliveries: deliveries.map((row) => ({
+        eventType: row.event_type,
+        ok: row.ok === 1,
+        statusCode: row.status_code,
+        error: row.error,
+        attemptedAt: row.attempted_at,
+      })),
+      testFlash,
     }),
   );
 });
@@ -432,6 +479,25 @@ dashboardRoutes.post("/settings/api-keys/revoke", async (c) => {
     await revokeApiKey(db, id, session.sub);
   }
   return c.redirect("/dashboard/settings/api-keys", 303);
+});
+
+// Fires a synthetic `webhook.test` event through the dispatcher so the user
+// can verify their receiver + signing without waiting for a real scan. Awaits
+// the result (rather than waitUntil) so we can flash the outcome on redirect.
+dashboardRoutes.post("/settings/webhook/test", async (c) => {
+  const session = c.get("user" as never) as SessionPayload;
+  const db = (c.env as { DB: D1Database }).DB;
+  const result = await dispatchWebhook(db, session.sub, {
+    type: "webhook.test",
+    data: { message: "Hello from dmarcheck" },
+  });
+  if (!result) {
+    return c.redirect("/dashboard/settings");
+  }
+  return c.redirect(
+    `/dashboard/settings?test=${result.ok ? "ok" : "fail"}`,
+    303,
+  );
 });
 
 // Save webhook URL

--- a/src/db/migrations/0006_webhook_deliveries.sql
+++ b/src/db/migrations/0006_webhook_deliveries.sql
@@ -1,0 +1,20 @@
+-- Outbound webhook delivery audit log. Records every attempt the dispatcher
+-- makes to POST to a user-configured webhook URL, so the dashboard can show
+-- recent delivery results and operators can debug failures without storing
+-- the request body itself (only its SHA-256 fingerprint).
+CREATE TABLE IF NOT EXISTS webhook_deliveries (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  webhook_id INTEGER NOT NULL REFERENCES webhooks(id) ON DELETE CASCADE,
+  event_id TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  url TEXT NOT NULL,
+  status_code INTEGER,
+  ok INTEGER NOT NULL,
+  error TEXT,
+  request_body_sha256 TEXT NOT NULL,
+  attempted_at INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_user_time
+  ON webhook_deliveries (user_id, attempted_at DESC);

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -85,6 +85,21 @@ CREATE TABLE IF NOT EXISTS api_keys (
   revoked_at INTEGER
 );
 
+-- Outbound webhook delivery audit log
+CREATE TABLE IF NOT EXISTS webhook_deliveries (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  webhook_id INTEGER NOT NULL REFERENCES webhooks(id) ON DELETE CASCADE,
+  event_id TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  url TEXT NOT NULL,
+  status_code INTEGER,
+  ok INTEGER NOT NULL,
+  error TEXT,
+  request_body_sha256 TEXT NOT NULL,
+  attempted_at INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
 -- Indexes for common queries
 CREATE INDEX IF NOT EXISTS idx_domains_user_id ON domains(user_id);
 CREATE INDEX IF NOT EXISTS idx_scan_history_domain_id ON scan_history(domain_id);
@@ -96,3 +111,5 @@ CREATE INDEX IF NOT EXISTS idx_domains_last_scanned ON domains(last_scanned_at);
 CREATE INDEX IF NOT EXISTS idx_subscriptions_status ON subscriptions(status);
 CREATE INDEX IF NOT EXISTS idx_api_keys_hash ON api_keys(hash);
 CREATE INDEX IF NOT EXISTS idx_api_keys_user_id ON api_keys(user_id);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_user_time
+  ON webhook_deliveries (user_id, attempted_at DESC);

--- a/src/db/webhook-deliveries.ts
+++ b/src/db/webhook-deliveries.ts
@@ -1,0 +1,71 @@
+// Audit log for outbound webhook attempts. Read by the dashboard settings
+// view to surface recent deliveries; written by the dispatcher after every
+// POST attempt (success or failure). Bodies are not stored — only the
+// SHA-256 of the request body so support can correlate without holding PII.
+
+export interface WebhookDeliveryRow {
+  id: number;
+  user_id: string;
+  webhook_id: number;
+  event_id: string;
+  event_type: string;
+  url: string;
+  status_code: number | null;
+  ok: number;
+  error: string | null;
+  request_body_sha256: string;
+  attempted_at: number;
+}
+
+export interface InsertWebhookDeliveryInput {
+  userId: string;
+  webhookId: number;
+  eventId: string;
+  eventType: string;
+  url: string;
+  statusCode: number | null;
+  ok: boolean;
+  error: string | null;
+  requestBodySha256: string;
+}
+
+export async function insertWebhookDelivery(
+  db: D1Database,
+  input: InsertWebhookDeliveryInput,
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO webhook_deliveries
+        (user_id, webhook_id, event_id, event_type, url, status_code, ok, error, request_body_sha256)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(
+      input.userId,
+      input.webhookId,
+      input.eventId,
+      input.eventType,
+      input.url,
+      input.statusCode,
+      input.ok ? 1 : 0,
+      input.error,
+      input.requestBodySha256,
+    )
+    .run();
+}
+
+export async function getRecentDeliveriesForUser(
+  db: D1Database,
+  userId: string,
+  limit = 10,
+): Promise<WebhookDeliveryRow[]> {
+  const result = await db
+    .prepare(
+      `SELECT * FROM webhook_deliveries
+       WHERE user_id = ?
+       ORDER BY attempted_at DESC
+       LIMIT ?`,
+    )
+    .bind(userId, limit)
+    .all<WebhookDeliveryRow>();
+  return result.results;
+}

--- a/src/db/webhooks.ts
+++ b/src/db/webhooks.ts
@@ -1,0 +1,23 @@
+// Lookup helpers for the user-configured outbound webhooks table. Writes
+// (save URL / rotate secret) currently live inline in the dashboard route
+// handler — leaving them there for now to keep route-level tests stable.
+
+export interface WebhookRow {
+  id: number;
+  user_id: string;
+  url: string;
+  secret: string | null;
+  created_at: number;
+}
+
+// Returns the webhook config for a user, or null if none is set. The dispatch
+// path treats null as "no-op, the user opted out" — not an error.
+export async function getWebhookForUser(
+  db: D1Database,
+  userId: string,
+): Promise<WebhookRow | null> {
+  return db
+    .prepare("SELECT * FROM webhooks WHERE user_id = ?")
+    .bind(userId)
+    .first<WebhookRow>();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,7 @@ import {
 import { renderPricingPage } from "./views/pricing.js";
 import { JS } from "./views/scripts.js";
 import { CSS } from "./views/styles.js";
+import { fireBulkScanWebhooks } from "./webhooks/triggers.js";
 
 // The Hono app is exported for tests (which call `app.request(...)`).
 // Runtime Workers use the Sentry-wrapped default export below, which adds
@@ -884,6 +885,9 @@ app.post("/api/bulk-scan", async (c) => {
       400,
     );
   }
+  c.executionCtx.waitUntil(
+    fireBulkScanWebhooks(db, bearer.userId, outcome.results, "bulk_api"),
+  );
   return c.json(outcome);
 });
 

--- a/src/shared/hmac.ts
+++ b/src/shared/hmac.ts
@@ -1,0 +1,40 @@
+// HMAC-SHA256 helpers shared by Stripe inbound signature verification and
+// our own outbound webhook signing. Kept in one place so the two codepaths
+// agree byte-for-byte on encoding and on the constant-time compare.
+
+export async function hmacSha256Hex(
+  secret: string,
+  payload: string,
+): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(payload),
+  );
+  return bytesToHex(new Uint8Array(sig));
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  let out = "";
+  for (const b of bytes) out += b.toString(16).padStart(2, "0");
+  return out;
+}
+
+// Length-checked, branch-free hex compare. Both inputs must be lowercase hex
+// of the same length; we accumulate XOR diff over every char so timing leaks
+// nothing about which byte mismatched.
+export function constantTimeEqualHex(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -1062,6 +1062,20 @@ function renderBulkRow(row: BulkResultRow): string {
 </tr>`;
 }
 
+export interface RecentWebhookDelivery {
+  eventType: string;
+  ok: boolean;
+  statusCode: number | null;
+  error: string | null;
+  attemptedAt: number;
+}
+
+export interface WebhookTestFlash {
+  ok: boolean;
+  statusCode: number | null;
+  error: string | null;
+}
+
 export function renderSettingsPage({
   email,
   webhookUrl,
@@ -1069,6 +1083,8 @@ export function renderSettingsPage({
   billingEnabled,
   emailAlertsEnabled,
   showRetirementBanner,
+  recentDeliveries = [],
+  testFlash = null,
 }: {
   email: string;
   webhookUrl: string | null;
@@ -1076,6 +1092,8 @@ export function renderSettingsPage({
   billingEnabled: boolean;
   emailAlertsEnabled: boolean;
   showRetirementBanner: boolean;
+  recentDeliveries?: RecentWebhookDelivery[];
+  testFlash?: WebhookTestFlash | null;
 }): string {
   const retirementBanner = showRetirementBanner
     ? `<div class="settings-section" style="border-color:var(--clr-accent);background:var(--clr-accent-muted, rgba(249,115,22,0.08))">
@@ -1109,6 +1127,11 @@ ${retirementBanner}
 
 <div class="settings-section">
   <h2>Webhook</h2>
+  <p style="font-size:0.875rem;color:var(--clr-text-muted);margin-bottom:0.75rem">
+    Receive a signed POST when a scan completes. Verify with the
+    <code>Dmarcheck-Signature</code> header (HMAC-SHA256 over
+    <code>&lt;timestamp&gt;.&lt;body&gt;</code>).
+  </p>
   <form method="POST" action="/dashboard/settings/webhook">
     <label for="webhook-url" style="display:block;font-size:0.875rem;color:var(--clr-text-muted);margin-bottom:0.4rem">Webhook URL</label>
     <input
@@ -1124,6 +1147,15 @@ ${retirementBanner}
     >
     <button type="submit" class="btn">Save Webhook</button>
   </form>
+  ${
+    webhookUrl
+      ? `<form method="POST" action="/dashboard/settings/webhook/test" style="margin-top:0.5rem">
+    <button type="submit" class="btn btn-secondary">Send test event</button>
+  </form>`
+      : ""
+  }
+  ${renderWebhookTestFlash(testFlash)}
+  ${renderWebhookDeliveries(recentDeliveries)}
 </div>
 
 <div class="settings-section">
@@ -1146,6 +1178,49 @@ ${retirementBanner}
 </div>`;
 
   return dashboardPage("Settings — dmarc.mx", body, email);
+}
+
+function renderWebhookTestFlash(flash: WebhookTestFlash | null): string {
+  if (!flash) return "";
+  const headline = flash.ok
+    ? `Test event delivered (HTTP ${flash.statusCode ?? "?"})`
+    : flash.statusCode !== null
+      ? `Test event failed: HTTP ${flash.statusCode}`
+      : `Test event failed: ${flash.error ?? "network error"}`;
+  const tone = flash.ok
+    ? "var(--clr-success, #16a34a)"
+    : "var(--clr-danger, #dc2626)";
+  return `<p style="margin-top:0.75rem;color:${tone};font-size:0.875rem">${esc(headline)}</p>`;
+}
+
+function renderWebhookDeliveries(rows: RecentWebhookDelivery[]): string {
+  if (rows.length === 0) return "";
+  const items = rows
+    .map((row) => {
+      const when = new Date(row.attemptedAt * 1000).toLocaleString();
+      const result = row.ok
+        ? `HTTP ${row.statusCode ?? "?"} ✓`
+        : row.statusCode !== null
+          ? `HTTP ${row.statusCode} ✗`
+          : `${esc(row.error ?? "error")} ✗`;
+      return `<tr>
+  <td style="padding:0.25rem 0.5rem">${esc(when)}</td>
+  <td style="padding:0.25rem 0.5rem"><code>${esc(row.eventType)}</code></td>
+  <td style="padding:0.25rem 0.5rem">${result}</td>
+</tr>`;
+    })
+    .join("");
+  return `<details style="margin-top:1rem">
+  <summary style="cursor:pointer;font-size:0.875rem;color:var(--clr-text-muted)">Recent deliveries (${rows.length})</summary>
+  <table style="margin-top:0.5rem;font-size:0.8125rem;border-collapse:collapse;width:100%">
+    <thead><tr style="text-align:left;color:var(--clr-text-muted)">
+      <th style="padding:0.25rem 0.5rem">When</th>
+      <th style="padding:0.25rem 0.5rem">Event</th>
+      <th style="padding:0.25rem 0.5rem">Result</th>
+    </tr></thead>
+    <tbody>${items}</tbody>
+  </table>
+</details>`;
 }
 
 export interface ApiKeyListEntry {

--- a/src/webhooks/dispatcher.ts
+++ b/src/webhooks/dispatcher.ts
@@ -1,0 +1,167 @@
+import { insertWebhookDelivery } from "../db/webhook-deliveries.js";
+import { getWebhookForUser } from "../db/webhooks.js";
+import { hmacSha256Hex } from "../shared/hmac.js";
+
+// Outbound webhook dispatcher. Single-attempt POST with a 5s timeout, signed
+// like Stripe (Dmarcheck-Signature: t=<unix>,v1=<hex of HMAC-SHA256 over
+// "<unix>.<body>" with the user's per-webhook secret). Every attempt — success
+// or failure — is recorded to webhook_deliveries so the dashboard can show
+// recent results without us having to keep request bodies around.
+
+const FETCH_TIMEOUT_MS = 5_000;
+
+// Payload shapes per event type. `data` is whatever the trigger site has on
+// hand at completion; receivers can call back into the API for more detail.
+export interface ScanCompletedData {
+  domain: string;
+  grade: string;
+  scan_id: string | number;
+  trigger: "dashboard" | "cron" | "bulk_api";
+  report_url: string;
+}
+
+export interface WebhookTestData {
+  message: string;
+}
+
+export type WebhookEvent =
+  | { type: "scan.completed"; data: ScanCompletedData }
+  | { type: "webhook.test"; data: WebhookTestData };
+
+export interface DispatchResult {
+  ok: boolean;
+  status: number | null;
+  error: string | null;
+  attempted_at: number;
+  event_id: string;
+}
+
+export interface DispatchOptions {
+  // Override for tests so signatures and event timestamps are deterministic.
+  now?: number;
+  // Override for tests so generated event ids are deterministic.
+  eventId?: string;
+}
+
+export async function dispatchWebhook(
+  db: D1Database,
+  userId: string,
+  event: WebhookEvent,
+  options: DispatchOptions = {},
+): Promise<DispatchResult | null> {
+  const webhook = await getWebhookForUser(db, userId);
+  if (!webhook) return null;
+
+  const now = options.now ?? Math.floor(Date.now() / 1000);
+  const eventId = options.eventId ?? `evt_${crypto.randomUUID()}`;
+  const envelope = {
+    id: eventId,
+    type: event.type,
+    created: now,
+    data: event.data,
+  };
+  const body = JSON.stringify(envelope);
+  const bodySha = await sha256Hex(body);
+
+  // No secret = nothing to sign with. Surface as a recorded failure so the
+  // user sees it in their delivery log instead of silently dropping events.
+  if (!webhook.secret) {
+    const result: DispatchResult = {
+      ok: false,
+      status: null,
+      error: "webhook secret missing — re-save the webhook to rotate",
+      attempted_at: now,
+      event_id: eventId,
+    };
+    await recordDelivery(
+      db,
+      userId,
+      webhook.id,
+      webhook.url,
+      event.type,
+      body,
+      bodySha,
+      result,
+    );
+    return result;
+  }
+
+  const signature = await hmacSha256Hex(webhook.secret, `${now}.${body}`);
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "Dmarcheck-Signature": `t=${now},v1=${signature}`,
+    "User-Agent": "dmarcheck-webhook/1",
+  };
+
+  let result: DispatchResult;
+  try {
+    const response = await fetch(webhook.url, {
+      method: "POST",
+      headers,
+      body,
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    result = {
+      ok: response.ok,
+      status: response.status,
+      error: response.ok ? null : `HTTP ${response.status}`,
+      attempted_at: now,
+      event_id: eventId,
+    };
+  } catch (err) {
+    result = {
+      ok: false,
+      status: null,
+      error: err instanceof Error ? err.message : String(err),
+      attempted_at: now,
+      event_id: eventId,
+    };
+  }
+
+  await recordDelivery(
+    db,
+    userId,
+    webhook.id,
+    webhook.url,
+    event.type,
+    body,
+    bodySha,
+    result,
+  );
+  return result;
+}
+
+async function recordDelivery(
+  db: D1Database,
+  userId: string,
+  webhookId: number,
+  url: string,
+  eventType: string,
+  _body: string,
+  bodySha: string,
+  result: DispatchResult,
+): Promise<void> {
+  await insertWebhookDelivery(db, {
+    userId,
+    webhookId,
+    eventId: result.event_id,
+    eventType,
+    url,
+    statusCode: result.status,
+    ok: result.ok,
+    error: result.error,
+    requestBodySha256: bodySha,
+  });
+}
+
+async function sha256Hex(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(input),
+  );
+  let out = "";
+  for (const b of new Uint8Array(digest)) {
+    out += b.toString(16).padStart(2, "0");
+  }
+  return out;
+}

--- a/src/webhooks/triggers.ts
+++ b/src/webhooks/triggers.ts
@@ -1,0 +1,57 @@
+import type { BulkResultEntry } from "../api/bulk-scan.js";
+import { CANONICAL_ORIGIN } from "../api/catalog.js";
+import { dispatchWebhook, type ScanCompletedData } from "./dispatcher.js";
+
+// Convenience wrapper used by every scan trigger (dashboard / cron / bulk).
+// Centralizes the `scan.completed` payload shape so adding a field later
+// (e.g. an alert summary) only touches one place.
+export async function fireScanCompletedWebhook(
+  db: D1Database,
+  userId: string,
+  input: {
+    domain: string;
+    grade: string;
+    scanId: string | number;
+    trigger: ScanCompletedData["trigger"];
+  },
+): Promise<void> {
+  try {
+    await dispatchWebhook(db, userId, {
+      type: "scan.completed",
+      data: {
+        domain: input.domain,
+        grade: input.grade,
+        scan_id: input.scanId,
+        trigger: input.trigger,
+        report_url: `${CANONICAL_ORIGIN}/check?domain=${encodeURIComponent(input.domain)}`,
+      },
+    });
+  } catch {
+    // Dispatcher already records its own failures into webhook_deliveries; the
+    // `try` here exists only so an unexpected throw can't bubble out of a
+    // `waitUntil` and crash an unrelated request handler.
+  }
+}
+
+// Fires one `scan.completed` event per successfully-scanned entry in a bulk
+// outcome. Best-effort and serial — callers should hand this to `waitUntil`
+// so it never blocks the response. Queued/invalid/error entries are skipped
+// (no scan happened, nothing to report).
+export async function fireBulkScanWebhooks(
+  db: D1Database,
+  userId: string,
+  results: BulkResultEntry[],
+  trigger: ScanCompletedData["trigger"],
+): Promise<void> {
+  for (const entry of results) {
+    if (entry.status !== "scanned" || !entry.grade) continue;
+    await fireScanCompletedWebhook(db, userId, {
+      domain: entry.domain,
+      grade: entry.grade,
+      // Bulk scans don't surface a stable scan_history.id; receivers can
+      // re-fetch by domain via /api/domain/:name/history.
+      scanId: entry.domain,
+      trigger,
+    });
+  }
+}

--- a/test/billing-checkout-session.test.ts
+++ b/test/billing-checkout-session.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createCheckoutSession } from "../src/billing/stripe.js";
+
+const ENV = {
+  STRIPE_SECRET_KEY: "sk_test_x",
+  STRIPE_WEBHOOK_SECRET: "whsec_x",
+  STRIPE_PRICE_ID_PRO: "price_pro_test",
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("billing/stripe.createCheckoutSession", () => {
+  it("requests Stripe Checkout with allow_promotion_codes enabled", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ id: "cs_test_1", url: "https://stripe" }), {
+        status: 200,
+      }),
+    );
+
+    const result = await createCheckoutSession(ENV, {
+      customerId: "cus_test_1",
+      successUrl: "https://app/success",
+      cancelUrl: "https://app/cancel",
+      userId: "user-1",
+    });
+
+    expect(result.id).toBe("cs_test_1");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const params = new URLSearchParams(String(init.body));
+    expect(params.get("allow_promotion_codes")).toBe("true");
+    // Sanity-check the rest of the request hasn't been broken.
+    expect(params.get("mode")).toBe("subscription");
+    expect(params.get("customer")).toBe("cus_test_1");
+    expect(params.get("line_items[0][price]")).toBe("price_pro_test");
+    expect(params.get("subscription_data[metadata][user_id]")).toBe("user-1");
+  });
+});

--- a/test/shared-hmac.test.ts
+++ b/test/shared-hmac.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { constantTimeEqualHex, hmacSha256Hex } from "../src/shared/hmac.js";
+
+describe("shared/hmac", () => {
+  it("hmacSha256Hex matches a known RFC 4231 vector", async () => {
+    // RFC 4231 test case 1: key=0x0b*20, data="Hi There"
+    // Expected: b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7
+    const key = String.fromCharCode(...new Array(20).fill(0x0b));
+    const out = await hmacSha256Hex(key, "Hi There");
+    expect(out).toBe(
+      "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7",
+    );
+  });
+
+  it("hmacSha256Hex produces deterministic output", async () => {
+    const a = await hmacSha256Hex("secret", "hello");
+    const b = await hmacSha256Hex("secret", "hello");
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("hmacSha256Hex changes with payload", async () => {
+    const a = await hmacSha256Hex("secret", "hello");
+    const b = await hmacSha256Hex("secret", "hello!");
+    expect(a).not.toBe(b);
+  });
+
+  it("constantTimeEqualHex returns true for identical hex", () => {
+    expect(constantTimeEqualHex("abcd1234", "abcd1234")).toBe(true);
+  });
+
+  it("constantTimeEqualHex returns false for differing hex", () => {
+    expect(constantTimeEqualHex("abcd1234", "abcd1235")).toBe(false);
+  });
+
+  it("constantTimeEqualHex returns false for different lengths", () => {
+    expect(constantTimeEqualHex("ab", "abcd")).toBe(false);
+  });
+});

--- a/test/webhooks-dispatcher.test.ts
+++ b/test/webhooks-dispatcher.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { hmacSha256Hex } from "../src/shared/hmac.js";
+import { dispatchWebhook } from "../src/webhooks/dispatcher.js";
+
+interface FakeWebhookRow {
+  id: number;
+  user_id: string;
+  url: string;
+  secret: string | null;
+  created_at: number;
+}
+
+interface DeliveryRow {
+  user_id: string;
+  webhook_id: number;
+  event_id: string;
+  event_type: string;
+  url: string;
+  status_code: number | null;
+  ok: number;
+  error: string | null;
+  request_body_sha256: string;
+}
+
+let webhooksByUser: Map<string, FakeWebhookRow>;
+let deliveries: DeliveryRow[];
+
+function makeDb(): D1Database {
+  const prepare = (sql: string) => ({
+    bind: (...params: unknown[]) => ({
+      first: async <T>() => {
+        if (/^SELECT \* FROM webhooks WHERE user_id = \?/i.test(sql)) {
+          const [userId] = params as [string];
+          return (webhooksByUser.get(userId) as T | undefined) ?? null;
+        }
+        return null;
+      },
+      run: async () => {
+        if (/^INSERT INTO webhook_deliveries/i.test(sql)) {
+          const [
+            userId,
+            webhookId,
+            eventId,
+            eventType,
+            url,
+            statusCode,
+            ok,
+            error,
+            sha,
+          ] = params as [
+            string,
+            number,
+            string,
+            string,
+            string,
+            number | null,
+            number,
+            string | null,
+            string,
+          ];
+          deliveries.push({
+            user_id: userId,
+            webhook_id: webhookId,
+            event_id: eventId,
+            event_type: eventType,
+            url,
+            status_code: statusCode,
+            ok,
+            error,
+            request_body_sha256: sha,
+          });
+        }
+        return { meta: {} } as never;
+      },
+      all: async <T>() => ({ results: [] as T[] }),
+    }),
+  });
+  return { prepare } as unknown as D1Database;
+}
+
+beforeEach(() => {
+  webhooksByUser = new Map();
+  deliveries = [];
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("webhooks/dispatcher.dispatchWebhook", () => {
+  it("returns null and does not fetch when the user has no webhook configured", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const db = makeDb();
+
+    const result = await dispatchWebhook(db, "user-without-hook", {
+      type: "webhook.test",
+      data: { message: "ping" },
+    });
+
+    expect(result).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(deliveries).toHaveLength(0);
+  });
+
+  it("POSTs a signed envelope and records a successful delivery", async () => {
+    webhooksByUser.set("u1", {
+      id: 42,
+      user_id: "u1",
+      url: "https://hook.example/receive",
+      secret: "shhh",
+      created_at: 0,
+    });
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("", { status: 202 }));
+    const db = makeDb();
+
+    const result = await dispatchWebhook(
+      db,
+      "u1",
+      { type: "webhook.test", data: { message: "ping" } },
+      { now: 1_700_000_000 },
+    );
+
+    expect(result?.ok).toBe(true);
+    expect(result?.status).toBe(202);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    const [calledUrl, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(calledUrl).toBe("https://hook.example/receive");
+    expect(init.method).toBe("POST");
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Content-Type"]).toBe("application/json");
+    const sig = headers["Dmarcheck-Signature"];
+    expect(sig).toMatch(/^t=1700000000,v1=[0-9a-f]{64}$/);
+
+    const body = String(init.body);
+    const envelope = JSON.parse(body) as {
+      id: string;
+      type: string;
+      created: number;
+      data: { message: string };
+    };
+    expect(envelope.type).toBe("webhook.test");
+    expect(envelope.created).toBe(1_700_000_000);
+    expect(envelope.id).toMatch(/^evt_/);
+    expect(envelope.data.message).toBe("ping");
+
+    // Signature must validate against the webhook's secret.
+    const expectedV1 = await hmacSha256Hex("shhh", `1700000000.${body}`);
+    expect(sig).toBe(`t=1700000000,v1=${expectedV1}`);
+
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0].ok).toBe(1);
+    expect(deliveries[0].status_code).toBe(202);
+    expect(deliveries[0].webhook_id).toBe(42);
+    expect(deliveries[0].event_type).toBe("webhook.test");
+    expect(deliveries[0].request_body_sha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("records a failed delivery when the receiver returns 500", async () => {
+    webhooksByUser.set("u1", {
+      id: 7,
+      user_id: "u1",
+      url: "https://hook.example/receive",
+      secret: "shhh",
+      created_at: 0,
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("nope", { status: 500 }),
+    );
+    const db = makeDb();
+
+    const result = await dispatchWebhook(db, "u1", {
+      type: "webhook.test",
+      data: { message: "ping" },
+    });
+
+    expect(result?.ok).toBe(false);
+    expect(result?.status).toBe(500);
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0].ok).toBe(0);
+    expect(deliveries[0].status_code).toBe(500);
+  });
+
+  it("records a failed delivery when fetch throws (network/timeout)", async () => {
+    webhooksByUser.set("u1", {
+      id: 9,
+      user_id: "u1",
+      url: "https://hook.example/receive",
+      secret: "shhh",
+      created_at: 0,
+    });
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
+    const db = makeDb();
+
+    const result = await dispatchWebhook(db, "u1", {
+      type: "webhook.test",
+      data: { message: "ping" },
+    });
+
+    expect(result?.ok).toBe(false);
+    expect(result?.status).toBeNull();
+    expect(result?.error).toMatch(/ECONNREFUSED/);
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0].ok).toBe(0);
+    expect(deliveries[0].status_code).toBeNull();
+    expect(deliveries[0].error).toMatch(/ECONNREFUSED/);
+  });
+
+  it("skips dispatch and records an error when the webhook row has no secret", async () => {
+    webhooksByUser.set("u1", {
+      id: 11,
+      user_id: "u1",
+      url: "https://hook.example/receive",
+      secret: null,
+      created_at: 0,
+    });
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const db = makeDb();
+
+    const result = await dispatchWebhook(db, "u1", {
+      type: "webhook.test",
+      data: { message: "ping" },
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result?.ok).toBe(false);
+    expect(result?.error).toMatch(/secret/i);
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0].ok).toBe(0);
+    expect(deliveries[0].status_code).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- **Outbound webhook dispatch.** The `webhooks` table has stored a URL + secret since launch but nothing ever POSTed to it. This adds `src/webhooks/dispatcher.ts` (single-attempt, 5s timeout, signed `Dmarcheck-Signature: t=<unix>,v1=<hex>` mirroring our inbound Stripe verification) and wires it into all four scan completion sites: dashboard single scan, dashboard bulk, `/api/bulk-scan`, and the nightly cron rescan. HMAC helpers extracted to `src/shared/hmac.ts` so signing and verifying use the same code path.
- **Send test event UI.** New `POST /dashboard/settings/webhook/test` route + button on the settings page fire a synthetic `webhook.test` event and flash the HTTP outcome on redirect. Recent deliveries (last 10) render as a collapsible table backed by the new `webhook_deliveries` audit log.
- **Stripe promo codes.** `allow_promotion_codes: true` added to `createCheckoutSession` so a 100%-off coupon created in the Stripe Dashboard can be redeemed on the hosted Checkout page — unblocks issuing free-Pro grants without minting per-customer price IDs.
- **Migration 0006.** `webhook_deliveries` table records every attempt (user_id, webhook_id, event_id/type, url, status_code, ok, error, request_body_sha256, attempted_at) with a `(user_id, attempted_at DESC)` index. Stores the SHA-256 of the body, not the body itself — surfaces delivery state without holding scan PII.

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 692/692 pass, including new `shared-hmac.test.ts` (6), `webhooks-dispatcher.test.ts` (5), `billing-checkout-session.test.ts` (1)
- [x] Smoke-tested API key auth against prod: `/api/domain/.../history` and `/api/bulk-scan` both return 402 "requires Pro" with the test bearer (proves auth works; Pro gate fires)
- [ ] After merge: log into `/dashboard/settings`, save an HTTPS receiver URL, click **Send test event** — expect a flashed HTTP status + a `Dmarcheck-Signature` POST at the receiver whose `v1` validates over `${t}.${body}` with the saved secret
- [ ] After merge: scan a monitored domain from the dashboard — expect a `scan.completed` POST within seconds
- [ ] After merge: create a 100%-off coupon + promotion code in Stripe Dashboard, redeem at `/dashboard/billing/subscribe`, confirm `subscriptions.status='active'` in D1
- [ ] Migration 0006 auto-applies via `.github/workflows/migrate.yml` after CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)