### PR TITLE
feat(webhooks): multi-format dispatch (raw / slack / google_chat)

### DIFF
--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -47,6 +47,10 @@ import {
 } from "../views/dashboard.js";
 import { dispatchWebhook } from "../webhooks/dispatcher.js";
 import {
+  isWebhookFormat,
+  type WebhookFormat,
+} from "../webhooks/formats/index.js";
+import {
   fireBulkScanWebhooks,
   fireScanCompletedWebhook,
 } from "../webhooks/triggers.js";
@@ -355,9 +359,9 @@ dashboardRoutes.get("/settings", async (c) => {
     return c.redirect("/auth/logout");
   }
   const webhook = await db
-    .prepare("SELECT url FROM webhooks WHERE user_id = ?")
+    .prepare("SELECT url, format FROM webhooks WHERE user_id = ?")
     .bind(session.sub)
-    .first<{ url: string }>();
+    .first<{ url: string; format: WebhookFormat }>();
   const plan = await getPlanForUser(db, session.sub);
   const env = c.env as { STRIPE_SECRET_KEY?: string };
   const deliveries = await getRecentDeliveriesForUser(db, session.sub, 10);
@@ -384,6 +388,7 @@ dashboardRoutes.get("/settings", async (c) => {
     renderSettingsPage({
       email: user.email,
       webhookUrl: webhook?.url ?? null,
+      webhookFormat: webhook?.format ?? "raw",
       plan,
       billingEnabled: Boolean(env.STRIPE_SECRET_KEY),
       emailAlertsEnabled: user.email_alerts_enabled === 1,
@@ -500,7 +505,7 @@ dashboardRoutes.post("/settings/webhook/test", async (c) => {
   );
 });
 
-// Save webhook URL
+// Save webhook URL + format
 dashboardRoutes.post("/settings/webhook", async (c) => {
   const session = c.get("user" as never) as SessionPayload;
   const db = (c.env as { DB: D1Database }).DB;
@@ -517,20 +522,33 @@ dashboardRoutes.post("/settings/webhook", async (c) => {
     return c.redirect("/dashboard/settings");
   }
 
+  // Missing `format` (older submissions) means the legacy signed-JSON path.
+  // Unknown values are rejected with a no-save redirect to match the URL
+  // validation above — silent coercion would hide typos in the receiver UI.
+  const rawFormat = body.format;
+  const formatCandidate =
+    typeof rawFormat === "string" && rawFormat !== "" ? rawFormat : "raw";
+  if (!isWebhookFormat(formatCandidate)) {
+    return c.redirect("/dashboard/settings");
+  }
+  const format: WebhookFormat = formatCandidate;
+
   const existing = await db
     .prepare("SELECT id FROM webhooks WHERE user_id = ?")
     .bind(session.sub)
     .first<{ id: number }>();
   if (existing) {
     await db
-      .prepare("UPDATE webhooks SET url = ? WHERE user_id = ?")
-      .bind(url, session.sub)
+      .prepare("UPDATE webhooks SET url = ?, format = ? WHERE user_id = ?")
+      .bind(url, format, session.sub)
       .run();
   } else {
     const secret = crypto.randomUUID();
     await db
-      .prepare("INSERT INTO webhooks (user_id, url, secret) VALUES (?, ?, ?)")
-      .bind(session.sub, url, secret)
+      .prepare(
+        "INSERT INTO webhooks (user_id, url, secret, format) VALUES (?, ?, ?, ?)",
+      )
+      .bind(session.sub, url, secret, format)
       .run();
   }
   return c.redirect("/dashboard/settings");

--- a/src/db/migrations/0007_webhook_format.sql
+++ b/src/db/migrations/0007_webhook_format.sql
@@ -1,0 +1,5 @@
+-- Add a `format` column to outbound webhooks so users can target chat
+-- platforms (Slack, Google Chat) whose incoming-webhook receivers reject our
+-- signed-envelope shape. Existing rows default to 'raw', preserving the
+-- current signed-JSON behavior byte-for-byte.
+ALTER TABLE webhooks ADD COLUMN format TEXT NOT NULL DEFAULT 'raw';

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -50,6 +50,7 @@ CREATE TABLE IF NOT EXISTS webhooks (
   user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   url TEXT NOT NULL,
   secret TEXT,
+  format TEXT NOT NULL DEFAULT 'raw',
   created_at INTEGER NOT NULL DEFAULT (unixepoch())
 );
 

--- a/src/db/webhooks.ts
+++ b/src/db/webhooks.ts
@@ -2,11 +2,14 @@
 // (save URL / rotate secret) currently live inline in the dashboard route
 // handler — leaving them there for now to keep route-level tests stable.
 
+import type { WebhookFormat } from "../webhooks/formats/index.js";
+
 export interface WebhookRow {
   id: number;
   user_id: string;
   url: string;
   secret: string | null;
+  format: WebhookFormat;
   created_at: number;
 }
 

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -1,3 +1,4 @@
+import type { WebhookFormat } from "../webhooks/formats/index.js";
 import {
   esc,
   generateCreature,
@@ -1079,6 +1080,7 @@ export interface WebhookTestFlash {
 export function renderSettingsPage({
   email,
   webhookUrl,
+  webhookFormat = "raw",
   plan,
   billingEnabled,
   emailAlertsEnabled,
@@ -1088,6 +1090,7 @@ export function renderSettingsPage({
 }: {
   email: string;
   webhookUrl: string | null;
+  webhookFormat?: WebhookFormat;
   plan: "free" | "pro";
   billingEnabled: boolean;
   emailAlertsEnabled: boolean;
@@ -1128,9 +1131,10 @@ ${retirementBanner}
 <div class="settings-section">
   <h2>Webhook</h2>
   <p style="font-size:0.875rem;color:var(--clr-text-muted);margin-bottom:0.75rem">
-    Receive a signed POST when a scan completes. Verify with the
-    <code>Dmarcheck-Signature</code> header (HMAC-SHA256 over
-    <code>&lt;timestamp&gt;.&lt;body&gt;</code>).
+    Receive a POST when a scan completes. Pick a format: the raw JSON
+    envelope is signed with a <code>Dmarcheck-Signature</code> header
+    (HMAC-SHA256 over <code>&lt;timestamp&gt;.&lt;body&gt;</code>), or
+    target a Slack / Google Chat incoming webhook for chat delivery.
   </p>
   <form method="POST" action="/dashboard/settings/webhook">
     <label for="webhook-url" style="display:block;font-size:0.875rem;color:var(--clr-text-muted);margin-bottom:0.4rem">Webhook URL</label>
@@ -1145,6 +1149,15 @@ ${retirementBanner}
       autocorrect="off"
       spellcheck="false"
     >
+    <label for="webhook-format" style="display:block;font-size:0.875rem;color:var(--clr-text-muted);margin-bottom:0.4rem;margin-top:0.75rem">Format</label>
+    <select id="webhook-format" class="settings-input" name="format">
+      <option value="raw"${webhookFormat === "raw" ? " selected" : ""}>Raw (signed JSON envelope)</option>
+      <option value="slack"${webhookFormat === "slack" ? " selected" : ""}>Slack incoming webhook</option>
+      <option value="google_chat"${webhookFormat === "google_chat" ? " selected" : ""}>Google Chat incoming webhook</option>
+    </select>
+    <p style="font-size:0.8125rem;color:var(--clr-text-muted);margin:0.4rem 0 0.75rem">
+      Raw posts the signed envelope for your own receiver. Slack and Google Chat send a chat message and omit the signature header (those platforms don't verify it).
+    </p>
     <button type="submit" class="btn">Save Webhook</button>
   </form>
   ${

--- a/src/webhooks/dispatcher.ts
+++ b/src/webhooks/dispatcher.ts
@@ -1,32 +1,29 @@
 import { insertWebhookDelivery } from "../db/webhook-deliveries.js";
 import { getWebhookForUser } from "../db/webhooks.js";
 import { hmacSha256Hex } from "../shared/hmac.js";
+import {
+  getFormatAdapter,
+  type ScanCompletedData,
+  type WebhookEnvelope,
+  type WebhookEvent,
+  type WebhookTestData,
+} from "./formats/index.js";
 
-// Outbound webhook dispatcher. Single-attempt POST with a 5s timeout, signed
-// like Stripe (Dmarcheck-Signature: t=<unix>,v1=<hex of HMAC-SHA256 over
-// "<unix>.<body>" with the user's per-webhook secret). Every attempt — success
-// or failure — is recorded to webhook_deliveries so the dashboard can show
-// recent results without us having to keep request bodies around.
+// Outbound webhook dispatcher. Single-attempt POST with a 5s timeout. Every
+// attempt — success or failure — is recorded to webhook_deliveries so the
+// dashboard can show recent results without us keeping request bodies around.
+//
+// The format adapter chosen for the webhook row decides what goes on the
+// wire:
+//   - raw: JSON-stringified envelope, signed like Stripe
+//     (Dmarcheck-Signature: t=<unix>,v1=<hex of HMAC-SHA256 over
+//     "<unix>.<body>" with the user's per-webhook secret).
+//   - slack / google_chat: platform-specific text payload, no signature —
+//     those chat receivers don't verify one.
 
 const FETCH_TIMEOUT_MS = 5_000;
 
-// Payload shapes per event type. `data` is whatever the trigger site has on
-// hand at completion; receivers can call back into the API for more detail.
-export interface ScanCompletedData {
-  domain: string;
-  grade: string;
-  scan_id: string | number;
-  trigger: "dashboard" | "cron" | "bulk_api";
-  report_url: string;
-}
-
-export interface WebhookTestData {
-  message: string;
-}
-
-export type WebhookEvent =
-  | { type: "scan.completed"; data: ScanCompletedData }
-  | { type: "webhook.test"; data: WebhookTestData };
+export type { ScanCompletedData, WebhookEvent, WebhookTestData };
 
 export interface DispatchResult {
   ok: boolean;
@@ -54,44 +51,49 @@ export async function dispatchWebhook(
 
   const now = options.now ?? Math.floor(Date.now() / 1000);
   const eventId = options.eventId ?? `evt_${crypto.randomUUID()}`;
-  const envelope = {
+  const envelope: WebhookEnvelope = {
     id: eventId,
     type: event.type,
     created: now,
     data: event.data,
   };
-  const body = JSON.stringify(envelope);
+
+  const adapter = getFormatAdapter(webhook.format);
+  const { body } = adapter(envelope);
   const bodySha = await sha256Hex(body);
 
-  // No secret = nothing to sign with. Surface as a recorded failure so the
-  // user sees it in their delivery log instead of silently dropping events.
-  if (!webhook.secret) {
-    const result: DispatchResult = {
-      ok: false,
-      status: null,
-      error: "webhook secret missing — re-save the webhook to rotate",
-      attempted_at: now,
-      event_id: eventId,
-    };
-    await recordDelivery(
-      db,
-      userId,
-      webhook.id,
-      webhook.url,
-      event.type,
-      body,
-      bodySha,
-      result,
-    );
-    return result;
-  }
-
-  const signature = await hmacSha256Hex(webhook.secret, `${now}.${body}`);
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
-    "Dmarcheck-Signature": `t=${now},v1=${signature}`,
     "User-Agent": "dmarcheck-webhook/1",
   };
+
+  // `raw` is the only format that signs — chat platforms don't verify and
+  // sending the header to them is noise. The null-secret guard therefore
+  // only blocks dispatch on the `raw` path: legacy rows that predate the
+  // secret rotation can still deliver to Slack/Google Chat.
+  if (webhook.format === "raw") {
+    if (!webhook.secret) {
+      const result: DispatchResult = {
+        ok: false,
+        status: null,
+        error: "webhook secret missing — re-save the webhook to rotate",
+        attempted_at: now,
+        event_id: eventId,
+      };
+      await recordDelivery(
+        db,
+        userId,
+        webhook.id,
+        webhook.url,
+        event.type,
+        bodySha,
+        result,
+      );
+      return result;
+    }
+    const signature = await hmacSha256Hex(webhook.secret, `${now}.${body}`);
+    headers["Dmarcheck-Signature"] = `t=${now},v1=${signature}`;
+  }
 
   let result: DispatchResult;
   try {
@@ -124,7 +126,6 @@ export async function dispatchWebhook(
     webhook.id,
     webhook.url,
     event.type,
-    body,
     bodySha,
     result,
   );
@@ -137,7 +138,6 @@ async function recordDelivery(
   webhookId: number,
   url: string,
   eventType: string,
-  _body: string,
   bodySha: string,
   result: DispatchResult,
 ): Promise<void> {

--- a/src/webhooks/formats/google_chat.ts
+++ b/src/webhooks/formats/google_chat.ts
@@ -1,0 +1,8 @@
+import { renderMessage, type WebhookEnvelope } from "./index.js";
+
+// Google Chat incoming webhook: `{text: "..."}` renders as a plain chat
+// message with URLs auto-linked. Kept as its own module so moving to a
+// cardsV2 payload later doesn't touch the slack adapter.
+export function formatGoogleChat(envelope: WebhookEnvelope): { body: string } {
+  return { body: JSON.stringify({ text: renderMessage(envelope) }) };
+}

--- a/src/webhooks/formats/index.ts
+++ b/src/webhooks/formats/index.ts
@@ -1,0 +1,69 @@
+// Outbound webhook format adapters. Each adapter transforms the canonical
+// envelope into the body bytes a specific receiver expects. `raw` is the
+// signed-JSON shape our own docs describe; `slack` / `google_chat` target
+// incoming-webhook URLs on those chat platforms, which expect `{text: "..."}`
+// and do not verify signatures.
+
+import { formatGoogleChat } from "./google_chat.js";
+import { formatRaw } from "./raw.js";
+import { formatSlack } from "./slack.js";
+
+export const WEBHOOK_FORMATS = ["raw", "slack", "google_chat"] as const;
+export type WebhookFormat = (typeof WEBHOOK_FORMATS)[number];
+
+export interface ScanCompletedData {
+  domain: string;
+  grade: string;
+  scan_id: string | number;
+  trigger: "dashboard" | "cron" | "bulk_api";
+  report_url: string;
+}
+
+export interface WebhookTestData {
+  message: string;
+}
+
+export type WebhookEvent =
+  | { type: "scan.completed"; data: ScanCompletedData }
+  | { type: "webhook.test"; data: WebhookTestData };
+
+export interface WebhookEnvelope {
+  id: string;
+  type: WebhookEvent["type"];
+  created: number;
+  data: ScanCompletedData | WebhookTestData;
+}
+
+export interface FormatResult {
+  body: string;
+}
+
+export type FormatAdapter = (envelope: WebhookEnvelope) => FormatResult;
+
+const ADAPTERS: Record<WebhookFormat, FormatAdapter> = {
+  raw: formatRaw,
+  slack: formatSlack,
+  google_chat: formatGoogleChat,
+};
+
+export function getFormatAdapter(format: WebhookFormat): FormatAdapter {
+  return ADAPTERS[format];
+}
+
+export function isWebhookFormat(value: unknown): value is WebhookFormat {
+  return (
+    typeof value === "string" &&
+    (WEBHOOK_FORMATS as readonly string[]).includes(value)
+  );
+}
+
+// One-line human summary used by chat adapters. Kept here so divergence
+// between slack/google_chat stays trivial to spot — both call this today.
+export function renderMessage(envelope: WebhookEnvelope): string {
+  if (envelope.type === "scan.completed") {
+    const d = envelope.data as ScanCompletedData;
+    return `DMARC scan complete: ${d.domain} → ${d.grade} — ${d.report_url}`;
+  }
+  const d = envelope.data as WebhookTestData;
+  return `dmarcheck webhook test — ${d.message}`;
+}

--- a/src/webhooks/formats/raw.ts
+++ b/src/webhooks/formats/raw.ts
@@ -1,0 +1,7 @@
+import type { WebhookEnvelope } from "./index.js";
+
+// Canonical dmarcheck envelope: serialize as-is. The dispatcher signs this
+// body with HMAC-SHA256 and attaches the Dmarcheck-Signature header.
+export function formatRaw(envelope: WebhookEnvelope): { body: string } {
+  return { body: JSON.stringify(envelope) };
+}

--- a/src/webhooks/formats/slack.ts
+++ b/src/webhooks/formats/slack.ts
@@ -1,0 +1,7 @@
+import { renderMessage, type WebhookEnvelope } from "./index.js";
+
+// Slack incoming webhook: `{text: "..."}` renders as a plain chat message
+// with URLs auto-linked. No signature header — Slack doesn't verify one.
+export function formatSlack(envelope: WebhookEnvelope): { body: string } {
+  return { body: JSON.stringify({ text: renderMessage(envelope) }) };
+}

--- a/test/dashboard-routes.test.ts
+++ b/test/dashboard-routes.test.ts
@@ -74,6 +74,7 @@ function createMockDB(data: {
     user_id: string;
     url: string;
     secret: string;
+    format?: "raw" | "slack" | "google_chat";
   }>;
   apiKeys?: Array<{
     id: string;
@@ -120,9 +121,11 @@ function createMockDB(data: {
           (d) => d.user_id === bindings[0] && d.domain === bindings[1],
         ) ?? null) as T | null;
       }
-      if (sql.includes("SELECT url FROM webhooks WHERE user_id")) {
+      if (sql.includes("SELECT url, format FROM webhooks WHERE user_id")) {
         const wh = webhooks.find((w) => w.user_id === bindings[0]);
-        return (wh ? { url: wh.url } : null) as T | null;
+        return (
+          wh ? { url: wh.url, format: wh.format ?? "raw" } : null
+        ) as T | null;
       }
       if (sql.includes("SELECT id FROM webhooks WHERE user_id")) {
         const wh = webhooks.find((w) => w.user_id === bindings[0]);
@@ -1075,7 +1078,61 @@ describe("dashboard/routes", () => {
     });
 
     it("redirects to /dashboard/settings after saving webhook", async () => {
-      const db = createMockDB({ webhooks: [] });
+      const writes: Array<{ sql: string; bindings: unknown[] }> = [];
+      const db = createMockDB({ webhooks: [], writes });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const body = new URLSearchParams({
+        webhookUrl: "https://example.com/hook",
+        format: "slack",
+      });
+      const res = await app.request("/dashboard/settings/webhook", {
+        method: "POST",
+        headers: {
+          Cookie: cookie,
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: body.toString(),
+      });
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/dashboard/settings");
+
+      const insert = writes.find((w) => /^INSERT INTO webhooks/i.test(w.sql));
+      expect(insert).toBeDefined();
+      // (user_id, url, secret, format) — format lands in position 4.
+      expect(insert?.bindings[3]).toBe("slack");
+    });
+
+    it("rejects an unknown format with a no-save redirect", async () => {
+      const writes: Array<{ sql: string; bindings: unknown[] }> = [];
+      const db = createMockDB({ webhooks: [], writes });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const body = new URLSearchParams({
+        webhookUrl: "https://example.com/hook",
+        format: "borked",
+      });
+      const res = await app.request("/dashboard/settings/webhook", {
+        method: "POST",
+        headers: {
+          Cookie: cookie,
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: body.toString(),
+      });
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/dashboard/settings");
+      expect(
+        writes.find((w) => /INSERT INTO webhooks/i.test(w.sql)),
+      ).toBeUndefined();
+      expect(
+        writes.find((w) => /UPDATE webhooks/i.test(w.sql)),
+      ).toBeUndefined();
+    });
+
+    it("defaults missing format to raw", async () => {
+      const writes: Array<{ sql: string; bindings: unknown[] }> = [];
+      const db = createMockDB({ webhooks: [], writes });
       const app = createTestApp(db);
       const cookie = await makeSessionCookie("user_1", "alice@example.com");
       const body = new URLSearchParams({
@@ -1090,7 +1147,8 @@ describe("dashboard/routes", () => {
         body: body.toString(),
       });
       expect(res.status).toBe(302);
-      expect(res.headers.get("Location")).toBe("/dashboard/settings");
+      const insert = writes.find((w) => /^INSERT INTO webhooks/i.test(w.sql));
+      expect(insert?.bindings[3]).toBe("raw");
     });
   });
 

--- a/test/dashboard-views.test.ts
+++ b/test/dashboard-views.test.ts
@@ -222,6 +222,26 @@ describe("renderSettingsPage", () => {
     expect(html).toContain("Webhook");
   });
 
+  it("renders a format <select> with all three options, raw selected by default", () => {
+    const html = renderSettingsPage(defaults);
+    expect(html).toContain('name="format"');
+    expect(html).toContain('value="raw"');
+    expect(html).toContain('value="slack"');
+    expect(html).toContain('value="google_chat"');
+    // Default value is "raw", which the template pre-selects.
+    expect(html).toMatch(/value="raw" selected/);
+  });
+
+  it("pre-selects slack when webhookFormat is slack", () => {
+    const html = renderSettingsPage({
+      ...defaults,
+      webhookUrl: "https://hooks.slack.com/services/T/B/X",
+      webhookFormat: "slack",
+    });
+    expect(html).toMatch(/value="slack" selected/);
+    expect(html).not.toMatch(/value="raw" selected/);
+  });
+
   it("renders the Pro badge and Manage Billing link for pro users", () => {
     const html = renderSettingsPage({ ...defaults, plan: "pro" });
     expect(html).toContain("Manage Billing");

--- a/test/webhooks-dispatcher.test.ts
+++ b/test/webhooks-dispatcher.test.ts
@@ -7,6 +7,7 @@ interface FakeWebhookRow {
   user_id: string;
   url: string;
   secret: string | null;
+  format: "raw" | "slack" | "google_chat";
   created_at: number;
 }
 
@@ -108,6 +109,7 @@ describe("webhooks/dispatcher.dispatchWebhook", () => {
       user_id: "u1",
       url: "https://hook.example/receive",
       secret: "shhh",
+      format: "raw",
       created_at: 0,
     });
     const fetchSpy = vi
@@ -164,6 +166,7 @@ describe("webhooks/dispatcher.dispatchWebhook", () => {
       user_id: "u1",
       url: "https://hook.example/receive",
       secret: "shhh",
+      format: "raw",
       created_at: 0,
     });
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
@@ -189,6 +192,7 @@ describe("webhooks/dispatcher.dispatchWebhook", () => {
       user_id: "u1",
       url: "https://hook.example/receive",
       secret: "shhh",
+      format: "raw",
       created_at: 0,
     });
     vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
@@ -214,6 +218,7 @@ describe("webhooks/dispatcher.dispatchWebhook", () => {
       user_id: "u1",
       url: "https://hook.example/receive",
       secret: null,
+      format: "raw",
       created_at: 0,
     });
     const fetchSpy = vi.spyOn(globalThis, "fetch");
@@ -230,5 +235,89 @@ describe("webhooks/dispatcher.dispatchWebhook", () => {
     expect(deliveries).toHaveLength(1);
     expect(deliveries[0].ok).toBe(0);
     expect(deliveries[0].status_code).toBeNull();
+  });
+
+  it("POSTs a Slack-shaped body with no signature header when format is slack", async () => {
+    webhooksByUser.set("u1", {
+      id: 21,
+      user_id: "u1",
+      url: "https://hooks.slack.com/services/T/B/X",
+      secret: "ignored-for-chat-formats",
+      format: "slack",
+      created_at: 0,
+    });
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("ok", { status: 200 }));
+    const db = makeDb();
+
+    const result = await dispatchWebhook(
+      db,
+      "u1",
+      { type: "webhook.test", data: { message: "Hello from dmarcheck" } },
+      { now: 1_700_000_000 },
+    );
+
+    expect(result?.ok).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [calledUrl, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(calledUrl).toBe("https://hooks.slack.com/services/T/B/X");
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Content-Type"]).toBe("application/json");
+    expect(headers["Dmarcheck-Signature"]).toBeUndefined();
+
+    const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+    expect(Object.keys(body)).toEqual(["text"]);
+    expect(body.text).toBe("dmarcheck webhook test — Hello from dmarcheck");
+
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0].ok).toBe(1);
+    expect(deliveries[0].webhook_id).toBe(21);
+  });
+
+  it("POSTs a Google Chat-shaped body with no signature header when format is google_chat", async () => {
+    webhooksByUser.set("u1", {
+      id: 22,
+      user_id: "u1",
+      url: "https://chat.googleapis.com/v1/spaces/ABC/messages?key=x&token=y",
+      secret: null,
+      format: "google_chat",
+      created_at: 0,
+    });
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}", { status: 200 }));
+    const db = makeDb();
+
+    const result = await dispatchWebhook(
+      db,
+      "u1",
+      {
+        type: "scan.completed",
+        data: {
+          domain: "example.com",
+          grade: "A",
+          scan_id: "scn_1",
+          trigger: "cron",
+          report_url: "https://dmarc.mx/check?domain=example.com",
+        },
+      },
+      { now: 1_700_000_000 },
+    );
+
+    expect(result?.ok).toBe(true);
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Dmarcheck-Signature"]).toBeUndefined();
+
+    const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+    expect(Object.keys(body)).toEqual(["text"]);
+    expect(body.text).toBe(
+      "DMARC scan complete: example.com → A — https://dmarc.mx/check?domain=example.com",
+    );
+
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0].ok).toBe(1);
+    expect(deliveries[0].event_type).toBe("scan.completed");
   });
 });


### PR DESCRIPTION
## Summary

- Adds a `format` column to `webhooks` (migration `0007_webhook_format.sql`, additive, default `'raw'`) with three v1 options: `raw`, `slack`, `google_chat`.
- `raw` remains byte-identical to the signed-envelope shape from [#175](https://github.com/schmug/dmarcheck/pull/175) — the existing null-secret guard stays scoped to this path only.
- `slack` and `google_chat` transform the envelope to `{text: "..."}` and omit the `Dmarcheck-Signature` header (those platforms don't verify it).
- Settings page gains a `<select name=\"format\">` under the URL input; POST handler validates against the enum and rejects unknown values with a no-save redirect (matches existing URL-validation behavior).
- Discord / Teams / Block Kit / cardsV2 are intentionally out of scope until someone asks. The adapter registry makes them a one-file addition.

## Decision: dropdown only, no URL-host auto-detection

Auto-defaulting `format` from the URL host (`hooks.slack.com` → `slack`, `chat.googleapis.com` → `google_chat`) was considered and rejected. It's hidden behavior that surprises anyone routing through a proxy, a `webhook.site` replay URL, or an internal collector. An explicit dropdown is one extra click and makes the choice auditable in the UI.

## Live verification — webhook.site receiver

Fired one `scan.completed` event per format at `https://webhook.site/f603474b-b852-4e93-b254-f31d7c0f0e71`. Dispatcher returned `{ok: true, status: 200}` for all three; webhook.site logs the following requests:

**raw**
\`\`\`json
{
  \"body\": \"{\\\"id\\\":\\\"evt_...\\\",\\\"type\\\":\\\"scan.completed\\\",\\\"created\\\":1777044553,\\\"data\\\":{\\\"domain\\\":\\\"dmarc.mx\\\",\\\"grade\\\":\\\"S\\\",\\\"scan_id\\\":\\\"scn_live\\\",\\\"trigger\\\":\\\"dashboard\\\",\\\"report_url\\\":\\\"https://dmarc.mx/check?domain=dmarc.mx\\\"}}\",
  \"Dmarcheck-Signature\": \"t=1777044553,v1=9d4b5e4e009df805e65a943ea042eb2533a532fbd9ea8ead37e8dcd36c418bc9\",
  \"Content-Type\": \"application/json\"
}
\`\`\`

**slack / google_chat** (identical wire shape today, kept as two adapters so future divergence is trivial)
\`\`\`json
{
  \"body\": \"{\\\"text\\\":\\\"DMARC scan complete: dmarc.mx → S — https://dmarc.mx/check?domain=dmarc.mx\\\"}\",
  \"Dmarcheck-Signature\": null,
  \"Content-Type\": \"application/json\"
}
\`\`\`

## Settings UI

No screenshot file in the PR body — preview was rendered locally (no auth bypass in dev, so the page was mounted via a one-off tsx script feeding `renderSettingsPage`). Accessibility-tree excerpt from the rendered page, with `webhookFormat: \"slack\"` pre-selected:

\`\`\`
[83] LabelText — Format
[86] combobox: \"Format\" (value: \"Slack incoming webhook\")
  [88] option: \"Raw (signed JSON envelope)\"
  [89] option: \"Slack incoming webhook\"  (selected)
  [90] option: \"Google Chat incoming webhook\"
[91] paragraph — \"Raw posts the signed envelope for your own receiver.
      Slack and Google Chat send a chat message and omit the signature
      header (those platforms don't verify it).\"
\`\`\`

Default (no stored format) pre-selects `raw`. Happy to drop a PNG in if you want one — flag me.

## Notes

- `request_body_sha256` in the delivery log now hashes the on-wire body, so for chat formats it's the SHA of `{text:...}` rather than the envelope. Grepped — only writers, no consumers/replay logic, so no regression.
- Type dependency points formats → db consumers (`WebhookFormat` lives in `src/webhooks/formats/index.ts`, imported by `src/db/webhooks.ts`), keeping the DB layer free of a format-module dependency.

## Test plan

- [x] `npm run lint && npm run typecheck && npm test` — all 698 tests green
- [x] New dispatcher tests: one happy-path per chat format, asserting body shape + absence of `Dmarcheck-Signature`
- [x] New route test: POST with `format=slack` persists the column; POST with `format=borked` no-save redirects; missing `format` defaults to `raw`
- [x] New view test: `<select name=\"format\">` with three options + correct `selected` state
- [x] Live webhook.site dispatch for all three formats (captured above)
- [ ] **Reviewer:** verify the receiver inspection at the webhook.site URL above renders as expected before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)