### PR TITLE
🎨 Palette: Add explicit ARIA labels to repetitive action buttons

### DIFF
--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -615,7 +615,7 @@ export function renderAlertsSection(
   <span class="alert-message">${esc(describeAlert(a))}</span>
   <span class="alert-time">${esc(relativeTime(a.createdAt, now))}</span>
   <form method="post" action="${ackHref}">
-    <button type="submit" class="btn-dismiss">Dismiss</button>
+    <button type="submit" class="btn-dismiss" aria-label="Dismiss alert for ${esc(a.domain)}">Dismiss</button>
   </form>
 </li>`;
     })
@@ -732,7 +732,7 @@ export function renderDomainDetailPage({
   </form>
   <a href="/check?domain=${encodeURIComponent(domain)}" class="btn btn-secondary">View Full Report</a>
   <form method="POST" action="/dashboard/domain/${encodeURIComponent(domain)}/delete" style="display:inline" onsubmit="return confirm('Stop monitoring ${esc(domain)}?');">
-    <button type="submit" class="btn btn-secondary">Delete</button>
+    <button type="submit" class="btn btn-secondary" aria-label="Delete domain ${esc(domain)}">Delete</button>
   </form>
 </div>
 <div class="section-card">
@@ -1312,11 +1312,12 @@ export function renderApiKeysPage({
         const lastUsed = k.lastUsedAt
           ? esc(k.lastUsedAt)
           : '<span style="color:var(--clr-text-muted)">Never</span>';
+        const labelName = k.name ? esc(k.name) : "unnamed";
         const actions = k.revoked
           ? ""
           : `<form method="POST" action="/dashboard/settings/api-keys/revoke" style="display:inline" onsubmit="return confirm('Revoke this key? Requests using it will start failing.');">
               <input type="hidden" name="id" value="${esc(k.id)}">
-              <button type="submit" class="btn btn-secondary" style="padding:0.25rem 0.6rem;font-size:0.8125rem">Revoke</button>
+              <button type="submit" class="btn btn-secondary" style="padding:0.25rem 0.6rem;font-size:0.8125rem" aria-label="Revoke API key ${labelName}">Revoke</button>
             </form>`;
         return `<tr>
   <td>${name}</td>


### PR DESCRIPTION
💡 **What**: Added contextual `aria-label`s to the "Dismiss" (alerts), "Delete" (domains), and "Revoke" (API keys) buttons in the dashboard.
🎯 **Why**: Sighted users rely on visual row placement (e.g. "Delete" button inside the "example.com" row) to understand what action these buttons perform. For screen reader users tabbing through elements, a series of identical "Delete" or "Revoke" announcements lacks context, making it hard to know which item is being deleted.
📸 **Before/After**: Visually invisible. Functionally accessible. 
♿ **Accessibility**: Provides robust context for non-visual users interacting with lists and tables.

---
*PR created automatically by Jules for task [15629779694090168840](https://jules.google.com/task/15629779694090168840) started by @schmug*