### PR TITLE
fix(dashboard): use single-character ESCAPE in domain search LIKE

### DIFF
--- a/src/db/domains.ts
+++ b/src/db/domains.ts
@@ -84,7 +84,11 @@ function buildFilter(opts: ListDomainsOptions): {
   const bindings: unknown[] = [opts.userId];
   const search = opts.search?.trim();
   if (search) {
-    clauses.push("LOWER(domain) LIKE ? ESCAPE '\\\\'");
+    // SQLite's ESCAPE clause must be exactly one character. The JS source
+    // here produces a SQL string containing a single backslash; double
+    // backslashes blow up at runtime as `ESCAPE expression must be a single
+    // character`.
+    clauses.push("LOWER(domain) LIKE ? ESCAPE '\\'");
     bindings.push(`%${escapeLike(search.toLowerCase())}%`);
   }
   if (opts.grade) {

--- a/test/db-domains.test.ts
+++ b/test/db-domains.test.ts
@@ -289,6 +289,15 @@ function makePagedMock(seed: Domain[]): D1Database {
     let cursor = 0;
     const userId = params[cursor++] as string;
     let rows = data.filter((d) => d.user_id === userId);
+    // Mirror SQLite's runtime check: ESCAPE expression must be a single
+    // character. Catches the JS-string-literal trap where '\\\\' compiles to
+    // two backslashes in the actual SQL and D1 rejects the whole query.
+    const escapeMatch = sql.match(/ESCAPE '([^']*)'/);
+    if (escapeMatch && escapeMatch[1].length !== 1) {
+      throw new Error(
+        `D1_ERROR: ESCAPE expression must be a single character: SQLITE_ERROR (got ${JSON.stringify(escapeMatch[1])})`,
+      );
+    }
     if (/LOWER\(domain\) LIKE \?/i.test(sql)) {
       const like = params[cursor++] as string;
       const inner = like.slice(1, -1).replace(/\\([\\%_])/g, "$1");


### PR DESCRIPTION
## Summary

Hotfix for the `D1_ERROR: ESCAPE expression must be a single character: SQLITE_ERROR` blowing up the Pro domain list whenever the search filter is exercised. Introduced in [#178](https://github.com/schmug/dmarcheck/pull/178).

Not a missing migration — no schema changed.

## Root cause

The JS source had:

```ts
clauses.push("LOWER(domain) LIKE ? ESCAPE '\\\\'");
```

In a JS string literal, `\\\\` is two backslash characters. SQLite's `ESCAPE` clause requires **exactly one** character, so D1 rejects the whole prepared statement and the dashboard 500s.

The fix is the one-character form. Source `'\\'`, actual SQL `'\'`:

```ts
clauses.push("LOWER(domain) LIKE ? ESCAPE '\\'");
```

The `escapeLike()` helper that prepends `\\` to user-supplied `%` / `_` / `\\` is unchanged — it was already producing backslash-escaped wildcards in the bound parameter, which is what SQLite expects.

## Why CI didn't catch it

The `db-domains` mock matched `LIKE ?` but ignored the `ESCAPE '...'` clause entirely, so the malformed SQL flowed through tests cleanly. Strengthened the mock to mirror SQLite's runtime check — a revert of the fix now reproduces the production error from the test suite:

```
Error: D1_ERROR: ESCAPE expression must be a single character: SQLITE_ERROR (got "\\\\")
```

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` — 45 files / 718 tests
- [x] Confirmed the strengthened mock catches the bug: temporarily reverting the source fix makes the existing search tests fail with the exact production error message
- [ ] Manual verification on `/dashboard` with `?q=...` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)