### PR TITLE
feat(dashboard): live search/filter/sort on Pro domains list

### DIFF
--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -45,6 +45,7 @@ import {
   renderDashboardPage,
   renderDomainDetailPage,
   renderDomainHistoryPage,
+  renderDomainPanel,
   renderSettingsPage,
   toApiKeyListEntry,
 } from "../views/dashboard.js";
@@ -236,6 +237,66 @@ dashboardRoutes.get("/", async (c) => {
 // Dismiss a regression alert. IDOR-safe via SQL: acknowledgeAlert only updates
 // rows whose domain belongs to the session user. Returns 404 (not 500, not 303)
 // for invalid / cross-user / already-acked ids so the caller can distinguish.
+// Live-search fragment endpoint for the Pro domain list. Returns only the
+// `#domain-panel` markup (toolbar + table + pagination) so the client can
+// swap it in place when the user types or changes a filter — no full page
+// reload, no flicker, no focus loss. Free users get 404 because their
+// dashboard skips the search UI entirely; the full page already does the
+// right thing for them.
+dashboardRoutes.get("/domains", async (c) => {
+  const session = c.get("user" as never) as SessionPayload;
+  const db = (c.env as { DB: D1Database }).DB;
+  const plan = await getPlanForUser(db, session.sub);
+  if (plan !== "pro") return c.notFound();
+
+  const query = parseDomainListQuery(new URL(c.req.url));
+  const offset = (query.page - 1) * query.pageSize;
+  const [page, unackCounts] = await Promise.all([
+    listDomainsForUserPaged(db, {
+      userId: session.sub,
+      search: query.search || undefined,
+      grade: query.grade ?? undefined,
+      frequency: query.frequency ?? undefined,
+      sort: query.sort,
+      direction: query.direction,
+      limit: query.pageSize,
+      offset,
+    }),
+    countUnacknowledgedByDomain(db, session.sub),
+  ]);
+
+  const totalPages = Math.max(1, Math.ceil(page.total / query.pageSize));
+  const currentPage = Math.min(query.page, totalPages);
+
+  const html = renderDomainPanel({
+    domains: page.rows.map((d) => ({
+      domain: d.domain,
+      grade: d.last_grade ?? "—",
+      frequency: d.scan_frequency,
+      lastScanned: d.last_scanned_at
+        ? new Date(d.last_scanned_at * 1000).toLocaleDateString()
+        : null,
+      isFree: d.is_free === 1,
+      unacknowledgedAlerts: unackCounts.get(d.id) ?? 0,
+    })),
+    controls: {
+      search: query.search,
+      grade: query.grade,
+      frequency: query.frequency,
+      sort: query.sort,
+      direction: query.direction,
+      page: currentPage,
+      pageSize: query.pageSize,
+      totalPages,
+      total: page.total,
+    },
+  });
+
+  // no-store keeps a CDN from caching one user's domain list and serving it
+  // to another. The route is auth-required, but belt-and-suspenders.
+  return c.html(html, 200, { "Cache-Control": "no-store" });
+});
+
 dashboardRoutes.post("/alerts/:id/acknowledge", async (c) => {
   const session = c.get("user" as never) as SessionPayload;
   const db = (c.env as { DB: D1Database }).DB;

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -900,18 +900,17 @@ function renderPagination(controls: DashboardControls): string {
 </nav>`;
 }
 
-export function renderDashboardPage({
-  email,
-  alerts = [],
+// Renders just the toolbar + table + pagination, wrapped in a stable
+// `#domain-panel` element so the live-search client script can swap it in
+// place via /dashboard/domains. Used both inline by renderDashboardPage and
+// directly by the fragment route — keep the wrapper markup identical between
+// the two so the swap is a clean replace.
+export function renderDomainPanel({
   domains,
-  controls = null,
+  controls,
 }: {
-  email: string;
-  alerts?: DashboardAlert[];
   domains: DashboardDomain[];
-  // Set only for Pro accounts; gates the search/sort/pagination UI.
-  plan?: "free" | "pro";
-  controls?: DashboardControls | null;
+  controls: DashboardControls | null;
 }): string {
   const isFiltered =
     controls !== null &&
@@ -979,13 +978,34 @@ export function renderDashboardPage({
   const toolbar = controls ? renderDomainToolbar(controls) : "";
   const pagination = controls ? renderPagination(controls) : "";
 
+  // data-pro="1" is the signal the client script uses to enable live
+  // search/swap. Free users render the same wrapper so a future plan upgrade
+  // doesn't need a markup migration, but the script bails out early.
+  return `<div id="domain-panel" data-pro="${controls ? "1" : "0"}">
+${toolbar}
+${tableBody}
+${pagination}
+</div>`;
+}
+
+export function renderDashboardPage({
+  email,
+  alerts = [],
+  domains,
+  controls = null,
+}: {
+  email: string;
+  alerts?: DashboardAlert[];
+  domains: DashboardDomain[];
+  // Set only for Pro accounts; gates the search/sort/pagination UI.
+  plan?: "free" | "pro";
+  controls?: DashboardControls | null;
+}): string {
   return dashboardPage(
     "Domains — dmarc.mx",
     `<h1 class="dashboard-title">Your Domains</h1>
 ${renderAlertsSection(alerts)}
-${toolbar}
-${tableBody}
-${pagination}`,
+${renderDomainPanel({ domains, controls })}`,
     email,
   );
 }

--- a/src/views/scripts.ts
+++ b/src/views/scripts.ts
@@ -656,4 +656,142 @@ if (typeof navigator !== 'undefined' && navigator.modelContext && typeof navigat
     });
   } catch (e) { /* ignore */ }
 }
+
+/* Pro dashboard live search/filter/sort. Looks for #domain-panel[data-pro="1"]
+   and progressively enhances the toolbar form: typing in the search box,
+   changing a filter, clicking a sort header, or paginating swaps the panel
+   via /dashboard/domains instead of doing a full page reload. The form still
+   submits as a normal GET if JS fails or is disabled, so the Apply button
+   stays in the markup — we just hide it once the script boots. */
+(function() {
+  var initial = document.getElementById('domain-panel');
+  if (!initial || initial.getAttribute('data-pro') !== '1') return;
+
+  function getPanel() { return document.getElementById('domain-panel'); }
+  function getForm() {
+    var p = getPanel();
+    return p ? p.querySelector('form.domain-toolbar') : null;
+  }
+  function hideApplyButton() {
+    var form = getForm();
+    if (!form) return;
+    var btn = form.querySelector('.toolbar-actions button[type="submit"]');
+    if (btn) btn.style.display = 'none';
+  }
+  hideApplyButton();
+
+  var inflight = null;
+  var searchTimer = null;
+
+  function paramsFromForm() {
+    var form = getForm();
+    var p = new URLSearchParams();
+    if (!form) return p;
+    var fd = new FormData(form);
+    fd.forEach(function(value, key) {
+      var s = String(value);
+      if (s !== '') p.set(key, s);
+    });
+    return p;
+  }
+
+  function paramsFromHref(href) {
+    try { return new URL(href, location.origin).searchParams; }
+    catch (e) { return new URLSearchParams(); }
+  }
+
+  function loadFragment(params) {
+    if (inflight) inflight.abort();
+    var ctrl = (typeof AbortController !== 'undefined') ? new AbortController() : null;
+    inflight = ctrl;
+    var qs = params.toString();
+    var panelEl = getPanel();
+    if (panelEl) panelEl.setAttribute('aria-busy', 'true');
+    var fragmentUrl = '/dashboard/domains' + (qs ? '?' + qs : '');
+    var opts = { credentials: 'same-origin', headers: { 'Accept': 'text/html' } };
+    if (ctrl) opts.signal = ctrl.signal;
+    fetch(fragmentUrl, opts)
+      .then(function(res) {
+        if (!res.ok) throw new Error('http ' + res.status);
+        return res.text();
+      })
+      .then(function(html) {
+        var current = getPanel();
+        if (!current) return;
+        /* DOMParser parses without executing scripts and without touching the
+           live document; safer than innerHTML on a detached node. The fragment
+           is same-origin authenticated HTML and domains go through esc() on
+           the server, but parse-don't-execute is the right default. */
+        var doc = new DOMParser().parseFromString(html, 'text/html');
+        var fresh = doc.getElementById('domain-panel');
+        if (!fresh) return;
+        var imported = document.importNode(fresh, true);
+        /* Preserve cursor + focus on the search input across the swap so
+           rapid typing doesn't flicker or strand the caret. */
+        var prev = current.querySelector('input[name="q"]');
+        var refocus = document.activeElement === prev;
+        var selStart = prev ? prev.selectionStart : null;
+        var selEnd = prev ? prev.selectionEnd : null;
+        current.replaceWith(imported);
+        hideApplyButton();
+        if (refocus) {
+          var next = imported.querySelector('input[name="q"]');
+          if (next) {
+            next.focus();
+            try {
+              if (selStart !== null && selEnd !== null) {
+                next.setSelectionRange(selStart, selEnd);
+              }
+            } catch (e) { /* readonly inputs etc. */ }
+          }
+        }
+        var dashUrl = '/dashboard' + (qs ? '?' + qs : '');
+        history.replaceState(null, '', dashUrl);
+      })
+      .catch(function() { /* aborted or network error — leave panel as-is */ })
+      .finally(function() {
+        if (inflight === ctrl) inflight = null;
+        var p = getPanel();
+        if (p) p.removeAttribute('aria-busy');
+      });
+  }
+
+  document.addEventListener('input', function(e) {
+    if (!e.target || !e.target.matches) return;
+    if (!e.target.matches('form.domain-toolbar input[name="q"]')) return;
+    if (searchTimer) clearTimeout(searchTimer);
+    searchTimer = setTimeout(function() {
+      var p = paramsFromForm();
+      p.delete('page');
+      loadFragment(p);
+    }, 250);
+  });
+
+  document.addEventListener('change', function(e) {
+    if (!e.target || !e.target.matches) return;
+    if (!e.target.matches('form.domain-toolbar select')) return;
+    var p = paramsFromForm();
+    p.delete('page');
+    loadFragment(p);
+  });
+
+  document.addEventListener('submit', function(e) {
+    if (!e.target || !e.target.matches || !e.target.matches('form.domain-toolbar')) return;
+    e.preventDefault();
+    if (searchTimer) { clearTimeout(searchTimer); searchTimer = null; }
+    loadFragment(paramsFromForm());
+  });
+
+  document.addEventListener('click', function(e) {
+    if (!e.target || !e.target.closest) return;
+    /* Skip modified clicks so cmd/ctrl-click still opens new tabs. */
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+    var link = e.target.closest('#domain-panel a.sort-link, #domain-panel .domain-pagination a');
+    if (!link) return;
+    var href = link.getAttribute('href');
+    if (!href || href.charAt(0) !== '/') return;
+    e.preventDefault();
+    loadFragment(paramsFromHref(href));
+  });
+})();
 `;

--- a/test/dashboard-routes.test.ts
+++ b/test/dashboard-routes.test.ts
@@ -573,6 +573,134 @@ describe("dashboard/routes", () => {
     });
   });
 
+  describe("GET /dashboard/domains (live-search fragment)", () => {
+    it("redirects to /auth/login without a session cookie", async () => {
+      const db = createMockDB({});
+      const app = createTestApp(db);
+      const res = await app.request("/dashboard/domains");
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/auth/login");
+    });
+
+    it("returns 404 for free-plan users (Pro-only endpoint)", async () => {
+      const db = createMockDB({
+        domains: [
+          {
+            id: 1,
+            user_id: "user_1",
+            domain: "example.com",
+            is_free: 1,
+            scan_frequency: "monthly",
+            last_scanned_at: null,
+            last_grade: null,
+            created_at: 1700000000,
+          },
+        ],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/domains", {
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("returns the panel fragment (no <html> shell) for Pro users", async () => {
+      const db = createMockDB({
+        users: [
+          {
+            id: "user_pro",
+            email: "pro@example.com",
+            email_domain: "example.com",
+            stripe_customer_id: "cus_x",
+            email_alerts_enabled: 1,
+            api_key_retirement_acknowledged_at: 1700000000,
+            created_at: 1700000000,
+          },
+        ],
+        subscriptions: [{ user_id: "user_pro", status: "active" }],
+        domains: [
+          {
+            id: 1,
+            user_id: "user_pro",
+            domain: "alpha.example.com",
+            is_free: 0,
+            scan_frequency: "weekly",
+            last_scanned_at: null,
+            last_grade: "A",
+            created_at: 1700000000,
+          },
+        ],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_pro", "pro@example.com");
+      const res = await app.request("/dashboard/domains", {
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Cache-Control")).toBe("no-store");
+      const body = await res.text();
+      // Fragment, not a full page.
+      expect(body).not.toContain("<!DOCTYPE");
+      expect(body).not.toContain("<html");
+      expect(body).not.toContain("dashboard-nav");
+      // But it does include the live-search-aware wrapper + toolbar + table.
+      expect(body).toContain('id="domain-panel"');
+      expect(body).toContain('data-pro="1"');
+      expect(body).toContain('<form class="domain-toolbar"');
+      expect(body).toContain("alpha.example.com");
+    });
+
+    it("honors the q filter so the fragment matches the full-page result", async () => {
+      const db = createMockDB({
+        users: [
+          {
+            id: "user_pro",
+            email: "pro@example.com",
+            email_domain: "example.com",
+            stripe_customer_id: "cus_x",
+            email_alerts_enabled: 1,
+            api_key_retirement_acknowledged_at: 1700000000,
+            created_at: 1700000000,
+          },
+        ],
+        subscriptions: [{ user_id: "user_pro", status: "active" }],
+        domains: [
+          {
+            id: 1,
+            user_id: "user_pro",
+            domain: "alpha.example.com",
+            is_free: 0,
+            scan_frequency: "weekly",
+            last_scanned_at: null,
+            last_grade: "A",
+            created_at: 1700000000,
+          },
+          {
+            id: 2,
+            user_id: "user_pro",
+            domain: "beta.io",
+            is_free: 0,
+            scan_frequency: "weekly",
+            last_scanned_at: null,
+            last_grade: "B",
+            created_at: 1700000001,
+          },
+        ],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_pro", "pro@example.com");
+      const res = await app.request("/dashboard/domains?q=alpha", {
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body).toContain("alpha.example.com");
+      expect(body).not.toContain("beta.io");
+      expect(body).toContain("Showing 1–1 of 1");
+    });
+  });
+
   describe("GET /dashboard/domain/:domain", () => {
     it("redirects to /auth/login without a session cookie", async () => {
       const db = createMockDB({});


### PR DESCRIPTION
## Summary

Replaces the Apply-button round-trip on the Pro domain list with a debounced fragment swap. Typing, changing a filter, clicking a sort header, or paginating now updates the table in place without a full page reload.

## What changed

- **`renderDomainPanel`** extracted from `renderDashboardPage` so the toolbar + table + pagination render standalone, wrapped in a stable `#domain-panel` element. Same markup either way, so the swap is a clean replace.
- **`GET /dashboard/domains`** new fragment endpoint. Pro-only (404s free), `Cache-Control: no-store`. Reuses the exact query parsing + DB call as the full page, so `/dashboard?q=…&sort=…&page=…` deep-links keep working identically.
- **Client script** (`src/views/scripts.ts`): progressive-enhancement IIFE that bails on any page without `#domain-panel[data-pro="1"]`. 250 ms debounce on search input; `AbortController` cancels in-flight fetches when a new keystroke comes in; `DOMParser` + `replaceWith` for the swap; `history.replaceState` keeps the URL bar in sync; focus + caret on the search input survive the swap. Modified clicks (cmd/ctrl/shift/alt, middle-click) skipped so "open in new tab" still works.
- The form still submits as a normal GET if JS is off or fails — the Apply button stays in the markup and is hidden via JS once the script boots.
- 4 new test cases in `test/dashboard-routes.test.ts` covering auth redirect, free-plan 404, fragment-only HTML response with `Cache-Control: no-store`, and `q=` filter parity with the full page.

## Why

Hitting Apply on every change was a tax on the most common dashboard interaction. A live UI is the standard expectation for this kind of list; doing it as a fragment swap (rather than just auto-submitting the form) keeps focus, avoids flicker, and doesn't burn a cache slot per keystroke.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm test` — 722 tests pass, including 4 new fragment-route cases
- [x] Browser smoke: script's early-return guard verified on landing (no console errors, no listeners registered when no panel)
- [x] Browser end-to-end against synthetic markup matching `renderDomainPanel`'s output: Apply button hidden on boot; typing → debounce → fragment fetch → swap; sort click → fragment fetch → swap; pagination click → fragment fetch → swap; URL bar updated via `history.replaceState`; search input keeps focus + caret across swap; rapid typing aborts in-flight requests via `AbortController`
- [ ] Live verification on the actual auth-gated dashboard requires WorkOS login (can't reach from local) — to confirm post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)