### PR TITLE
feat(agent-discovery): publish Agent Skills index at /.well-known/agent-skills/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,11 +40,14 @@ Live at dmarc.mx | Repo: github.com/schmug/dmarcheck
 ## Agent discovery
 
 - `/.well-known/api-catalog` — RFC 9727 linkset (`application/linkset+json`) pointing to OpenAPI + docs + health
+- `/.well-known/agent-skills/index.json` — Cloudflare Agent Skills Discovery RFC v0.2.0 index. Lists `scan_domain` in two formats (markdown SKILL.md + OpenAPI) with sha256 digests computed lazily over the served bytes
+- `/.well-known/agent-skills/scan-domain/SKILL.md` — prose description of the `scan_domain` skill, served as `text/markdown`
 - `/openapi.json` — OpenAPI 3.1 service description (`application/openapi+json`)
 - `/docs/api` — Human-readable API reference (HTML, or markdown with `Accept: text/markdown`)
-- Every HTML page ships a `Link` header advertising four relations (`api-catalog`, `service-desc`, `service-doc`, `status`)
+- Every HTML page ships a `Link` header advertising five relations (`api-catalog`, `https://agentskills.io/rel/index`, `service-desc`, `service-doc`, `status`)
 - Content negotiation: `Accept: text/markdown` (or `?format=md`) on `/`, `/check`, `/scoring`, `/learn`, `/docs/api` returns a markdown rendering (noindexed)
 - The client JS bundle registers a WebMCP `scan_domain` tool via `navigator.modelContext.provideContext()` when that API is available — silent no-op in browsers without WebMCP
+- **Intentionally not published**: `/.well-known/openid-configuration`, `/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource`, `/.well-known/mcp/server-card.json`. We are not an OAuth/OIDC issuer (WorkOS AuthKit is — we're the relying party), our protected APIs use dmarcheck-minted bearer API keys (not OAuth-issued tokens, so RFC 9728 doesn't fit), and we don't yet run a remote MCP server. Tracked: [#181](https://github.com/schmug/dmarcheck/issues/181) for the MCP server.
 
 ## Conventions
 

--- a/src/api/agent-skills.ts
+++ b/src/api/agent-skills.ts
@@ -1,0 +1,138 @@
+// Agent Skills discovery index — Cloudflare RFC v0.2.0.
+// https://github.com/cloudflare/agent-skills-discovery-rfc
+//
+// Lists discoverable skills for AI agents. We expose one skill, `scan_domain`,
+// in two formats: a prose SKILL.md (the format isitagentready.com itself uses)
+// and a pointer at our OpenAPI 3.1 doc for machine-readable detail.
+//
+// The index is built lazily because Web Crypto digests are async and Workers
+// don't allow top-level await. Cached per Worker instance after the first
+// request.
+
+import { CANONICAL_ORIGIN } from "./catalog.js";
+import { OPENAPI_JSON } from "./openapi.js";
+
+export const SCAN_DOMAIN_SKILL_MD = `# scan_domain
+
+Run a DNS-only email security scan on a domain. Returns DMARC, SPF, DKIM,
+BIMI, MTA-STS, and MX analysis with a letter grade and a list of issues.
+
+No authentication required. The endpoint is rate-limited to 10 requests per
+IP per 60 seconds.
+
+## How to call
+
+\`\`\`
+GET https://dmarc.mx/api/check?domain=<domain>[&selectors=<sel1>,<sel2>]
+Accept: application/json
+\`\`\`
+
+- \`domain\` — required. Lowercased; \`[a-z0-9.-]\` only.
+- \`selectors\` — optional. Comma-separated DKIM selectors to probe.
+  Restricted to \`[A-Za-z0-9._-]\`. Defaults to a small built-in list.
+
+## Response shape
+
+JSON. The \`score\` block carries \`grade\` (S/A+/A/B/C/D/F) and \`issues\`.
+Each protocol block reports \`status\` (\`pass\` | \`warn\` | \`fail\` | \`info\`).
+The full schema lives in the OpenAPI document at
+\`https://dmarc.mx/openapi.json\` (component \`ScanResult\`).
+
+## Streaming variant
+
+Use \`GET /api/check/stream?domain=<domain>\` with
+\`Accept: text/event-stream\` to receive per-protocol events as they
+complete instead of waiting for the full scan.
+
+## Bulk variant (Pro)
+
+\`POST /api/bulk-scan\` with a bearer API key scans up to ${"`BULK_TOTAL_CAP`"} domains
+per request. See the OpenAPI doc for the request/response shape.
+
+## Errors
+
+- \`400\` — invalid domain or selectors.
+- \`429\` — rate limit exceeded. Honor \`Retry-After\`.
+- \`5xx\` — transient. Retry with exponential backoff.
+
+## Examples
+
+\`\`\`bash
+curl -H 'Accept: application/json' 'https://dmarc.mx/api/check?domain=dmarc.mx'
+\`\`\`
+
+## Related
+
+- API catalog: \`https://dmarc.mx/.well-known/api-catalog\` (RFC 9727)
+- OpenAPI 3.1: \`https://dmarc.mx/openapi.json\`
+- Human docs: \`https://dmarc.mx/docs/api\`
+`;
+
+const SKILLS_SCHEMA_URL =
+  "https://raw.githubusercontent.com/cloudflare/agent-skills-discovery-rfc/main/schemas/v0.2.0/index.json";
+
+interface SkillEntry {
+  name: string;
+  type: string;
+  description: string;
+  url: string;
+  sha256: string;
+}
+
+interface SkillsIndex {
+  $schema: string;
+  skills: SkillEntry[];
+}
+
+async function sha256Hex(input: string): Promise<string> {
+  const bytes = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+const cache = new Map<string, string>();
+
+export async function getAgentSkillsIndexJson(
+  origin: string = CANONICAL_ORIGIN,
+): Promise<string> {
+  const cached = cache.get(origin);
+  if (cached) return cached;
+
+  const [skillSha, openapiSha] = await Promise.all([
+    sha256Hex(SCAN_DOMAIN_SKILL_MD),
+    sha256Hex(OPENAPI_JSON),
+  ]);
+
+  const index: SkillsIndex = {
+    $schema: SKILLS_SCHEMA_URL,
+    skills: [
+      {
+        name: "scan_domain",
+        type: "markdown",
+        description:
+          "Run a DNS-only DMARC/SPF/DKIM/BIMI/MTA-STS scan and return a graded report.",
+        url: `${origin}/.well-known/agent-skills/scan-domain/SKILL.md`,
+        sha256: skillSha,
+      },
+      {
+        name: "scan_domain",
+        type: "openapi",
+        description:
+          "OpenAPI 3.1 description of the scan API and related endpoints.",
+        url: `${origin}/openapi.json`,
+        sha256: openapiSha,
+      },
+    ],
+  };
+
+  const json = JSON.stringify(index);
+  cache.set(origin, json);
+  return json;
+}
+
+// Test-only escape hatch — clears memoized indexes between cases.
+export function _resetAgentSkillsCache(): void {
+  cache.clear();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,10 @@ import type {
   SpfResult,
 } from "./analyzers/types.js";
 import {
+  getAgentSkillsIndexJson,
+  SCAN_DOMAIN_SKILL_MD,
+} from "./api/agent-skills.js";
+import {
   BULK_IN_BAND_CAP,
   isCapExceeded,
   processBulkScan,
@@ -144,6 +148,7 @@ const NOINDEX_CONTENT_TYPES = [
 // using the API directly.
 const AGENT_DISCOVERY_LINK_HEADER = [
   '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"',
+  '</.well-known/agent-skills/index.json>; rel="https://agentskills.io/rel/index"; type="application/json"',
   '</openapi.json>; rel="service-desc"; type="application/openapi+json"',
   '</docs/api>; rel="service-doc"; type="text/html"',
   '</health>; rel="status"',
@@ -669,6 +674,23 @@ app.get("/health", (c) => {
 app.get("/.well-known/api-catalog", (c) => {
   return c.body(API_CATALOG_JSON, 200, {
     "Content-Type": "application/linkset+json",
+    "Cache-Control": "public, max-age=3600",
+  });
+});
+
+// Agent Skills discovery index — Cloudflare RFC v0.2.0.
+// https://github.com/cloudflare/agent-skills-discovery-rfc
+app.get("/.well-known/agent-skills/index.json", async (c) => {
+  const json = await getAgentSkillsIndexJson();
+  return c.body(json, 200, {
+    "Content-Type": "application/json; charset=utf-8",
+    "Cache-Control": "public, max-age=3600",
+  });
+});
+
+app.get("/.well-known/agent-skills/scan-domain/SKILL.md", (c) => {
+  return c.body(SCAN_DOMAIN_SKILL_MD, 200, {
+    "Content-Type": "text/markdown; charset=utf-8",
     "Cache-Control": "public, max-age=3600",
   });
 });

--- a/test/agent-discovery.test.ts
+++ b/test/agent-discovery.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { _resetAgentSkillsCache } from "../src/api/agent-skills.js";
 import { app } from "../src/index.js";
 import { _memoryStore } from "../src/rate-limit.js";
 
@@ -14,6 +15,7 @@ vi.mock("../src/dns/client.js", () => ({
 
 beforeEach(() => {
   _memoryStore.clear();
+  _resetAgentSkillsCache();
 });
 
 describe("Link response header", () => {
@@ -29,6 +31,7 @@ describe("Link response header", () => {
     expect(link).toContain("</openapi.json>");
     expect(link).toContain("</docs/api>");
     expect(link).toContain("</health>");
+    expect(link).toContain("</.well-known/agent-skills/index.json>");
   });
 
   it("sets Link on scoring, learn, and docs pages too", async () => {
@@ -175,6 +178,97 @@ describe("markdown content negotiation", () => {
       headers: { Accept: "text/markdown" },
     });
     expect(res.headers.get("X-Robots-Tag")).toBe("noindex");
+  });
+});
+
+describe("/.well-known/agent-skills/index.json", () => {
+  it("returns a v0.2.0 skills index with sha256 digests", async () => {
+    const res = await app.request("/.well-known/agent-skills/index.json");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe(
+      "application/json; charset=utf-8",
+    );
+    const body = (await res.json()) as {
+      $schema: string;
+      skills: Array<{
+        name: string;
+        type: string;
+        description: string;
+        url: string;
+        sha256: string;
+      }>;
+    };
+    expect(body.$schema).toContain("agent-skills-discovery-rfc");
+    expect(body.skills.length).toBeGreaterThanOrEqual(2);
+    const types = body.skills.map((s) => s.type);
+    expect(types).toContain("markdown");
+    expect(types).toContain("openapi");
+    for (const skill of body.skills) {
+      expect(skill.name).toBe("scan_domain");
+      expect(skill.url).toMatch(/^https:\/\/dmarc\.mx\//);
+      expect(skill.sha256).toMatch(/^[0-9a-f]{64}$/);
+    }
+  });
+
+  it("digest matches the served SKILL.md byte-for-byte", async () => {
+    const indexRes = await app.request("/.well-known/agent-skills/index.json");
+    const index = (await indexRes.json()) as {
+      skills: Array<{ type: string; url: string; sha256: string }>;
+    };
+    const markdownEntry = index.skills.find((s) => s.type === "markdown");
+    expect(markdownEntry).toBeDefined();
+
+    const skillRes = await app.request(
+      "/.well-known/agent-skills/scan-domain/SKILL.md",
+    );
+    expect(skillRes.headers.get("Content-Type")).toBe(
+      "text/markdown; charset=utf-8",
+    );
+    const text = await skillRes.text();
+    const digest = await crypto.subtle.digest(
+      "SHA-256",
+      new TextEncoder().encode(text),
+    );
+    const hex = Array.from(new Uint8Array(digest))
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+    expect(hex).toBe(markdownEntry?.sha256);
+  });
+
+  it("openapi entry digest matches /openapi.json byte-for-byte", async () => {
+    const indexRes = await app.request("/.well-known/agent-skills/index.json");
+    const index = (await indexRes.json()) as {
+      skills: Array<{ type: string; url: string; sha256: string }>;
+    };
+    const openapiEntry = index.skills.find((s) => s.type === "openapi");
+    expect(openapiEntry).toBeDefined();
+
+    const openapiRes = await app.request("/openapi.json");
+    const text = await openapiRes.text();
+    const digest = await crypto.subtle.digest(
+      "SHA-256",
+      new TextEncoder().encode(text),
+    );
+    const hex = Array.from(new Uint8Array(digest))
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+    expect(hex).toBe(openapiEntry?.sha256);
+  });
+});
+
+describe("/.well-known/agent-skills/scan-domain/SKILL.md", () => {
+  it("renders the scan_domain skill in markdown", async () => {
+    const res = await app.request(
+      "/.well-known/agent-skills/scan-domain/SKILL.md",
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe(
+      "text/markdown; charset=utf-8",
+    );
+    const body = await res.text();
+    expect(body).toContain("# scan_domain");
+    expect(body).toContain("/api/check");
+    expect(body).toContain("/openapi.json");
   });
 });
 


### PR DESCRIPTION
## Summary

Implements the [Cloudflare Agent Skills Discovery RFC v0.2.0](https://github.com/cloudflare/agent-skills-discovery-rfc) index so AI agents can discover the public scan API via standard well-known paths. Addresses the last actionable gap from the [isitagentready.com audit](https://isitagentready.com/dmarc.mx) — the OAuth/OIDC and MCP server-card items remain out of scope (see below + #181).

- **`/.well-known/agent-skills/index.json`** — lists `scan_domain` in two formats (markdown SKILL.md + OpenAPI), each with a sha256 digest computed lazily over the served bytes and memoized per Worker instance.
- **`/.well-known/agent-skills/scan-domain/SKILL.md`** — prose description of the skill, served as `text/markdown`.
- **Link header** on HTML pages now advertises the new index relation (`https://agentskills.io/rel/index`) alongside the existing four (`api-catalog`, `service-desc`, `service-doc`, `status`).
- **5 new tests** in `agent-discovery.test.ts`: schema shape, byte-for-byte digest match for both referenced docs, content-type, Link advertisement.

## Why these four checks, and not the others?

isitagentready.com flagged four gaps. Three of them don't apply to dmarcheck and would mislead agents if we faked them — documented in `CLAUDE.md`:

| Audit gap | Disposition | Reason |
|---|---|---|
| OIDC discovery (`/.well-known/openid-configuration`) | Skip | We are the OAuth **client** of WorkOS AuthKit, not an issuer. Discovery docs are published by issuers. |
| OAuth Protected Resource Metadata (RFC 9728) | Skip | Our protected APIs use dmarcheck-minted opaque API keys, not OAuth-issued access tokens. The mandatory `authorization_servers` field has nothing meaningful to point at. |
| MCP Server Card (SEP-1649) | Defer → #181 | We don't run a remote MCP server (only WebMCP via `navigator.modelContext`). Tracked as a separate effort because it's a real feature, not just a metadata file. |
| Agent Skills index (RFC v0.2.0) | **This PR** | Static JSON pointing at existing assets. Low risk, real value. |

## Design notes

- Two skill entries share `name: "scan_domain"` and differ on `type` (markdown / openapi). The `type` discriminates; this matches how isitagentready.com itself publishes its skill catalog.
- Digests are computed lazily on first request and memoized — Web Crypto digest is async and Workers don't permit top-level await.
- Both new endpoints inherit `X-Robots-Tag: noindex` automatically via the existing content-type middleware (`application/json` and `text/markdown` are both in `NOINDEX_CONTENT_TYPES`).
- `Cache-Control: public, max-age=3600` matches the existing `/.well-known/api-catalog` endpoint.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` — 726/726 pass (17 in agent-discovery.test.ts, +5 new)
- [ ] Post-deploy: re-run isitagentready.com and confirm the agent-skills check flips to passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)