### PR TITLE
feat(seo): cross-link report cards and /scoring headings to /learn

### DIFF
--- a/src/views/components.ts
+++ b/src/views/components.ts
@@ -227,7 +227,11 @@ export function protocolCard(
   subtitle: string,
   body: string,
   expanded = false,
+  learnSlug?: string,
 ): string {
+  const learnLink = learnSlug
+    ? `<div class="card-learn-link"><a href="/learn/${esc(learnSlug)}">Learn about ${esc(name)} &rarr;</a></div>`
+    : "";
   return `<div class="card${expanded ? " expanded" : ""}">
   <div class="card-header" role="button" tabindex="0" aria-expanded="${expanded ? "true" : "false"}">
     ${statusDot(status)}
@@ -235,7 +239,7 @@ export function protocolCard(
     <div class="card-subtitle">${esc(subtitle)}</div>
     <div class="card-chevron" aria-hidden="true">&#9654;</div>
   </div>
-  <div class="card-body">${body}</div>
+  <div class="card-body">${body}${learnLink}</div>
 </div>`;
 }
 

--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -204,7 +204,7 @@ export function renderDmarcCard(dmarc: DmarcResult): string {
     ? rawRecord(dmarc.record)
     : rawRecordExpand(dmarc.record, "Show TXT records found");
   const body = tagGrid(dmarc.tags) + validationList(dmarc.validations) + raw;
-  return protocolCard("DMARC", dmarc.status, subtitle, body, true);
+  return protocolCard("DMARC", dmarc.status, subtitle, body, true, "dmarc");
 }
 
 export function renderSpfCard(spf: SpfResult): string {
@@ -218,7 +218,7 @@ export function renderSpfCard(spf: SpfResult): string {
   }
   body += validationList(spf.validations);
   body += rawRecord(spf.record);
-  return protocolCard("SPF", spf.status, subtitle, body, true);
+  return protocolCard("SPF", spf.status, subtitle, body, true, "spf");
 }
 
 export function renderDkimCard(dkim: DkimResult): string {
@@ -229,7 +229,7 @@ export function renderDkimCard(dkim: DkimResult): string {
       : "No selectors found";
   const body =
     dkimSelectorGrid(dkim.selectors) + validationList(dkim.validations);
-  return protocolCard("DKIM", dkim.status, subtitle, body);
+  return protocolCard("DKIM", dkim.status, subtitle, body, false, "dkim");
 }
 
 export function renderBimiCard(bimi: BimiResult): string {
@@ -244,7 +244,7 @@ export function renderBimiCard(bimi: BimiResult): string {
     : "";
   const body =
     logo + tagGrid(bimi.tags) + validationList(bimi.validations) + raw;
-  return protocolCard("BIMI", bimi.status, subtitle, body);
+  return protocolCard("BIMI", bimi.status, subtitle, body, false, "bimi");
 }
 
 export function renderMtaStsCard(mtaSts: MtaStsResult): string {
@@ -259,7 +259,14 @@ export function renderMtaStsCard(mtaSts: MtaStsResult): string {
   if (mtaSts.dns_record) {
     body += rawRecord(mtaSts.dns_record);
   }
-  return protocolCard("MTA-STS", mtaSts.status, subtitle, body);
+  return protocolCard(
+    "MTA-STS",
+    mtaSts.status,
+    subtitle,
+    body,
+    false,
+    "mta-sts",
+  );
 }
 
 export function renderMxCard(mx: MxResult): string {
@@ -625,23 +632,23 @@ export function renderScoringRubric(): string {
     <div class="bd-card-title">The five protocols</div>
     <div class="bd-card-body">
       <div class="rubric-protocol">
-        <h3>DMARC</h3>
+        <h3><a href="/learn/dmarc">DMARC</a></h3>
         <p>Domain-based Message Authentication, Reporting &amp; Conformance. The policy layer that ties SPF and DKIM together and tells receivers what to do with unauthenticated mail. This is the most important factor in your grade.</p>
       </div>
       <div class="rubric-protocol">
-        <h3>SPF</h3>
+        <h3><a href="/learn/spf">SPF</a></h3>
         <p>Sender Policy Framework. A DNS record listing which IP addresses are authorized to send mail for your domain. Receivers check the sending server's IP against this list.</p>
       </div>
       <div class="rubric-protocol">
-        <h3>DKIM</h3>
+        <h3><a href="/learn/dkim">DKIM</a></h3>
         <p>DomainKeys Identified Mail. Adds a cryptographic signature to outgoing messages, proving they haven't been tampered with in transit. Key strength (2048+ bits) and multiple selectors improve your score.</p>
       </div>
       <div class="rubric-protocol">
-        <h3>BIMI</h3>
+        <h3><a href="/learn/bimi">BIMI</a></h3>
         <p>Brand Indicators for Message Identification. Displays your brand logo next to authenticated messages in supporting email clients. Requires DMARC p=reject.</p>
       </div>
       <div class="rubric-protocol">
-        <h3>MTA-STS</h3>
+        <h3><a href="/learn/mta-sts">MTA-STS</a></h3>
         <p>Mail Transfer Agent Strict Transport Security. Forces TLS encryption for inbound mail delivery, preventing downgrade attacks. Modes: testing (report only) and enforce (reject unencrypted).</p>
       </div>
     </div>

--- a/src/views/styles.ts
+++ b/src/views/styles.ts
@@ -382,6 +382,9 @@ h1.domain-name, .domain-name { font-size: 1.5rem; font-weight: 700; margin: 0; }
 .card-body { padding: 0 20px 20px; border-top: 1px solid var(--clr-border); display: none; }
 .card.expanded .card-body { display: block; }
 .card.expanded .card-chevron { transform: rotate(90deg); }
+.card-learn-link { margin-top: 16px; padding-top: 12px; border-top: 1px dashed var(--clr-border); font-size: 0.85rem; }
+.card-learn-link a { color: var(--clr-text-dim); text-decoration: underline; text-underline-offset: 2px; }
+.card-learn-link a:hover { color: var(--clr-accent); }
 
 /* Tag grid */
 .tag-grid {
@@ -712,6 +715,8 @@ h1.domain-name, .domain-name { font-size: 1.5rem; font-weight: 700; margin: 0; }
 .rubric-protocol { padding: 10px 0; border-bottom: 1px solid var(--clr-border-subtle); }
 .rubric-protocol:last-child { border-bottom: none; }
 .rubric-protocol h3 { font-size: 0.9rem; font-weight: 600; color: var(--clr-accent); margin-bottom: 4px; }
+.rubric-protocol h3 a { color: inherit; text-decoration: none; }
+.rubric-protocol h3 a:hover { text-decoration: underline; text-underline-offset: 3px; }
 .rubric-protocol p { font-size: 0.82rem; color: var(--clr-text-muted); line-height: 1.5; }
 .rubric-cta {
   display: inline-block; padding: 10px 24px; background: var(--clr-accent); color: var(--clr-on-accent);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -553,6 +553,52 @@ describe("HTML head tags", () => {
     expect(html).toContain('<dt><a href="/learn/mta-sts">MTA-STS</a></dt>');
   });
 
+  it("/scoring cross-links each protocol heading to its /learn page", async () => {
+    const res = await app.request("/scoring");
+    const html = await res.text();
+    expect(html).toContain('<h3><a href="/learn/dmarc">DMARC</a></h3>');
+    expect(html).toContain('<h3><a href="/learn/spf">SPF</a></h3>');
+    expect(html).toContain('<h3><a href="/learn/dkim">DKIM</a></h3>');
+    expect(html).toContain('<h3><a href="/learn/bimi">BIMI</a></h3>');
+    expect(html).toContain('<h3><a href="/learn/mta-sts">MTA-STS</a></h3>');
+  });
+
+  it("report cards cross-link each protocol to its /learn page", async () => {
+    const {
+      renderDmarcCard,
+      renderSpfCard,
+      renderDkimCard,
+      renderBimiCard,
+      renderMtaStsCard,
+    } = await import("../src/views/html.js");
+    const empty = { status: "fail" as const, validations: [] };
+    expect(renderDmarcCard({ ...empty, record: null, tags: null })).toContain(
+      '<div class="card-learn-link"><a href="/learn/dmarc">Learn about DMARC &rarr;</a></div>',
+    );
+    expect(
+      renderSpfCard({
+        ...empty,
+        record: null,
+        lookups_used: 0,
+        lookup_limit: 10,
+        include_tree: null,
+      }),
+    ).toContain(
+      '<div class="card-learn-link"><a href="/learn/spf">Learn about SPF &rarr;</a></div>',
+    );
+    expect(renderDkimCard({ ...empty, selectors: {} })).toContain(
+      '<div class="card-learn-link"><a href="/learn/dkim">Learn about DKIM &rarr;</a></div>',
+    );
+    expect(renderBimiCard({ ...empty, record: null, tags: null })).toContain(
+      '<div class="card-learn-link"><a href="/learn/bimi">Learn about BIMI &rarr;</a></div>',
+    );
+    expect(
+      renderMtaStsCard({ ...empty, dns_record: null, policy: null }),
+    ).toContain(
+      '<div class="card-learn-link"><a href="/learn/mta-sts">Learn about MTA-STS &rarr;</a></div>',
+    );
+  });
+
   it("landing page embeds WebSite + SoftwareApplication JSON-LD", async () => {
     const res = await app.request("/");
     const html = await res.text();


### PR DESCRIPTION
## Summary

GSC shows `/learn/dmarc`, `/learn/spf`, `/learn/dkim`, `/learn/bimi`, and `/learn` sitting in **"Discovered – currently not indexed"** while every other top-level page is indexed. The protocol learn pages currently get inbound internal links only from the landing explainer — the report pages and `/scoring` push readers toward an external Cloudflare guide instead of our own.

This PR closes that gap by adding contextual `/learn/<slug>` links to:

- **Every report card** — DMARC, SPF, DKIM, BIMI, MTA-STS each append a small `Learn about <X> →` row inside the card body, separated by a dashed border so it reads as a footer rather than content. MX correctly omits the link (no `/learn/mx` page).
- **`/scoring` "five protocols" headings** — each `<h3>` is now wrapped in an anchor to `/learn/<slug>`. The h3 keeps its accent color and only picks up an underline on hover, so the page looks unchanged at rest.

That's 5 new outbound links on every `/check?domain=…` report (a high-traffic surface — accounts for 27 of 43 GSC impressions in the last 90 days), plus 5 more on `/scoring`. Combined with the 5 already on the landing explainer, every key public surface now points at every protocol learn page. This is the internal-PageRank flow Google looks for before promoting "Discovered" pages to indexed.

GSC baseline at the time of writing (3-month window):
- 43 impressions, 0 clicks, avg position 46.4
- 6 indexed pages (`/`, three sample `/check?domain=` URLs, `/scoring`, `/learn/mta-sts`)
- 10 not indexed — **5 of which are the unindexed `/learn/*` pages**

## What's not in this PR

- **Backlinks.** The page-46 ranking is fundamentally a Domain Authority problem; no internal-linking change closes that. HN/Reddit/comparison-blog work is the actual lever and lives outside the codebase.
- **Sitemap changes.** `/sitemap.xml` already includes all `/learn/*` pages (PR #103); they're discovered, just not promoted.
- **Copy rewrites.** Each `/learn/*` page may benefit from beefier unique content over time, but that's separate from getting them indexed.

## Test plan

- [x] `npm test` — 724/724 passing (added two tests: `/scoring` h3 anchors, and direct calls to each card renderer for the per-protocol learn link)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] Visual check in `wrangler dev`: card-learn-link renders with dashed top border, dim text, links resolve correctly; `/scoring` h3 anchors inherit accent color and only underline on hover
- [x] DOM check: `document.querySelectorAll('.card-learn-link a')` returns 5 elements with correct hrefs and anchor text on a `/check?domain=…&_direct=1` report
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)