### PR TITLE
fix(webhooks): parallelize fireBulkScanWebhooks dispatch (#186)

### DIFF
--- a/src/webhooks/triggers.ts
+++ b/src/webhooks/triggers.ts
@@ -34,24 +34,33 @@ export async function fireScanCompletedWebhook(
 }
 
 // Fires one `scan.completed` event per successfully-scanned entry in a bulk
-// outcome. Best-effort and serial — callers should hand this to `waitUntil`
-// so it never blocks the response. Queued/invalid/error entries are skipped
-// (no scan happened, nothing to report).
+// outcome. Best-effort; callers should hand this to `waitUntil` so it never
+// blocks the response. Queued/invalid/error entries are skipped (no scan
+// happened, nothing to report).
+//
+// Dispatch fans out via `Promise.allSettled` so cumulative wallclock is
+// max(per-call) rather than sum(per-call). A serial loop here previously
+// blew the waitUntil budget on 25-domain bulk adds: receivers got the
+// bytes but the AbortSignal fired on the tail before the response was
+// observed, recording every late delivery as a timeout. See #186.
 export async function fireBulkScanWebhooks(
   db: D1Database,
   userId: string,
   results: BulkResultEntry[],
   trigger: ScanCompletedData["trigger"],
 ): Promise<void> {
-  for (const entry of results) {
-    if (entry.status !== "scanned" || !entry.grade) continue;
-    await fireScanCompletedWebhook(db, userId, {
-      domain: entry.domain,
-      grade: entry.grade,
-      // Bulk scans don't surface a stable scan_history.id; receivers can
-      // re-fetch by domain via /api/domain/:name/history.
-      scanId: entry.domain,
-      trigger,
-    });
-  }
+  const dispatches = results
+    .filter((entry) => entry.status === "scanned" && entry.grade)
+    .map((entry) =>
+      fireScanCompletedWebhook(db, userId, {
+        domain: entry.domain,
+        // biome-ignore lint/style/noNonNullAssertion: filtered above.
+        grade: entry.grade!,
+        // Bulk scans don't surface a stable scan_history.id; receivers can
+        // re-fetch by domain via /api/domain/:name/history.
+        scanId: entry.domain,
+        trigger,
+      }),
+    );
+  await Promise.allSettled(dispatches);
 }

--- a/test/webhooks-triggers.test.ts
+++ b/test/webhooks-triggers.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { BulkResultEntry } from "../src/api/bulk-scan.js";
+import { fireBulkScanWebhooks } from "../src/webhooks/triggers.js";
+
+interface FakeWebhookRow {
+  id: number;
+  user_id: string;
+  url: string;
+  secret: string | null;
+  format: "raw" | "slack" | "google_chat";
+  created_at: number;
+}
+
+let webhooksByUser: Map<string, FakeWebhookRow>;
+let deliveriesInserted: number;
+
+function makeDb(): D1Database {
+  const prepare = (sql: string) => ({
+    bind: (...params: unknown[]) => ({
+      first: async <T>() => {
+        if (/^SELECT \* FROM webhooks WHERE user_id = \?/i.test(sql)) {
+          const [userId] = params as [string];
+          return (webhooksByUser.get(userId) as T | undefined) ?? null;
+        }
+        return null;
+      },
+      run: async () => {
+        if (/^INSERT INTO webhook_deliveries/i.test(sql)) {
+          deliveriesInserted += 1;
+        }
+        return { meta: {} } as never;
+      },
+      all: async <T>() => ({ results: [] as T[] }),
+    }),
+  });
+  return { prepare } as unknown as D1Database;
+}
+
+beforeEach(() => {
+  webhooksByUser = new Map();
+  deliveriesInserted = 0;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("webhooks/triggers.fireBulkScanWebhooks", () => {
+  it("dispatches all scan.completed webhooks concurrently rather than serially", async () => {
+    webhooksByUser.set("u1", {
+      id: 1,
+      user_id: "u1",
+      url: "https://hook.example/receive",
+      secret: "shhh",
+      format: "raw",
+      created_at: 0,
+    });
+
+    // Track in-flight fetch count to prove concurrency: if dispatch is
+    // serial, max in-flight will be 1; if parallel, it climbs to N.
+    let inFlight = 0;
+    let maxInFlight = 0;
+    let resolveAll: (() => void) | null = null;
+    const allStarted = new Promise<void>((resolve) => {
+      resolveAll = resolve;
+    });
+    const STARTED_THRESHOLD = 5;
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        if (inFlight >= STARTED_THRESHOLD && resolveAll) {
+          const r = resolveAll;
+          resolveAll = null;
+          r();
+        }
+        // Hold each fetch open until all 5 are observed in-flight. A serial
+        // implementation would deadlock here; a parallel one resolves.
+        await allStarted;
+        inFlight -= 1;
+        return new Response("", { status: 202 });
+      });
+
+    const db = makeDb();
+    const results: BulkResultEntry[] = Array.from({ length: 5 }, (_, i) => ({
+      domain: `example${i}.com`,
+      status: "scanned",
+      grade: "A",
+    })) as BulkResultEntry[];
+
+    await fireBulkScanWebhooks(db, "u1", results, "dashboard");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(5);
+    expect(maxInFlight).toBe(5);
+    expect(deliveriesInserted).toBe(5);
+  });
+
+  it("skips entries that did not produce a scanned grade", async () => {
+    webhooksByUser.set("u1", {
+      id: 1,
+      user_id: "u1",
+      url: "https://hook.example/receive",
+      secret: "shhh",
+      format: "raw",
+      created_at: 0,
+    });
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("", { status: 202 }));
+
+    const db = makeDb();
+    const results: BulkResultEntry[] = [
+      { domain: "ok.example", status: "scanned", grade: "A" },
+      { domain: "queued.example", status: "queued" },
+      { domain: "invalid.example", status: "invalid", reason: "format" },
+      { domain: "errored.example", status: "error", error: "boom" },
+    ] as BulkResultEntry[];
+
+    await fireBulkScanWebhooks(db, "u1", results, "bulk_api");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(deliveriesInserted).toBe(1);
+  });
+
+  it("does not let one failed dispatch abort the rest of the batch", async () => {
+    webhooksByUser.set("u1", {
+      id: 1,
+      user_id: "u1",
+      url: "https://hook.example/receive",
+      secret: "shhh",
+      format: "raw",
+      created_at: 0,
+    });
+
+    let call = 0;
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => {
+        call += 1;
+        if (call === 2) throw new Error("ECONNRESET");
+        return new Response("", { status: 202 });
+      });
+
+    const db = makeDb();
+    const results: BulkResultEntry[] = Array.from({ length: 3 }, (_, i) => ({
+      domain: `example${i}.com`,
+      status: "scanned",
+      grade: "B",
+    })) as BulkResultEntry[];
+
+    await fireBulkScanWebhooks(db, "u1", results, "dashboard");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    // Every attempt — including the rejected one — must be recorded.
+    expect(deliveriesInserted).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

- Bulk webhook fan-out switches from a serial `for...await` loop to `Promise.allSettled`, collapsing cumulative wallclock from sum(per-call) to max(per-call).
- Adds `test/webhooks-triggers.test.ts` covering concurrency, skipped non-scanned entries, and one-failure-doesn't-poison-the-batch.

## Why

When a Pro user bulk-added ~25 domains with a Google Chat webhook configured, every chat message was actually delivered, but `/dashboard/settings` showed all of the most-recent-10 deliveries as `The operation was aborted due to timeout ✗`. Receivers got the bytes; we recorded the wrong outcome.

Root cause: `fireBulkScanWebhooks` ran inside `c.executionCtx.waitUntil(...)` and dispatched serially. With N×~1–5s per fetch, the cumulative wallclock blew through the waitUntil budget. The AbortSignal then fired on the tail of the batch *after* the request body had already left the worker, recording timeouts that didn't reflect the receiver's view.

Fan-out via `Promise.allSettled` eliminates the budget pressure (Pro tier is capped at 25 domains; concurrent subrequests are well within Worker limits) without changing the per-call timeout or the recorded-on-every-attempt audit shape.

## Test plan

- [x] `npm test` — 731/731 pass, including 3 new triggers tests
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [ ] Live verify: bulk-add 25 domains on staging once #195 lands and confirm the dashboard shows successful deliveries

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)