### PR TITLE
feat(infra): stand up staging.dmarc.mx with gated migration promotion (#195)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,38 @@
+name: Deploy Staging Worker
+
+# Pushes the dmarcheck Worker to the [env.staging] config in wrangler.toml
+# on every commit to main, so staging.dmarc.mx mirrors prod's code. The
+# Cloudflare Git integration handles prod independently. See #195.
+#
+# This workflow deliberately runs unconditionally on push (not gated on the
+# CI workflow_run) — a fast staging deploy is the value here. CI still
+# blocks merges to main via branch protection, so the only way for code to
+# arrive on main is via a green CI run on the merging PR.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: "22"
+          cache: "npm"
+      - run: npm ci
+      - name: Deploy to staging
+        env:
+          # The same token used for D1 migrations works here as long as it
+          # also has Workers Scripts:Edit on the account. If you'd rather
+          # have a scope-restricted deploy token, create a new one with
+          # only Workers Scripts:Edit + Workers Routes:Edit and store it
+          # as CLOUDFLARE_STAGING_DEPLOY_TOKEN; then swap the secret name.
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_D1_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx wrangler deploy --env staging

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -1,15 +1,23 @@
 name: Migrate D1
 
-# Applies pending D1 migrations from src/db/migrations/ to the remote
-# database after CI passes on main. The Cloudflare Git integration deploys the
-# Worker in parallel, so all migrations MUST be additive (new tables, new
-# nullable/defaulted columns, new indexes) — see CLAUDE.md "Database
-# migrations".
+# Promotes pending D1 migrations from src/db/migrations/ through staging
+# into prod after CI passes on main. The Cloudflare Git integration deploys
+# the Worker code in parallel, so all migrations MUST be additive (new
+# tables, new nullable/defaulted columns, new indexes) — see CLAUDE.md
+# "Database migrations".
 #
-# Bootstrap (one-time, manual): seed the d1_migrations tracking table with the
-# names of every migration already applied out-of-band, otherwise the first
-# run of `wrangler d1 migrations apply` will replay them and fail on
-# ALTER TABLE statements.
+# Flow (#195):
+#   1. apply-staging: apply migrations to dmarcheck-db-staging, then
+#      smoke-test https://staging.dmarc.mx/health.
+#   2. apply-prod: gated on the `prod-migrations` GitHub Environment so a
+#      human approves before prod schema moves. After approval, apply
+#      migrations to dmarcheck-db.
+#
+# Bootstrap (one-time, manual): seed the d1_migrations tracking table with
+# the names of every migration already applied out-of-band, otherwise the
+# first run of `wrangler d1 migrations apply` will replay them and fail on
+# ALTER TABLE statements. Repeat for the staging database the first time
+# this workflow runs against it.
 on:
   workflow_run:
     workflows: [CI]
@@ -20,7 +28,7 @@ permissions:
   contents: read
 
 jobs:
-  migrate:
+  apply-staging:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
@@ -30,12 +38,54 @@ jobs:
           node-version: "22"
           cache: "npm"
       - run: npm ci
-      - name: List pending migrations
+      - name: List pending staging migrations
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_D1_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx wrangler d1 migrations list dmarcheck-db-staging --remote --env staging
+      - name: Apply pending staging migrations
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_D1_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx wrangler d1 migrations apply dmarcheck-db-staging --remote --env staging
+      - name: Smoke-test staging
+        # /health is unauthenticated. A 200 here proves the migrated schema
+        # is compatible with the currently-deployed staging Worker code. Up
+        # to 50s of polling so a just-deployed Worker has time to settle
+        # behind the route.
+        run: |
+          for i in 1 2 3 4 5; do
+            status=$(curl -fsS -o /dev/null -w "%{http_code}" https://staging.dmarc.mx/health || true)
+            if [ "$status" = "200" ]; then
+              echo "staging /health -> 200 on attempt $i"
+              exit 0
+            fi
+            echo "staging /health -> $status on attempt $i (waiting 10s)"
+            sleep 10
+          done
+          echo "staging /health did not return 200 after 5 attempts"
+          exit 1
+
+  apply-prod:
+    needs: apply-staging
+    runs-on: ubuntu-latest
+    # Gate prod migrations on the `prod-migrations` GitHub Environment.
+    # Configure the environment with required reviewers (see #195) so a
+    # human click is needed before prod schema moves.
+    environment: prod-migrations
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: "22"
+          cache: "npm"
+      - run: npm ci
+      - name: List pending prod migrations
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_D1_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: npx wrangler d1 migrations list dmarcheck-db --remote
-      - name: Apply pending migrations
+      - name: Apply pending prod migrations
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_D1_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,8 +92,15 @@ Live at dmarc.mx | Repo: github.com/schmug/dmarcheck
 - Migrations live in `src/db/migrations/`, named `NNNN_description.sql` with a monotonically-increasing 4-digit prefix. Pick the next prefix by listing the directory — never reuse one (PR #154 collided on `0003_` and had to be renamed).
 - Every schema change updates **both** `src/db/schema.sql` (fresh-DB shape) and a new migration file (delta against prod). The migration is what runs against the live D1; `schema.sql` is what self-hosters apply on first install.
 - **Additive-only**: new tables, new nullable or defaulted columns, new indexes. Column drops, renames, and type changes go through a two-PR expand/contract because `.github/workflows/migrate.yml` and the Cloudflare Git auto-deploy run in parallel — there is no ordering guarantee between schema change and code change.
-- Migrations apply automatically: `.github/workflows/migrate.yml` runs `wrangler d1 migrations apply dmarcheck-db --remote` after CI passes on `main`. **Do not** run `npx wrangler d1 execute --file=...` by hand anymore.
-- Wrangler tracks applied migrations in the `d1_migrations` table. If a migration is added, applied manually, and then automation tries to replay it, `ALTER TABLE ADD COLUMN` will fail. If you ever apply one out of band, also `INSERT INTO d1_migrations (name) VALUES ('NNNN_description.sql')` so the workflow skips it.
+- Migrations apply automatically through staging then prod: `.github/workflows/migrate.yml` runs `wrangler d1 migrations apply dmarcheck-db-staging --remote --env staging`, smoke-tests `https://staging.dmarc.mx/health`, then waits on the `prod-migrations` GitHub Environment for an approval click before applying to `dmarcheck-db`. **Do not** run `npx wrangler d1 execute --file=...` by hand anymore.
+- Wrangler tracks applied migrations per-database in the `d1_migrations` table. If a migration is added, applied manually, and then automation tries to replay it, `ALTER TABLE ADD COLUMN` will fail. If you ever apply one out of band, also `INSERT INTO d1_migrations (name) VALUES ('NNNN_description.sql')` so the workflow skips it. Do this on **both** `dmarcheck-db-staging` and `dmarcheck-db` if the manual apply landed in both.
+
+## Staging
+
+- `staging.dmarc.mx` is a non-public preview surface for migration promotion (#195). HTML responses get a sticky red banner injected via the middleware, a `<meta name="robots" content="noindex,nofollow">`, and `robots.txt` blanket-disallows. Don't link to staging from anywhere indexable; if you find it via a Google result, that's a bug — file an issue.
+- Staging runs the same code as prod (deployed by `.github/workflows/deploy-staging.yml` on every main commit), against a separate D1 database (`dmarcheck-db-staging`), separate WorkOS sandbox tenant, and Stripe test-mode keys. The `DEPLOY_ENV=staging` var (set in `wrangler.toml [env.staging.vars]`) is what every env-aware code path keys off.
+- Sentry events from staging are tagged `environment: staging` with full `tracesSampler` (1.0). Use that filter in the Sentry UI to keep prod dashboards clean.
+- `CF_ANALYTICS_TOKEN` is intentionally not set on staging — the beacon stays out of analytics so prod dashboards aren't polluted by tester traffic.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,13 @@ If you skip the secrets, the workflow will fail and you can either delete
 `.github/workflows/migrate.yml` from your fork or apply migrations manually
 with `npx wrangler d1 migrations apply dmarcheck-db --remote`.
 
+The hosted tier promotes migrations through `staging.dmarc.mx` first: the
+workflow applies to `dmarcheck-db-staging`, smoke-tests the staging
+deploy, then waits on the `prod-migrations` GitHub Environment for an
+approval click before touching prod. Self-host forks that don't run a
+staging environment can either delete the `apply-staging` job from the
+workflow or remove the `--env staging` overrides and skip the gate.
+
 ### Optional: paid-tier env vars
 
 These unlock the same Pro features the hosted tier at `dmarc.mx` offers — see the [three ways to use dmarcheck](#three-ways-to-use-dmarcheck) table up top. They're all optional: the free scanner, dashboard, and API work without any of them. Set any as wrangler secrets (`wrangler secret put NAME`):

--- a/src/env.ts
+++ b/src/env.ts
@@ -21,4 +21,10 @@ export interface Env {
   // but lives here so self-host forks don't accidentally ship data to the
   // hosted tier's dashboard.
   CF_ANALYTICS_TOKEN?: string;
+  // Deploy environment marker. Set to "staging" via wrangler.toml's
+  // [env.staging.vars] block; unset (or any other value) on prod and on
+  // self-host deploys, which both behave as production. Drives the Sentry
+  // `environment` tag, the staging banner injection, the noindex meta tag,
+  // and the robots.txt Disallow:/ on staging. Non-secret.
+  DEPLOY_ENV?: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -221,6 +221,23 @@ app.use("*", async (c, next) => {
         headers: c.res.headers,
       });
     }
+
+    // Staging surface: tag every HTML response with a top-of-page banner
+    // and a noindex meta. Same buffered-string-replace shape as the
+    // analytics beacon — keeps tests runnable without HTMLRewriter.
+    if ((c.env as Env | undefined)?.DEPLOY_ENV === "staging") {
+      const body = await c.res.text();
+      const noindex = '<meta name="robots" content="noindex,nofollow">';
+      const banner = `<div role="status" style="position:sticky;top:0;z-index:9999;background:#b91c1c;color:#fff;text-align:center;padding:0.4rem 1rem;font-family:system-ui,sans-serif;font-size:0.875rem;font-weight:600">STAGING — non-production data, do not link</div>`;
+      const injected = body
+        .replace("</head>", `${noindex}</head>`)
+        .replace("<body>", `<body>${banner}`);
+      c.res = new Response(injected, {
+        status: c.res.status,
+        statusText: c.res.statusText,
+        headers: c.res.headers,
+      });
+    }
   } else {
     // `frame-ancestors` does not inherit from `default-src`, so it must be
     // declared explicitly to keep JSON/CSV/SSE responses unframable.
@@ -709,9 +726,16 @@ app.get("/docs/api", (c) => {
 
 // Crawl guidance for search engines. Block the API namespace (Google was
 // logging `/api/check?domain=dmarc.mx` as "Crawled - currently not indexed"
-// noise) and point to the sitemap.
+// noise) and point to the sitemap. Staging blanket-disallows so the
+// preview surface never enters search indexes; the per-page noindex meta
+// is the secondary backstop.
 app.get("/robots.txt", (c) => {
-  const body = `User-agent: *
+  const isStaging = (c.env as Env | undefined)?.DEPLOY_ENV === "staging";
+  const body = isStaging
+    ? `User-agent: *
+Disallow: /
+`
+    : `User-agent: *
 Allow: /
 Disallow: /api/
 Sitemap: https://dmarc.mx/sitemap.xml
@@ -1220,14 +1244,17 @@ const handler: ExportedHandler<Env> = {
   scheduled,
 };
 
-export default Sentry.withSentry<Env>(
-  (env) => ({
+export default Sentry.withSentry<Env>((env) => {
+  const isStaging = env?.DEPLOY_ENV === "staging";
+  return {
     dsn: env?.SENTRY_DSN ?? "",
+    environment: isStaging ? "staging" : "production",
     tracesSampler: (samplingContext: { parentSampled?: boolean }) => {
       if (samplingContext.parentSampled !== undefined)
         return samplingContext.parentSampled;
-      return 0.3;
+      // Staging gets full sampling — every event is interesting there and
+      // the volume is bounded by the lone tester.
+      return isStaging ? 1.0 : 0.3;
     },
-  }),
-  handler,
-);
+  };
+}, handler);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -670,6 +670,35 @@ describe("SEO routes", () => {
     const res = await app.request("/sitemap.xml");
     expect(res.headers.get("X-Robots-Tag")).toBeNull();
   });
+
+  it("staging /robots.txt blanket-disallows so the preview never lands in search", async () => {
+    const res = await app.request("/robots.txt", undefined, {
+      DEPLOY_ENV: "staging",
+    });
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("User-agent: *");
+    expect(body).toContain("Disallow: /");
+    expect(body).not.toContain("Allow: /");
+    expect(body).not.toContain("Sitemap:");
+  });
+});
+
+describe("staging surface", () => {
+  it("injects a STAGING banner and noindex meta on HTML responses when DEPLOY_ENV=staging", async () => {
+    const res = await app.request("/", undefined, { DEPLOY_ENV: "staging" });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('content="noindex,nofollow"');
+    expect(html).toContain("STAGING");
+  });
+
+  it("does not inject the banner when DEPLOY_ENV is unset (prod / self-host)", async () => {
+    const res = await app.request("/");
+    const html = await res.text();
+    expect(html).not.toContain("noindex,nofollow");
+    expect(html).not.toMatch(/STAGING — non-production data, do not link/);
+  });
 });
 
 describe("Learn pages", () => {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -29,3 +29,50 @@ migrations_dir = "src/db/migrations"
 [[send_email]]
 name = "EMAIL"
 allowed_sender_addresses = ["alerts@dmarc.mx"]
+
+# ---- Staging environment ----------------------------------------------------
+# staging.dmarc.mx is a non-public testing surface for migration promotion
+# (#195). The migrate workflow applies new D1 schema migrations to staging,
+# smoke-tests the deploy, and gates the prod migration on a manual approval.
+#
+# One-time setup before this env activates:
+#   1. Create D1 database `dmarcheck-db-staging` and paste the id into
+#      `database_id` below.
+#   2. Add DNS record `staging.dmarc.mx` pointing at the staging Worker.
+#   3. Set staging-only secrets via:
+#        npx wrangler secret put SESSION_SECRET --env staging
+#        npx wrangler secret put WORKOS_CLIENT_ID --env staging
+#        npx wrangler secret put WORKOS_CLIENT_SECRET --env staging
+#        npx wrangler secret put STRIPE_SECRET_KEY --env staging       # test mode
+#        npx wrangler secret put STRIPE_WEBHOOK_SECRET --env staging   # test mode
+#        npx wrangler secret put STRIPE_PRICE_ID_PRO --env staging     # test mode
+#      (Don't set CF_ANALYTICS_TOKEN — staging stays out of analytics.)
+#   4. Set the non-secret `DEPLOY_ENV` so the Worker tags Sentry events,
+#      enables the staging banner, and noindexes:
+#        npx wrangler deploy --env staging
+#      ↳ the [env.staging.vars] block below ships DEPLOY_ENV automatically.
+[env.staging]
+name = "dmarcheck-staging"
+routes = [
+  { pattern = "staging.dmarc.mx/*", zone_name = "dmarc.mx" },
+]
+
+[env.staging.vars]
+DEPLOY_ENV = "staging"
+
+# Match prod's cron cadence so staging exercises the same code path. Apps
+# that don't want cron noise on staging can comment this block out.
+[env.staging.triggers]
+crons = ["33 23 * * *", "50 23 * * *"]
+
+[[env.staging.d1_databases]]
+binding = "DB"
+database_name = "dmarcheck-db-staging"
+# TODO(#195): paste the staging D1 database id after running
+# `npx wrangler d1 create dmarcheck-db-staging`.
+database_id = "00000000-0000-0000-0000-000000000000"
+migrations_dir = "src/db/migrations"
+
+[[env.staging.send_email]]
+name = "EMAIL"
+allowed_sender_addresses = ["alerts@dmarc.mx"]


### PR DESCRIPTION
## Summary

Stands up a staging surface so D1 schema changes can be smoke-tested before they hit prod. Until now every migration flew straight to the live database via `migrate.yml`; with paid Pro about to launch (#185), a broken migration becomes a paying-customer outage instead of a "Cory notices and fixes."

## What this ships (code-side)

- **`wrangler.toml`**: `[env.staging]` block with `DEPLOY_ENV=staging` var, the `staging.dmarc.mx` route, a placeholder D1 database id, and the EMAIL binding for parity. `npx wrangler deploy --env staging --dry-run` parses cleanly.
- **`src/env.ts`**: optional `DEPLOY_ENV` var.
- **`src/index.ts`**:
  - Sentry `environment` keyed on `DEPLOY_ENV`; `tracesSampler` bumps to 1.0 on staging.
  - HTML middleware injects a sticky red STAGING banner and `<meta robots=noindex,nofollow>` on every HTML response when `DEPLOY_ENV=staging`. Same buffered-string-replace shape as the existing analytics beacon injection — keeps tests in the Node pool runnable without HTMLRewriter.
  - `/robots.txt` blanket-disallows on staging.
- **`.github/workflows/migrate.yml`**: split into `apply-staging` (unattended) → `apply-prod` (gated on the `prod-migrations` GitHub Environment with required reviewers).
- **`.github/workflows/deploy-staging.yml`**: NEW. Pushes the Worker to `env.staging` on every main commit so staging code mirrors prod.
- **`CLAUDE.md`** + **`README.md`**: document the staging surface and the promotion flow.
- **`test/index.test.ts`**: covers env-aware robots.txt and the banner + noindex injection.

## Post-merge manual steps

1. ` npx wrangler d1 create dmarcheck-db-staging` → paste the id into `wrangler.toml`.
2. Add DNS for `staging.dmarc.mx`.
3. Stand up a WorkOS sandbox tenant; capture `WORKOS_CLIENT_ID` / `WORKOS_CLIENT_SECRET`.
4. Set staging secrets via `wrangler secret put … --env staging`:
   - `SESSION_SECRET` (different from prod)
   - `WORKOS_CLIENT_ID` / `WORKOS_CLIENT_SECRET`
   - `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET` / `STRIPE_PRICE_ID_PRO` (Stripe test mode)
   - **Don't** set `CF_ANALYTICS_TOKEN`.
5. Create the `prod-migrations` GitHub Environment with required reviewers.
6. Confirm `CLOUDFLARE_D1_TOKEN` has `Workers Scripts:Edit` + `Workers Routes:Edit` in addition to `D1:Edit`, or swap the secret name in `deploy-staging.yml`.
7. Apply existing migrations once to the new staging DB and seed any out-of-band migrations into its `d1_migrations` table.

## Decisions surfaced (from the launch-plan brief)

- **Migration token**: reuse existing `CLOUDFLARE_D1_TOKEN`; the deploy-staging workflow comments call out the alternative if you'd rather have a scope-restricted deploy token.
- **Subdomain**: `staging.dmarc.mx` (issue default).
- **Stripe**: reuse Stripe **test mode** keys for staging (no new account).
- **Staging deploy mechanism**: GitHub Actions (`deploy-staging.yml`), not a second Cloudflare Git integration. Lower coordination cost and gives versioned-deploy headroom (`wrangler versions deploy`) if we ever want it.

## Test plan

- [x] `npm test` — 731/731 pass, including new robots.txt + banner-injection cases
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npx wrangler deploy --env staging --dry-run` — parses, shows expected bindings (DB → dmarcheck-db-staging, EMAIL, DEPLOY_ENV=staging)
- [ ] Live verify after the post-merge steps: `https://staging.dmarc.mx/health` returns 200, the landing page shows the red STAGING banner, `staging.dmarc.mx/robots.txt` blanket-disallows.

Refs #195 (acceptance criteria: a follow-up PR will demonstrate the gated migration flow end-to-end once the staging DB exists.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)