### PR TITLE
feat(seo): emphasize free + open-source in /check meta and gate scan-page indexing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ import {
   rateLimitHeaders,
 } from "./rate-limit.js";
 import { normalizeDomain } from "./shared/domain.js";
+import { listIndexableScanDomains } from "./shared/indexable-domains.js";
 import { CSS_PATH, JS_PATH } from "./views/assets.js";
 import {
   APPLE_TOUCH_ICON_BASE64,
@@ -722,11 +723,11 @@ Sitemap: https://dmarc.mx/sitemap.xml
   });
 });
 
-// Static URLs worth reinforcing to search engines. The three example domains
-// are already in Google's index and one of them ranks position 9 for a
-// long-tail query — listing them as canonical crawl targets is a cheap
-// authority signal.
-const SITEMAP_URLS: Array<{ loc: string; priority: string }> = [
+// Static URLs worth reinforcing to search engines. The /check entries are
+// generated from the curated allowlist in src/shared/indexable-domains.ts —
+// every domain listed there is also marked indexable on its scan page, so
+// the sitemap and the per-page robots meta stay in sync.
+const STATIC_SITEMAP_URLS: Array<{ loc: string; priority: string }> = [
   { loc: "https://dmarc.mx/", priority: "1.0" },
   { loc: "https://dmarc.mx/pricing", priority: "0.9" },
   { loc: "https://dmarc.mx/scoring", priority: "0.8" },
@@ -737,17 +738,24 @@ const SITEMAP_URLS: Array<{ loc: string; priority: string }> = [
   { loc: "https://dmarc.mx/learn/dkim", priority: "0.7" },
   { loc: "https://dmarc.mx/learn/bimi", priority: "0.6" },
   { loc: "https://dmarc.mx/learn/mta-sts", priority: "0.7" },
-  { loc: "https://dmarc.mx/check?domain=dmarc.mx", priority: "0.6" },
-  { loc: "https://dmarc.mx/check?domain=google.com", priority: "0.6" },
-  { loc: "https://dmarc.mx/check?domain=github.com", priority: "0.6" },
 ];
-const SITEMAP_LASTMOD = "2026-04-23";
+const SITEMAP_LASTMOD = "2026-04-26";
+
+function buildSitemapUrls(): Array<{ loc: string; priority: string }> {
+  const scanUrls = listIndexableScanDomains().map((domain) => ({
+    loc: `https://dmarc.mx/check?domain=${encodeURIComponent(domain)}`,
+    priority: "0.6",
+  }));
+  return [...STATIC_SITEMAP_URLS, ...scanUrls];
+}
 
 app.get("/sitemap.xml", (c) => {
-  const urls = SITEMAP_URLS.map(
-    ({ loc, priority }) =>
-      `  <url><loc>${loc}</loc><lastmod>${SITEMAP_LASTMOD}</lastmod><priority>${priority}</priority></url>`,
-  ).join("\n");
+  const urls = buildSitemapUrls()
+    .map(
+      ({ loc, priority }) =>
+        `  <url><loc>${loc}</loc><lastmod>${SITEMAP_LASTMOD}</lastmod><priority>${priority}</priority></url>`,
+    )
+    .join("\n");
   const body = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 ${urls}

--- a/src/shared/indexable-domains.ts
+++ b/src/shared/indexable-domains.ts
@@ -1,0 +1,100 @@
+// Curated allowlist of domains whose `/check?domain=…` page is allowed to be
+// indexed by search engines and listed in the sitemap. Two motivations:
+//
+//   1. Branded queries like "dmarc check gmail.com" are valuable inbound
+//      traffic. By pre-listing the popular targets in our sitemap we give
+//      Google a clean URL to crawl with a stable canonical and a meta
+//      description we control.
+//   2. Arbitrary user-submitted scan URLs make poor search results — content
+//      varies per scan, snippets get scraped from icon glyphs, and we have no
+//      query-intent signal. Those pages emit `noindex` so Google focuses
+//      authority on landing/learn/scoring and the curated examples here.
+//
+// Keep the list small (curated, not exhaustive). Every entry must already be
+// normalized through normalizeDomain() to lowercase, no protocol, no path.
+// Adding a domain here also commits us to the snippet looking reasonable —
+// don't list domains whose scans currently render poorly.
+
+const RAW_INDEXABLE_SCAN_DOMAINS = [
+  // Self
+  "dmarc.mx",
+
+  // Major mail providers — high-intent "dmarc check {provider}" queries
+  "gmail.com",
+  "googlemail.com",
+  "outlook.com",
+  "hotmail.com",
+  "yahoo.com",
+  "icloud.com",
+  "proton.me",
+  "protonmail.com",
+  "fastmail.com",
+  "zoho.com",
+  "aol.com",
+
+  // Big consumer brands
+  "google.com",
+  "microsoft.com",
+  "apple.com",
+  "amazon.com",
+  "meta.com",
+  "facebook.com",
+  "instagram.com",
+  "x.com",
+  "twitter.com",
+  "linkedin.com",
+  "netflix.com",
+  "spotify.com",
+  "youtube.com",
+  "reddit.com",
+  "tiktok.com",
+
+  // Developer / SaaS platforms
+  "github.com",
+  "gitlab.com",
+  "stripe.com",
+  "shopify.com",
+  "cloudflare.com",
+  "vercel.com",
+  "netlify.com",
+  "atlassian.com",
+  "slack.com",
+  "notion.so",
+  "figma.com",
+  "openai.com",
+  "anthropic.com",
+
+  // Commerce / financial
+  "paypal.com",
+  "ebay.com",
+  "wellsfargo.com",
+  "chase.com",
+  "bankofamerica.com",
+
+  // News / reference
+  "wikipedia.org",
+  "nytimes.com",
+  "bbc.com",
+  "cnn.com",
+] as const;
+
+const INDEXABLE_SCAN_DOMAINS: ReadonlySet<string> = new Set(
+  RAW_INDEXABLE_SCAN_DOMAINS,
+);
+
+/**
+ * Returns true if a `/check?domain=…` page for this domain should be indexed
+ * by search engines and listed in the sitemap. Input must already be
+ * normalized via normalizeDomain() (lowercase, no protocol, no path).
+ */
+export function isIndexableScanDomain(domain: string): boolean {
+  return INDEXABLE_SCAN_DOMAINS.has(domain);
+}
+
+/**
+ * The full curated list, used by the sitemap generator to enumerate the
+ * scan URLs we want crawled.
+ */
+export function listIndexableScanDomains(): readonly string[] {
+  return RAW_INDEXABLE_SCAN_DOMAINS;
+}

--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -7,6 +7,7 @@ import type {
   ScanResult,
   SpfResult,
 } from "../analyzers/types.js";
+import { isIndexableScanDomain } from "../shared/indexable-domains.js";
 import { CSS_PATH, JS_PATH } from "./assets.js";
 import {
   dkimSelectorGrid,
@@ -320,9 +321,10 @@ function reportBody(result: ScanResult): string {
 
 export function renderReport(result: ScanResult): string {
   return page({
-    title: `${result.domain} — dmarcheck`,
+    title: `${result.domain} DMARC report — Free check | dmarcheck`,
     path: `/check?domain=${encodeURIComponent(result.domain)}`,
-    description: `Live DMARC, SPF, DKIM, BIMI, and MTA-STS check for ${result.domain}. Grade: ${result.grade}.`,
+    description: `Free, open-source DMARC, SPF, DKIM, BIMI, and MTA-STS check for ${result.domain}. See the current grade, records, and fixes. No signup, no email required.`,
+    noindex: !isIndexableScanDomain(result.domain),
     body: reportBody(result),
   });
 }
@@ -385,9 +387,10 @@ export function renderStreamingLoading(
     : `domain=${encodeURIComponent(domain)}`;
 
   return page({
-    title: `Scanning ${domain} — dmarcheck`,
+    title: `${domain} DMARC report — Free check | dmarcheck`,
     path: `/check?domain=${encodeURIComponent(domain)}`,
-    description: `Live DMARC, SPF, DKIM, BIMI, and MTA-STS check for ${domain}.`,
+    description: `Free, open-source DMARC, SPF, DKIM, BIMI, and MTA-STS check for ${domain}. See the current grade, records, and fixes. No signup, no email required.`,
+    noindex: !isIndexableScanDomain(domain),
     body: `<main class="report" data-qs="${esc(qs)}">
   <div class="report-nav">
     <a href="/">${generateCreature("sm")} dmarcheck</a>

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -670,6 +670,63 @@ describe("SEO routes", () => {
     const res = await app.request("/sitemap.xml");
     expect(res.headers.get("X-Robots-Tag")).toBeNull();
   });
+
+  it("sitemap includes the curated /check?domain=… allowlist", async () => {
+    const res = await app.request("/sitemap.xml");
+    const body = await res.text();
+    // Spot-check a few representative entries from each category — full
+    // round-trip against listIndexableScanDomains() is in the unit tests.
+    expect(body).toContain(
+      "<loc>https://dmarc.mx/check?domain=gmail.com</loc>",
+    );
+    expect(body).toContain(
+      "<loc>https://dmarc.mx/check?domain=outlook.com</loc>",
+    );
+    expect(body).toContain(
+      "<loc>https://dmarc.mx/check?domain=github.com</loc>",
+    );
+    expect(body).toContain(
+      "<loc>https://dmarc.mx/check?domain=stripe.com</loc>",
+    );
+    expect(body).toContain("<loc>https://dmarc.mx/check?domain=dmarc.mx</loc>");
+  });
+
+  it("sitemap excludes domains not in the allowlist", async () => {
+    const res = await app.request("/sitemap.xml");
+    const body = await res.text();
+    expect(body).not.toContain("example.com");
+  });
+});
+
+describe("/check meta tags and noindex gating", () => {
+  it("emits the free + open-source description for an allowlisted domain", async () => {
+    const res = await app.request("/check?domain=github.com");
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain(
+      'content="Free, open-source DMARC, SPF, DKIM, BIMI, and MTA-STS check for github.com. See the current grade, records, and fixes. No signup, no email required."',
+    );
+  });
+
+  it("emits the new title format for the streaming loading page", async () => {
+    const res = await app.request("/check?domain=github.com");
+    const html = await res.text();
+    expect(html).toContain(
+      "<title>github.com DMARC report — Free check | dmarcheck</title>",
+    );
+  });
+
+  it("does NOT mark allowlisted scan pages noindex", async () => {
+    const res = await app.request("/check?domain=github.com");
+    const html = await res.text();
+    expect(html).not.toContain('name="robots" content="noindex,follow"');
+  });
+
+  it("marks non-allowlisted scan pages noindex,follow", async () => {
+    const res = await app.request("/check?domain=example.com");
+    const html = await res.text();
+    expect(html).toContain('<meta name="robots" content="noindex,follow">');
+  });
 });
 
 describe("Learn pages", () => {

--- a/test/indexable-domains.test.ts
+++ b/test/indexable-domains.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import {
+  isIndexableScanDomain,
+  listIndexableScanDomains,
+} from "../src/shared/indexable-domains.js";
+
+describe("isIndexableScanDomain", () => {
+  it("returns true for curated allowlist entries", () => {
+    expect(isIndexableScanDomain("gmail.com")).toBe(true);
+    expect(isIndexableScanDomain("github.com")).toBe(true);
+    expect(isIndexableScanDomain("dmarc.mx")).toBe(true);
+  });
+
+  it("returns false for arbitrary domains", () => {
+    expect(isIndexableScanDomain("example.com")).toBe(false);
+    expect(isIndexableScanDomain("some-random-startup.io")).toBe(false);
+  });
+
+  it("is case-sensitive — input must already be lowercased by normalizeDomain", () => {
+    // Catches future regressions where someone removes normalization upstream.
+    expect(isIndexableScanDomain("GMAIL.COM")).toBe(false);
+  });
+});
+
+describe("listIndexableScanDomains", () => {
+  it("returns a non-empty list of normalized domains", () => {
+    const domains = listIndexableScanDomains();
+    expect(domains.length).toBeGreaterThan(0);
+    for (const d of domains) {
+      expect(d).toBe(d.toLowerCase());
+      expect(d).not.toMatch(/^https?:/);
+      expect(d).not.toContain("/");
+      expect(d).toContain(".");
+    }
+  });
+
+  it("agrees with isIndexableScanDomain for every listed entry", () => {
+    for (const d of listIndexableScanDomains()) {
+      expect(isIndexableScanDomain(d)).toBe(true);
+    }
+  });
+
+  it("has no duplicate entries", () => {
+    const domains = listIndexableScanDomains();
+    expect(new Set(domains).size).toBe(domains.length);
+  });
+});


### PR DESCRIPTION
## Summary

Triggered by a Google SERP screenshot for `/check?domain=github.com` that showed the snippet scraped from body text (icon glyphs leaking through as `i 1 MX record found`, expand-triangle `▷`, partial `vVersion — must be...`). Two root causes:

1. **Generic meta description** — Google ignored ours and made up a worse one from body extraction.
2. **Indiscriminate indexing of arbitrary scan pages** — every user-submitted scan was crawlable, but per-scan pages can't really win SERPs (results vary, content is dynamic) and there's no query-intent signal.

This PR addresses both, plus turns the sitemap into a small acquisition lever for branded "dmarc check {bigsite}" queries.

- Rewrites title/description for `/check` to lead with **"Free"** and **"open-source"** and drop scan-state details so Google prefers our description over body text:
  - Title: `${domain} DMARC report — Free check | dmarcheck`
  - Description: `Free, open-source DMARC, SPF, DKIM, BIMI, and MTA-STS check for ${domain}. See the current grade, records, and fixes. No signup, no email required.`
- Adds a curated allowlist in [src/shared/indexable-domains.ts](src/shared/indexable-domains.ts) of ~50 popular domains (major mail providers, big consumer brands, dev/SaaS, finance, news). Only those `/check?domain=…` pages stay indexable — everything else emits `<meta name="robots" content="noindex,follow">`.
- Sitemap is now generated from the same allowlist so on-page robots and the sitemap stay in sync (no more drift between the two).

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` — 740/740 passing, including new allowlist unit tests and `/check` meta + sitemap integration tests
- [x] Verified live in `npm run dev`:
  - Allowlisted `/check?domain=github.com` → no `robots` meta, new title + description present
  - Non-allowlisted `/check?domain=example.com` → `noindex,follow` emitted, same title/description
  - Final rendered report (`X-Scan-Fetch: 1`) matches the streaming-loading page meta on both branches
  - `/sitemap.xml` enumerates all curated domains (gmail, outlook, github, stripe, etc.) and excludes arbitrary domains

🤖 Generated with [Claude Code](https://claude.com/claude-code)