### PR TITLE
fix(webhooks): parallelize bulk fan-out to stop false-timeout reports

### DIFF
--- a/src/webhooks/triggers.ts
+++ b/src/webhooks/triggers.ts
@@ -33,25 +33,44 @@ export async function fireScanCompletedWebhook(
   }
 }
 
+// Bounded concurrency so a 30-domain bulk doesn't hit a single chat receiver
+// with 30 simultaneous POSTs. Mirrors `BULK_BATCH_SIZE` in api/bulk-scan.
+const WEBHOOK_BATCH_SIZE = 10;
+
 // Fires one `scan.completed` event per successfully-scanned entry in a bulk
-// outcome. Best-effort and serial — callers should hand this to `waitUntil`
-// so it never blocks the response. Queued/invalid/error entries are skipped
-// (no scan happened, nothing to report).
+// outcome. Best-effort and bounded-parallel — callers should hand this to
+// `waitUntil` so it never blocks the response. Queued/invalid/error entries
+// are skipped (no scan happened, nothing to report).
+//
+// Parallel matters: a serial loop over N webhooks accumulates wall-clock
+// time inside the waitUntil budget. Once the runtime decides to recycle the
+// isolate, every pending fetch is aborted with the literal "operation
+// aborted due to timeout" message — including ones whose request bytes
+// already left and were acked by the chat platform. Batching keeps total
+// wall-clock under budget while still capping the burst per receiver.
 export async function fireBulkScanWebhooks(
   db: D1Database,
   userId: string,
   results: BulkResultEntry[],
   trigger: ScanCompletedData["trigger"],
 ): Promise<void> {
-  for (const entry of results) {
-    if (entry.status !== "scanned" || !entry.grade) continue;
-    await fireScanCompletedWebhook(db, userId, {
-      domain: entry.domain,
-      grade: entry.grade,
-      // Bulk scans don't surface a stable scan_history.id; receivers can
-      // re-fetch by domain via /api/domain/:name/history.
-      scanId: entry.domain,
-      trigger,
-    });
+  const toFire = results.filter(
+    (entry): entry is BulkResultEntry & { grade: string } =>
+      entry.status === "scanned" && !!entry.grade,
+  );
+  for (let i = 0; i < toFire.length; i += WEBHOOK_BATCH_SIZE) {
+    const batch = toFire.slice(i, i + WEBHOOK_BATCH_SIZE);
+    await Promise.allSettled(
+      batch.map((entry) =>
+        fireScanCompletedWebhook(db, userId, {
+          domain: entry.domain,
+          grade: entry.grade,
+          // Bulk scans don't surface a stable scan_history.id; receivers can
+          // re-fetch by domain via /api/domain/:name/history.
+          scanId: entry.domain,
+          trigger,
+        }),
+      ),
+    );
   }
 }

--- a/test/webhooks-triggers.test.ts
+++ b/test/webhooks-triggers.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { BulkResultEntry } from "../src/api/bulk-scan.js";
+
+const dispatchWebhookMock = vi.fn();
+vi.mock("../src/webhooks/dispatcher.js", () => ({
+  dispatchWebhook: dispatchWebhookMock,
+}));
+
+// Imported after the mock so the trigger module sees the mocked dispatcher.
+const { fireBulkScanWebhooks, fireScanCompletedWebhook } = await import(
+  "../src/webhooks/triggers.js"
+);
+
+beforeEach(() => {
+  dispatchWebhookMock.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const fakeDb = {} as D1Database;
+
+describe("webhooks/triggers.fireScanCompletedWebhook", () => {
+  it("forwards a scan.completed event with the canonical report URL", async () => {
+    dispatchWebhookMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      error: null,
+      attempted_at: 0,
+      event_id: "evt_x",
+    });
+
+    await fireScanCompletedWebhook(fakeDb, "u1", {
+      domain: "example.com",
+      grade: "A",
+      scanId: 42,
+      trigger: "cron",
+    });
+
+    expect(dispatchWebhookMock).toHaveBeenCalledTimes(1);
+    const [, userId, event] = dispatchWebhookMock.mock.calls[0];
+    expect(userId).toBe("u1");
+    expect(event).toMatchObject({
+      type: "scan.completed",
+      data: {
+        domain: "example.com",
+        grade: "A",
+        scan_id: 42,
+        trigger: "cron",
+        report_url: "https://dmarc.mx/check?domain=example.com",
+      },
+    });
+  });
+
+  it("swallows dispatcher errors so the caller's waitUntil cannot crash", async () => {
+    dispatchWebhookMock.mockRejectedValue(new Error("network down"));
+    await expect(
+      fireScanCompletedWebhook(fakeDb, "u1", {
+        domain: "example.com",
+        grade: "B",
+        scanId: 1,
+        trigger: "dashboard",
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("webhooks/triggers.fireBulkScanWebhooks", () => {
+  it("fires only on entries with status 'scanned'", async () => {
+    dispatchWebhookMock.mockResolvedValue(null);
+    const results: BulkResultEntry[] = [
+      { domain: "ok.com", status: "scanned", grade: "A" },
+      { domain: "queued.com", status: "queued" },
+      { domain: "bad input", status: "invalid", error: "Not a valid domain" },
+      { domain: "boom.com", status: "error", error: "Scan failed" },
+    ];
+
+    await fireBulkScanWebhooks(fakeDb, "u1", results, "dashboard");
+
+    expect(dispatchWebhookMock).toHaveBeenCalledTimes(1);
+    const event = dispatchWebhookMock.mock.calls[0][2];
+    expect(event.data.domain).toBe("ok.com");
+    expect(event.data.grade).toBe("A");
+  });
+
+  // The point of the fan-out test is to lock in the fix for issue #186: a
+  // serial loop over 25+ webhooks blows the waitUntil budget and the runtime
+  // aborts every pending fetch with the literal message
+  // "The operation was aborted due to timeout" — even though the chat
+  // platform already received and acked the message. Parallel fan-out keeps
+  // total wall-clock under budget.
+  it("dispatches webhooks concurrently rather than one-at-a-time", async () => {
+    let active = 0;
+    let maxActive = 0;
+    dispatchWebhookMock.mockImplementation(async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      // Yield enough times that every queued dispatcher invocation can
+      // observe the increment before any of them resolves.
+      for (let i = 0; i < 5; i++) {
+        await Promise.resolve();
+      }
+      active--;
+      return {
+        ok: true,
+        status: 200,
+        error: null,
+        attempted_at: 0,
+        event_id: "evt",
+      };
+    });
+
+    const results: BulkResultEntry[] = Array.from({ length: 8 }, (_, i) => ({
+      domain: `e${i}.com`,
+      status: "scanned",
+      grade: "A",
+    }));
+
+    await fireBulkScanWebhooks(fakeDb, "u1", results, "bulk_api");
+
+    expect(dispatchWebhookMock).toHaveBeenCalledTimes(8);
+    // 8 entries fit inside one batch (batch size is 10), so all 8 dispatches
+    // should be in flight simultaneously. A weaker `> 1` would still pass
+    // under accidental serialization (e.g. batch size = 2) and miss the
+    // regression we want to lock in.
+    expect(maxActive).toBe(8);
+  });
+
+  it("does not propagate rejections from a failing dispatch", async () => {
+    dispatchWebhookMock.mockRejectedValue(new Error("network down"));
+    const results: BulkResultEntry[] = [
+      { domain: "a.com", status: "scanned", grade: "A" },
+      { domain: "b.com", status: "scanned", grade: "B" },
+    ];
+
+    await expect(
+      fireBulkScanWebhooks(fakeDb, "u1", results, "dashboard"),
+    ).resolves.toBeUndefined();
+    expect(dispatchWebhookMock).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Bulk webhook fan-out (`fireBulkScanWebhooks`) ran serially inside `c.executionCtx.waitUntil`. Across N domains the cumulative wall-clock blew the runtime's budget; once the isolate recycled, every pending fetch was aborted with the literal `AbortSignal.timeout` message — including ones whose bytes were already on the wire and acked by the chat platform. Operator received the messages, dashboard showed every row as ✗.
- Batch the dispatch with `Promise.allSettled` of 10, matching the scan fan-out in `processBulkScan`. Total wall-clock for a 30-domain bulk drops from ~30s to ~3–5s, well inside the budget.
- New `test/webhooks-triggers.test.ts` covers the trigger module (no coverage previously), including a regression test that asserts all dispatches inside one batch are in flight simultaneously.

## Scope

Closes the reproducer in #186 (every-row-fails on bulk-add). The rarer hypothesis — a single chat platform genuinely takes >5s and the per-call `AbortSignal.timeout(5000)` fires after the request was already received — still surfaces the same misleading dashboard message; it's not addressed here and can be labeled distinctly from transport errors as a follow-up if it shows up in practice once the every-row mode is gone. Keeping this PR focused per the launch-plan brief.

Cron path (`src/cron/rescan.ts:130`) was checked: it already batches `rescanOne` calls in `Promise.allSettled` of 25, so per-domain webhooks fan out concurrently across the batch. No change needed there.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` — 733/733 pass, including the new file's 5 tests
- [x] Regression test: with the serial loop, the new concurrency assertion fails (`maxActive=1`); after the fix it observes `maxActive=8`
- [ ] After merge, watch `/dashboard/settings` deliveries on the next bulk-add to confirm the every-row-fails mode is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)