### PR TITLE
feat(billing): enforce free (3) and Pro (25) watchlist domain caps

### DIFF
--- a/src/api/bulk-scan.ts
+++ b/src/api/bulk-scan.ts
@@ -1,7 +1,13 @@
-import { createDomain, getDomainByUserAndName } from "../db/domains.js";
+import {
+  countDomainsByUser,
+  createDomain,
+  findExistingDomainsForUser,
+  getDomainByUserAndName,
+} from "../db/domains.js";
 import { recordScan } from "../db/scans.js";
 import { scan as defaultScan } from "../orchestrator.js";
 import { normalizeDomain } from "../shared/domain.js";
+import { PRO_WATCHLIST_CAP } from "../shared/limits.js";
 
 // Phase 4c — bulk scan core. Two callers (POST /api/bulk-scan with bearer
 // auth, POST /dashboard/bulk with session auth) share this logic; both must
@@ -46,6 +52,12 @@ export interface ProcessBulkScanInput {
   // Knobs for tests; defaults match the production caps above.
   inBandCap?: number;
   batchSize?: number;
+  // Plan-based watchlist cap. Net-new domains beyond `cap - currentCount`
+  // are returned as error rows tagged "Watchlist limit reached" rather than
+  // silently inserted. Re-submits of domains the user already owns don't
+  // consume slots. Defaults to PRO_WATCHLIST_CAP because both bulk callers
+  // are Pro-only.
+  watchlistCap?: number;
 }
 
 export interface BulkCapExceededError {
@@ -110,8 +122,36 @@ export async function processBulkScan(
     valid.push(normalized);
   }
 
-  const inBand = valid.slice(0, inBandCap);
-  const queued = valid.slice(inBandCap);
+  // Watchlist-cap enforcement. Pre-lookup which submitted domains the user
+  // already owns so a user near their cap can still re-scan tracked domains
+  // without seeing them rejected. Net-new domains past the remaining slots
+  // become error rows the caller surfaces row-by-row.
+  const cap = input.watchlistCap ?? PRO_WATCHLIST_CAP;
+  const currentCount = await countDomainsByUser(input.db, input.userId);
+  const existingSet = await findExistingDomainsForUser(
+    input.db,
+    input.userId,
+    valid,
+  );
+  const repeatDomains: string[] = [];
+  const newDomains: string[] = [];
+  for (const d of valid) {
+    if (existingSet.has(d)) repeatDomains.push(d);
+    else newDomains.push(d);
+  }
+  const remainingSlots = Math.max(0, cap - currentCount);
+  const acceptedNew = newDomains.slice(0, remainingSlots);
+  const capRejected: BulkResultEntry[] = newDomains
+    .slice(remainingSlots)
+    .map((d) => ({
+      domain: d,
+      status: "error",
+      error: "Watchlist limit reached",
+    }));
+  const accepted = [...repeatDomains, ...acceptedNew];
+
+  const inBand = accepted.slice(0, inBandCap);
+  const queued = accepted.slice(inBandCap);
 
   const inBandResults: BulkResultEntry[] = [];
   for (let i = 0; i < inBand.length; i += batchSize) {
@@ -148,14 +188,20 @@ export async function processBulkScan(
     }
   }
 
-  // Stable order: invalid first (so the user sees them), then in-band, then
-  // queued. This matches what the dashboard form will render top-to-bottom.
-  const results = [...invalidResults, ...inBandResults, ...queuedResults];
-  const accepted = results.filter(
+  // Stable order: invalid first (so the user sees them), then in-band,
+  // then queued, then cap-rejected last. This matches what the dashboard
+  // form will render top-to-bottom and keeps the over-cap rows together.
+  const results = [
+    ...invalidResults,
+    ...inBandResults,
+    ...queuedResults,
+    ...capRejected,
+  ];
+  const acceptedCount = results.filter(
     (r) => r.status === "scanned" || r.status === "queued",
   ).length;
-  const rejected = results.length - accepted;
-  return { accepted, rejected, results };
+  const rejectedCount = results.length - acceptedCount;
+  return { accepted: acceptedCount, rejected: rejectedCount, results };
 }
 
 async function scanOne(

--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -20,6 +20,7 @@ import {
   revokeApiKey,
 } from "../db/api-keys.js";
 import {
+  countDomainsByUser,
   createDomain,
   type DomainSortColumn,
   type DomainSortDirection,
@@ -38,6 +39,7 @@ import {
 import { getRecentDeliveriesForUser } from "../db/webhook-deliveries.js";
 import { scan } from "../orchestrator.js";
 import { normalizeDomain } from "../shared/domain.js";
+import { PRO_WATCHLIST_CAP, watchlistCapForPlan } from "../shared/limits.js";
 import {
   renderAddDomainPage,
   renderApiKeysPage,
@@ -182,22 +184,33 @@ dashboardRoutes.get("/", async (c) => {
           unacknowledgedAlerts: unackCounts.get(d.id) ?? 0,
         })),
         controls: null,
+        usage: {
+          plan,
+          current: domains.length,
+          cap: watchlistCapForPlan(plan),
+        },
       }),
     );
   }
 
   const query = parseDomainListQuery(new URL(c.req.url));
   const offset = (query.page - 1) * query.pageSize;
-  const page = await listDomainsForUserPaged(db, {
-    userId: session.sub,
-    search: query.search || undefined,
-    grade: query.grade ?? undefined,
-    frequency: query.frequency ?? undefined,
-    sort: query.sort,
-    direction: query.direction,
-    limit: query.pageSize,
-    offset,
-  });
+  // Unfiltered watchlist count, separate from `page.total` (which respects
+  // the search/grade/frequency filters). The toolbar usage hint reflects
+  // the user's full watchlist regardless of what's currently filtered.
+  const [page, totalForUser] = await Promise.all([
+    listDomainsForUserPaged(db, {
+      userId: session.sub,
+      search: query.search || undefined,
+      grade: query.grade ?? undefined,
+      frequency: query.frequency ?? undefined,
+      sort: query.sort,
+      direction: query.direction,
+      limit: query.pageSize,
+      offset,
+    }),
+    countDomainsByUser(db, session.sub),
+  ]);
 
   // Clamp out-of-range pages so a deep-linked stale URL doesn't render an
   // empty table when results exist.
@@ -229,6 +242,11 @@ dashboardRoutes.get("/", async (c) => {
         pageSize: query.pageSize,
         totalPages,
         total: page.total,
+      },
+      usage: {
+        plan,
+        current: totalForUser,
+        cap: watchlistCapForPlan(plan),
       },
     }),
   );
@@ -315,9 +333,20 @@ dashboardRoutes.post("/alerts/:id/acknowledge", async (c) => {
 // Add-domain form. Simple GET → form; POST → validate + insert.
 // `/domain/add` is matched before `/domain/:domain` because Hono picks routes
 // in registration order for literal-vs-param collisions.
-dashboardRoutes.get("/domain/add", (c) => {
+dashboardRoutes.get("/domain/add", async (c) => {
   const session = c.get("user" as never) as SessionPayload;
-  return c.html(renderAddDomainPage({ email: session.email, error: null }));
+  const db = (c.env as { DB: D1Database }).DB;
+  const [plan, current] = await Promise.all([
+    getPlanForUser(db, session.sub),
+    countDomainsByUser(db, session.sub),
+  ]);
+  return c.html(
+    renderAddDomainPage({
+      email: session.email,
+      error: null,
+      usage: { plan, current, cap: watchlistCapForPlan(plan) },
+    }),
+  );
 });
 
 dashboardRoutes.post("/domain/add", async (c) => {
@@ -325,23 +354,42 @@ dashboardRoutes.post("/domain/add", async (c) => {
   const db = (c.env as { DB: D1Database }).DB;
   const body = await c.req.parseBody();
   const normalized = normalizeDomain(body.domain as string | undefined);
+  const [plan, currentCount] = await Promise.all([
+    getPlanForUser(db, session.sub),
+    countDomainsByUser(db, session.sub),
+  ]);
+  const cap = watchlistCapForPlan(plan);
+  const usage = { plan, current: currentCount, cap };
   if (!normalized) {
     return c.html(
       renderAddDomainPage({
         email: session.email,
         error: "Enter a valid domain (e.g. example.com).",
+        usage,
       }),
       400,
     );
   }
 
   // Prevent duplicates per-user cleanly rather than surfacing the raw
-  // UNIQUE(user_id, domain) constraint violation from D1.
+  // UNIQUE(user_id, domain) constraint violation from D1. Re-submits
+  // bypass the cap check below — they don't consume a new slot.
   const existing = await getDomainByUserAndName(db, session.sub, normalized);
   if (existing) {
     return c.redirect(
       `/dashboard/domain/${encodeURIComponent(normalized)}`,
       303,
+    );
+  }
+
+  if (currentCount >= cap) {
+    const error =
+      plan === "pro"
+        ? `You've reached the Pro plan limit of ${cap} domains. Email support@dmarc.mx if you need more.`
+        : `Free plan limit reached (${cap} domains). Upgrade to Pro for up to ${PRO_WATCHLIST_CAP}.`;
+    return c.html(
+      renderAddDomainPage({ email: session.email, error, usage }),
+      400,
     );
   }
 
@@ -401,6 +449,7 @@ dashboardRoutes.post("/bulk", async (c) => {
     db,
     userId: session.sub,
     rawDomains: lines,
+    watchlistCap: watchlistCapForPlan(plan),
   });
   if (isCapExceeded(outcome)) {
     return c.html(

--- a/src/db/domains.ts
+++ b/src/db/domains.ts
@@ -33,6 +33,37 @@ export async function getDomainsByUser(
   return result.results;
 }
 
+export async function countDomainsByUser(
+  db: D1Database,
+  userId: string,
+): Promise<number> {
+  const row = await db
+    .prepare("SELECT COUNT(*) AS n FROM domains WHERE user_id = ?")
+    .bind(userId)
+    .first<{ n: number }>();
+  return row?.n ?? 0;
+}
+
+// Returns the subset of `domains` that the user already owns. Used by
+// `processBulkScan` to distinguish net-new adds (which consume watchlist
+// slots) from re-submits (which don't), so a user near their cap can still
+// re-scan domains they already track without seeing them rejected.
+export async function findExistingDomainsForUser(
+  db: D1Database,
+  userId: string,
+  domains: string[],
+): Promise<Set<string>> {
+  if (domains.length === 0) return new Set();
+  const placeholders = domains.map(() => "?").join(",");
+  const result = await db
+    .prepare(
+      `SELECT domain FROM domains WHERE user_id = ? AND domain IN (${placeholders})`,
+    )
+    .bind(userId, ...domains)
+    .all<{ domain: string }>();
+  return new Set(result.results.map((r) => r.domain));
+}
+
 export type DomainSortColumn = "domain" | "grade" | "last_scanned" | "created";
 export type DomainSortDirection = "asc" | "desc";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ import {
 } from "./rate-limit.js";
 import { normalizeDomain } from "./shared/domain.js";
 import { listIndexableScanDomains } from "./shared/indexable-domains.js";
+import { watchlistCapForPlan } from "./shared/limits.js";
 import { CSS_PATH, JS_PATH } from "./views/assets.js";
 import {
   APPLE_TOUCH_ICON_BASE64,
@@ -904,6 +905,7 @@ app.post("/api/bulk-scan", async (c) => {
     db,
     userId: bearer.userId,
     rawDomains,
+    watchlistCap: watchlistCapForPlan(plan),
   });
   if (isCapExceeded(outcome)) {
     return c.json(

--- a/src/shared/limits.ts
+++ b/src/shared/limits.ts
@@ -1,0 +1,16 @@
+import type { PlanTier } from "../db/subscriptions.js";
+
+// Domain caps for the watchlist. The free cap is set low enough to drive
+// the upgrade path while still letting a new user feel out the dashboard
+// with real data; the Pro cap matches the figure advertised on /pricing
+// and in the README.
+//
+// Existing accounts that already exceed the cap (legacy power users from
+// before enforcement landed) are grandfathered — they keep their domains
+// but can't add new ones. The cap only constrains net-new additions.
+export const FREE_WATCHLIST_CAP = 3;
+export const PRO_WATCHLIST_CAP = 25;
+
+export function watchlistCapForPlan(plan: PlanTier): number {
+  return plan === "pro" ? PRO_WATCHLIST_CAP : FREE_WATCHLIST_CAP;
+}

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -908,9 +908,11 @@ function renderPagination(controls: DashboardControls): string {
 export function renderDomainPanel({
   domains,
   controls,
+  usage,
 }: {
   domains: DashboardDomain[];
   controls: DashboardControls | null;
+  usage?: WatchlistUsage;
 }): string {
   const isFiltered =
     controls !== null &&
@@ -978,10 +980,13 @@ export function renderDomainPanel({
   const toolbar = controls ? renderDomainToolbar(controls) : "";
   const pagination = controls ? renderPagination(controls) : "";
 
+  const usageHint = usage ? renderUsageHint(usage) : "";
+
   // data-pro="1" is the signal the client script uses to enable live
   // search/swap. Free users render the same wrapper so a future plan upgrade
   // doesn't need a markup migration, but the script bails out early.
   return `<div id="domain-panel" data-pro="${controls ? "1" : "0"}">
+${usageHint}
 ${toolbar}
 ${tableBody}
 ${pagination}
@@ -993,6 +998,7 @@ export function renderDashboardPage({
   alerts = [],
   domains,
   controls = null,
+  usage,
 }: {
   email: string;
   alerts?: DashboardAlert[];
@@ -1000,12 +1006,15 @@ export function renderDashboardPage({
   // Set only for Pro accounts; gates the search/sort/pagination UI.
   plan?: "free" | "pro";
   controls?: DashboardControls | null;
+  // Cap usage shown in the panel header. Optional so older callers (and
+  // the fragment route under live search) can omit it.
+  usage?: WatchlistUsage;
 }): string {
   return dashboardPage(
     "Domains — dmarc.mx",
     `<h1 class="dashboard-title">Your Domains</h1>
 ${renderAlertsSection(alerts)}
-${renderDomainPanel({ domains, controls })}`,
+${renderDomainPanel({ domains, controls, usage })}`,
     email,
   );
 }
@@ -1235,19 +1244,32 @@ ${upgradePrompt}
   return dashboardPage(`History — ${domain} — dmarc.mx`, body, email);
 }
 
+export interface WatchlistUsage {
+  plan: "free" | "pro";
+  current: number;
+  cap: number;
+}
+
 export function renderAddDomainPage({
   email,
   error,
+  usage,
 }: {
   email: string;
   error: string | null;
+  usage: WatchlistUsage;
 }): string {
   const errorBlock = error
     ? `<div class="settings-section" style="border-color:var(--clr-danger, #b91c1c);color:var(--clr-danger, #b91c1c)">${esc(error)}</div>`
     : "";
 
+  const usageBlock = renderUsageHint(usage);
+  const atCap = usage.current >= usage.cap;
+  const submitDisabled = atCap ? " disabled" : "";
+
   const body = `<h1 class="dashboard-title">Add Domain</h1>
 ${errorBlock}
+${usageBlock}
 <form method="POST" action="/dashboard/domain/add" class="settings-section">
   <label for="domain-input" style="display:block;font-size:0.875rem;color:var(--clr-text-muted);margin-bottom:0.4rem">Domain to monitor</label>
   <input
@@ -1267,12 +1289,33 @@ ${errorBlock}
     We'll run a full DMARC/SPF/DKIM/BIMI/MTA-STS scan and notify you if the grade drops.
   </p>
   <div class="action-row">
-    <button type="submit" class="btn">Add Domain</button>
+    <button type="submit" class="btn"${submitDisabled}>Add Domain</button>
     <a href="/dashboard" class="btn btn-secondary">Cancel</a>
   </div>
 </form>`;
 
   return dashboardPage("Add Domain — dmarc.mx", body, email);
+}
+
+// Shared "X of N domains used" hint shown above the add-domain form and
+// in the main dashboard's domain panel toolbar. Free plans get an upgrade
+// CTA, Pro plans show a contact pointer when at cap.
+export function renderUsageHint(usage: WatchlistUsage): string {
+  const atCap = usage.current >= usage.cap;
+  const planLabel = usage.plan === "pro" ? "Pro" : "Free";
+  const cta =
+    usage.plan === "free"
+      ? `<a href="/dashboard/billing/subscribe" style="color:var(--clr-accent);text-decoration:none">Upgrade →</a>`
+      : atCap
+        ? `<a href="mailto:support@dmarc.mx" style="color:var(--clr-accent);text-decoration:none">Contact support</a>`
+        : "";
+  const tone = atCap
+    ? "color:var(--clr-danger, #b91c1c);font-weight:600"
+    : "color:var(--clr-text-muted)";
+  return `<p class="watchlist-usage" style="font-size:0.875rem;margin:0 0 1rem;${tone}">
+  <span>${esc(String(usage.current))} of ${esc(String(usage.cap))} ${planLabel} domains used.</span>
+  ${cta}
+</p>`;
 }
 
 export interface BulkResultRow {

--- a/test/bulk-scan.test.ts
+++ b/test/bulk-scan.test.ts
@@ -36,6 +36,7 @@ function makeDb(): D1Database {
     params: unknown[];
     run: () => Promise<{ success: true; meta: { changes: number } }>;
     first: <T>() => Promise<T | null>;
+    all: <T>() => Promise<{ results: T[] }>;
   };
 
   const applyWrite = async (sql: string, params: unknown[]) => {
@@ -85,7 +86,30 @@ function makeDb(): D1Database {
           (d) => d.user_id === params[0] && d.domain === params[1],
         ) ?? null) as T | null;
       }
+      if (
+        /^\s*SELECT COUNT\(\*\) AS n FROM domains WHERE user_id = \?/i.test(sql)
+      ) {
+        const userId = params[0] as string;
+        return {
+          n: domainStore.filter((d) => d.user_id === userId).length,
+        } as T;
+      }
       return null as T | null;
+    },
+    all: async <T>() => {
+      if (
+        /^\s*SELECT domain FROM domains WHERE user_id = \? AND domain IN/i.test(
+          sql,
+        )
+      ) {
+        const [userId, ...wanted] = params as [string, ...string[]];
+        const wantedSet = new Set(wanted);
+        const rows = domainStore
+          .filter((d) => d.user_id === userId && wantedSet.has(d.domain))
+          .map((d) => ({ domain: d.domain }));
+        return { results: rows as T[] };
+      }
+      return { results: [] as T[] };
     },
   });
 
@@ -178,6 +202,9 @@ describe("processBulkScan", () => {
       scanFn,
       inBandCap: 30,
       batchSize: 10,
+      // Watchlist cap raised so this test exercises inBandCap → queued
+      // behavior without colliding with the watchlist limit (default 25).
+      watchlistCap: 1000,
     });
     if (isCapExceeded(out)) throw new Error("unexpected cap");
     expect(out.accepted).toBe(35);
@@ -279,11 +306,101 @@ describe("processBulkScan", () => {
       rawDomains: submitted,
       scanFn,
       batchSize: 10,
+      // Same intent as the queued test above — exercise inBandCap, not the
+      // watchlist cap.
+      watchlistCap: 1000,
     });
     if (isCapExceeded(out)) throw new Error("unexpected cap");
     expect(out.accepted).toBe(BULK_IN_BAND_CAP);
     expect(scanFn).toHaveBeenCalledTimes(BULK_IN_BAND_CAP);
     expect(out.results.every((r) => r.status === "scanned")).toBe(true);
+  });
+
+  describe("watchlist cap enforcement", () => {
+    it("rejects net-new domains beyond the remaining slots as 'Watchlist limit reached'", async () => {
+      const scanFn = vi.fn(async (d: string) => okScan(d));
+      const out = await processBulkScan({
+        db: makeDb(),
+        userId: "user_1",
+        rawDomains: ["a.example", "b.example", "c.example", "d.example"],
+        scanFn,
+        watchlistCap: 2,
+      });
+      if (isCapExceeded(out)) throw new Error("unexpected cap");
+      const scanned = out.results.filter((r) => r.status === "scanned");
+      const rejected = out.results.filter(
+        (r) => r.status === "error" && r.error === "Watchlist limit reached",
+      );
+      expect(scanned).toHaveLength(2);
+      expect(rejected.map((r) => r.domain)).toEqual(["c.example", "d.example"]);
+      expect(scanFn).toHaveBeenCalledTimes(2);
+      expect(domainStore).toHaveLength(2);
+    });
+
+    it("rejects everything new when the user is already at or above cap (grandfathered)", async () => {
+      // Grandfathered Pro user already over a tighter cap.
+      for (let i = 0; i < 5; i++) {
+        domainStore.push({
+          id: i + 1,
+          user_id: "user_1",
+          domain: `legacy${i}.example`,
+          is_free: 0,
+          scan_frequency: "weekly",
+          last_scanned_at: 1700000000,
+          last_grade: "A",
+        });
+      }
+      const scanFn = vi.fn(async (d: string) => okScan(d));
+      const out = await processBulkScan({
+        db: makeDb(),
+        userId: "user_1",
+        rawDomains: ["new1.example", "new2.example"],
+        scanFn,
+        watchlistCap: 3,
+      });
+      if (isCapExceeded(out)) throw new Error("unexpected cap");
+      const rejected = out.results.filter(
+        (r) => r.status === "error" && r.error === "Watchlist limit reached",
+      );
+      expect(rejected.map((r) => r.domain)).toEqual([
+        "new1.example",
+        "new2.example",
+      ]);
+      expect(scanFn).not.toHaveBeenCalled();
+      // Existing rows preserved — grandfather behavior.
+      expect(domainStore).toHaveLength(5);
+    });
+
+    it("re-scans domains the user already owns even when at cap (slots not consumed)", async () => {
+      domainStore.push({
+        id: 1,
+        user_id: "user_1",
+        domain: "owned.example",
+        is_free: 0,
+        scan_frequency: "weekly",
+        last_scanned_at: 1700000000,
+        last_grade: "A",
+      });
+      const scanFn = vi.fn(async (d: string) => okScan(d));
+      const out = await processBulkScan({
+        db: makeDb(),
+        userId: "user_1",
+        rawDomains: ["owned.example", "newly.example"],
+        scanFn,
+        watchlistCap: 1,
+      });
+      if (isCapExceeded(out)) throw new Error("unexpected cap");
+      const scanned = out.results.filter((r) => r.status === "scanned");
+      const rejected = out.results.filter(
+        (r) => r.status === "error" && r.error === "Watchlist limit reached",
+      );
+      // Re-scan of the existing domain succeeds despite cap == current count;
+      // only the net-new domain is rejected.
+      expect(scanned.map((r) => r.domain)).toEqual(["owned.example"]);
+      expect(rejected.map((r) => r.domain)).toEqual(["newly.example"]);
+      // No new row inserted.
+      expect(domainStore).toHaveLength(1);
+    });
   });
 
   it("returns empty results for an empty submission", async () => {

--- a/test/dashboard-routes.test.ts
+++ b/test/dashboard-routes.test.ts
@@ -1621,6 +1621,141 @@ describe("dashboard/routes", () => {
       );
       expect(inserted?.bindings[1]).toBe("example.com");
     });
+
+    it("rejects net-new domain with 400 when a free user is at the cap", async () => {
+      const seedDomains = Array.from({ length: 3 }, (_, i) => ({
+        id: i + 1,
+        user_id: "user_1",
+        domain: `seed${i}.example`,
+        is_free: 0,
+        scan_frequency: "weekly",
+        last_scanned_at: null,
+        last_grade: null,
+        created_at: 1_700_000_000,
+      }));
+      const writes: Array<{ sql: string; bindings: unknown[] }> = [];
+      const db = createMockDB({ domains: seedDomains, writes });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const body = new URLSearchParams({ domain: "newdomain.example" });
+      const res = await app.request("/dashboard/domain/add", {
+        method: "POST",
+        headers: {
+          Cookie: cookie,
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: body.toString(),
+      });
+      expect(res.status).toBe(400);
+      const html = await res.text();
+      expect(html).toMatch(/Free plan limit reached/);
+      expect(html).toMatch(/Upgrade to Pro/);
+      const inserted = writes.find((w) =>
+        w.sql.includes("INSERT INTO domains"),
+      );
+      expect(inserted).toBeUndefined();
+    });
+
+    it("rejects net-new domain with 400 when a Pro user is at the cap", async () => {
+      // Pro user already at the cap of 25.
+      const seedDomains = Array.from({ length: 25 }, (_, i) => ({
+        id: i + 1,
+        user_id: "user_1",
+        domain: `seed${i}.example`,
+        is_free: 0,
+        scan_frequency: "weekly",
+        last_scanned_at: null,
+        last_grade: null,
+        created_at: 1_700_000_000,
+      }));
+      const writes: Array<{ sql: string; bindings: unknown[] }> = [];
+      const db = createMockDB({
+        domains: seedDomains,
+        subscriptions: [{ user_id: "user_1", status: "active" }],
+        writes,
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const body = new URLSearchParams({ domain: "overflow.example" });
+      const res = await app.request("/dashboard/domain/add", {
+        method: "POST",
+        headers: {
+          Cookie: cookie,
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: body.toString(),
+      });
+      expect(res.status).toBe(400);
+      const html = await res.text();
+      expect(html).toMatch(/Pro plan limit of 25 domains/);
+      expect(html).toContain("support@dmarc.mx");
+      const inserted = writes.find((w) =>
+        w.sql.includes("INSERT INTO domains"),
+      );
+      expect(inserted).toBeUndefined();
+    });
+
+    it("still redirects to the existing domain detail page for a duplicate even when at cap", async () => {
+      // Grandfather: a free user already over cap can still re-visit
+      // existing domains via the duplicate-redirect path. Net-new is what
+      // gets blocked.
+      const seedDomains = Array.from({ length: 5 }, (_, i) => ({
+        id: i + 1,
+        user_id: "user_1",
+        domain: `seed${i}.example`,
+        is_free: 0,
+        scan_frequency: "weekly",
+        last_scanned_at: null,
+        last_grade: null,
+        created_at: 1_700_000_000,
+      }));
+      const writes: Array<{ sql: string; bindings: unknown[] }> = [];
+      const db = createMockDB({ domains: seedDomains, writes });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const body = new URLSearchParams({ domain: "seed0.example" });
+      const res = await app.request("/dashboard/domain/add", {
+        method: "POST",
+        headers: {
+          Cookie: cookie,
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: body.toString(),
+      });
+      expect(res.status).toBe(303);
+      expect(res.headers.get("Location")).toBe(
+        "/dashboard/domain/seed0.example",
+      );
+      const inserted = writes.find((w) =>
+        w.sql.includes("INSERT INTO domains"),
+      );
+      expect(inserted).toBeUndefined();
+    });
+
+    it("renders the add-domain form with usage hint for a free user under cap", async () => {
+      const db = createMockDB({
+        domains: [
+          {
+            id: 1,
+            user_id: "user_1",
+            domain: "first.example",
+            is_free: 0,
+            scan_frequency: "weekly",
+            last_scanned_at: null,
+            last_grade: null,
+            created_at: 1_700_000_000,
+          },
+        ],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/domain/add", {
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toMatch(/1 of 3 Free domains used/);
+    });
   });
 
   describe("POST /dashboard/domain/:domain/delete", () => {
@@ -1937,9 +2072,10 @@ describe("dashboard/routes", () => {
       });
       const app = createTestApp(db);
       const cookie = await makeSessionCookie("user_1", "alice@example.com");
-      // 32 valid domains → 30 scanned, 2 queued.
+      // 27 valid domains, Pro cap = 25 → 25 scanned, 2 over-cap rejected.
+      // Stays under inBandCap (30) so we don't mix with queued behavior.
       const inputDomains = Array.from(
-        { length: 32 },
+        { length: 27 },
         (_, i) => `d${i}.example`,
       ).join("\n");
       const body = new URLSearchParams({ domains: inputDomains });
@@ -1954,9 +2090,9 @@ describe("dashboard/routes", () => {
       expect(res.status).toBe(200);
       const html = await res.text();
       expect(html).toContain('class="bulk-status scanned"');
-      expect(html).toContain('class="bulk-status queued"');
       expect(html).toContain("Results");
-      expect(html).toMatch(/32 submitted/);
+      expect(html).toMatch(/27 submitted/);
+      expect(html).toContain("Watchlist limit reached");
     });
 
     it("returns 400 when more than 100 domains are submitted", async () => {


### PR DESCRIPTION
## Summary

- New `src/shared/limits.ts` defines `FREE_WATCHLIST_CAP = 3`, `PRO_WATCHLIST_CAP = 25`, and `watchlistCapForPlan(plan)` so every enforcement point reads the same numbers.
- `POST /dashboard/domain/add` now loads the user's plan + current count and 400s with a plan-specific message when net-new domains would exceed the cap. Duplicate-redirect to an existing domain still works at cap (re-visits don't consume a slot — deliberate).
- `processBulkScan` (used by both `POST /dashboard/bulk` and `POST /api/bulk-scan`) takes a `watchlistCap` parameter, splits valid submissions into existing-vs-new via a single `SELECT … WHERE user_id = ? AND domain IN (…)`, trims net-new to the remaining slots, and surfaces excess as `error` rows tagged "Watchlist limit reached". Re-scans of already-owned domains pass through untrimmed.
- Add-domain form shows "X of N {plan} domains used" with an Upgrade link (free) or Contact-support link (Pro), and disables the submit button at cap. Pro dashboard toolbar gets the same usage hint above the table; free dashboard renders it inline above the simple list.

Closes [#187](https://github.com/schmug/dmarcheck/issues/187) and [#188](https://github.com/schmug/dmarcheck/issues/188).

## Decisions baked in

- **Free cap = 3** (per user direction). Tight enough to drive the upgrade path; loose enough to demo the dashboard with a real list.
- **Soft grandfather**: existing accounts above the cap (legacy free or the user's own 344-domain test Pro account) keep every domain. The cap only blocks net-new adds. Less surprising for paying customers; matches the recommendation in #187.
- **Duplicate-redirect bypasses the cap**: a user at cap who types a domain they already own gets redirected to the detail page, not an error. Re-visits aren't net-new and were never going to consume a slot.
- **Per-call cap parameter, not a global lookup**: `processBulkScan` accepts `watchlistCap` from each route rather than calling `getPlanForUser` itself. Both bulk routes already load the plan for the 402-gate; passing it in keeps the function pure and tests easy.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` — 735/735 pass, including 7 new tests:
  - `POST /domain/add` rejects 400 when free user is at cap (Upgrade copy)
  - `POST /domain/add` rejects 400 when Pro user is at cap (support@ copy)
  - `POST /domain/add` still 303-redirects on duplicate at cap (grandfather behavior)
  - `GET /domain/add` renders "X of N Free domains used" usage hint
  - `processBulkScan` trims net-new beyond remaining slots into "Watchlist limit reached" rows
  - `processBulkScan` rejects all net-new for grandfathered (over-cap) accounts
  - `processBulkScan` re-scans already-owned domains even when at cap (slots not consumed)
- [x] Live UI verification via standalone render of `renderAddDomainPage` + `renderDashboardPage` in all four states (under-cap, free-at-cap, pro-at-cap, dashboard-with-hint). Confirmed: usage hint switches from muted gray to danger red at cap, submit button disabled with opacity 0.6, error copy differentiates Free vs Pro correctly.

## Out of scope

The bulk-add edge case where a user near the cap re-submits some domains they already own is now handled correctly (existing-vs-new pre-lookup). No deferred follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)