### PR TITLE
feat(staging): scaffold staging.dmarc.mx environment (PR-A of #195)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,6 +6,12 @@
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev"],
       "port": 8790
+    },
+    {
+      "name": "wrangler-dev-staging",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["wrangler", "dev", "--env", "staging", "--port", "8792", "--local"],
+      "port": 8792
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,15 @@ Live at dmarc.mx | Repo: github.com/schmug/dmarcheck
 - Mock DNS client for unit tests (`vi.mock`)
 - Test scoring boundaries and analyzer parsing
 
+## Staging
+
+- `staging.dmarc.mx` runs the same Worker code as prod against a separate D1 (`dmarcheck-db-staging`), a WorkOS sandbox, separate Stripe **test-mode** webhook endpoint, and a distinct `SESSION_SECRET`. Configured via `[env.staging]` in `wrangler.toml`.
+- The staging worker has `IS_STAGING = "1"` set as a var. That flag drives a sticky red banner on every HTML response, an injected `<meta name="robots" content="noindex,nofollow">`, and `/robots.txt` flipping to `Disallow: /`.
+- Sentry events from staging are tagged `environment=staging` with `tracesSampler` cranked to 1.0 (everything is interesting on staging).
+- Staging has **no cron triggers** — it exists for migration smoke tests and manual e2e, not for nightly rescans.
+- Deployment: a single Cloudflare Workers Builds connection on `main` runs the production deploy command `npx wrangler deploy --env staging && curl -fsS https://staging.dmarc.mx/health && npx wrangler deploy`. Staging deploys first; prod follows only if staging built cleanly and `/health` returns 200.
+- Staging is not public-facing — don't link to it from prod, and respond to bug reports against `staging.dmarc.mx` URLs by asking for a repro on dmarc.mx.
+
 ## Releases
 
 - Automated via GitHub Actions on push to main (after CI passes)

--- a/src/env.ts
+++ b/src/env.ts
@@ -21,4 +21,9 @@ export interface Env {
   // but lives here so self-host forks don't accidentally ship data to the
   // hosted tier's dashboard.
   CF_ANALYTICS_TOKEN?: string;
+  // Set to "1" on the staging worker via wrangler.toml `[env.staging.vars]`.
+  // Toggles a STAGING banner + noindex meta on every HTML response, returns
+  // Disallow: / from /robots.txt, and tags Sentry events with
+  // environment=staging at sample rate 1.0.
+  IS_STAGING?: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ import { recordScan } from "./db/scans.js";
 import { getPlanForUser } from "./db/subscriptions.js";
 import { setEmailAlertsEnabled } from "./db/users.js";
 import type { Env } from "./env.js";
+import { isStaging, stagingMarker } from "./middleware/staging-marker.js";
 import type { ProtocolId, ProtocolResult } from "./orchestrator.js";
 import { scan, scanStreaming } from "./orchestrator.js";
 import {
@@ -102,6 +103,10 @@ import { fireBulkScanWebhooks } from "./webhooks/triggers.js";
 // Runtime Workers use the Sentry-wrapped default export below, which adds
 // cron (`scheduled`) alongside `fetch`.
 export const app = new Hono<{ Bindings: Env }>();
+
+// Staging marker — runs first so the noindex/banner injection wraps the
+// final HTML response after every other middleware has set headers.
+app.use("*", stagingMarker);
 
 // Set Sentry scope context for every request
 app.use("*", async (c, next) => {
@@ -710,9 +715,14 @@ app.get("/docs/api", (c) => {
 
 // Crawl guidance for search engines. Block the API namespace (Google was
 // logging `/api/check?domain=dmarc.mx` as "Crawled - currently not indexed"
-// noise) and point to the sitemap.
+// noise) and point to the sitemap. The staging worker serves a Disallow-all
+// instead so the non-public URL doesn't get indexed if it ever leaks.
 app.get("/robots.txt", (c) => {
-  const body = `User-agent: *
+  const body = isStaging(c.env)
+    ? `User-agent: *
+Disallow: /
+`
+    : `User-agent: *
 Allow: /
 Disallow: /api/
 Sitemap: https://dmarc.mx/sitemap.xml
@@ -1228,14 +1238,20 @@ const handler: ExportedHandler<Env> = {
   scheduled,
 };
 
-export default Sentry.withSentry<Env>(
-  (env) => ({
+export default Sentry.withSentry<Env>((env) => {
+  const staging = env?.IS_STAGING === "1";
+  return {
     dsn: env?.SENTRY_DSN ?? "",
-    tracesSampler: (samplingContext: { parentSampled?: boolean }) => {
-      if (samplingContext.parentSampled !== undefined)
-        return samplingContext.parentSampled;
-      return 0.3;
-    },
-  }),
-  handler,
-);
+    // Staging gets its own bucket so prod alerts aren't polluted by
+    // pre-promotion noise. Sample rate cranked to 1.0 — every staging
+    // event is interesting.
+    environment: staging ? "staging" : "production",
+    tracesSampler: staging
+      ? () => 1.0
+      : (samplingContext: { parentSampled?: boolean }) => {
+          if (samplingContext.parentSampled !== undefined)
+            return samplingContext.parentSampled;
+          return 0.3;
+        },
+  };
+}, handler);

--- a/src/middleware/staging-marker.ts
+++ b/src/middleware/staging-marker.ts
@@ -1,0 +1,39 @@
+import type { MiddlewareHandler } from "hono";
+import type { Env } from "../env.js";
+
+// Visible top-of-page ribbon + machine-readable noindex injected on every
+// HTML response from the staging worker. Lives as middleware so individual
+// view-render functions stay env-agnostic.
+const BANNER_HTML = `<div role="alert" data-staging-banner style="position:sticky;top:0;left:0;right:0;z-index:9999;background:#dc2626;color:#fff;text-align:center;padding:0.4rem 1rem;font-family:system-ui,sans-serif;font-size:0.85rem;font-weight:600;letter-spacing:0.02em;box-shadow:0 1px 4px rgba(0,0,0,0.3)">⚠ STAGING — not production. <a href="https://dmarc.mx" style="color:#fff;text-decoration:underline">Go to dmarc.mx</a></div>`;
+
+const NOINDEX_META = `<meta name="robots" content="noindex,nofollow">`;
+
+export function isStaging(env: Env | undefined): boolean {
+  return env?.IS_STAGING === "1";
+}
+
+// Hono middleware. Post-processes any HTML response when IS_STAGING=1:
+//   - injects a noindex,nofollow meta tag right after `<head>` (in addition
+//     to any per-page noindex already emitted by `page()`)
+//   - prepends a sticky red banner inside `<body>` so anyone visiting
+//     staging.dmarc.mx visually knows they aren't on prod
+// Non-HTML responses pass through untouched.
+export const stagingMarker: MiddlewareHandler<{ Bindings: Env }> = async (
+  c,
+  next,
+) => {
+  await next();
+  if (!isStaging(c.env)) return;
+  const ct = c.res.headers.get("content-type") ?? "";
+  if (!ct.toLowerCase().includes("text/html")) return;
+  const html = await c.res.text();
+  const stamped = html
+    .replace("<head>", `<head>\n${NOINDEX_META}`)
+    .replace("<body>", `<body>\n${BANNER_HTML}`);
+  // Hono's c.res is a getter/setter on a Response. Re-wrap with the same
+  // status + headers but the new body.
+  c.res = new Response(stamped, {
+    status: c.res.status,
+    headers: c.res.headers,
+  });
+};

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -696,6 +696,16 @@ describe("SEO routes", () => {
     const body = await res.text();
     expect(body).not.toContain("example.com");
   });
+
+  it("staging /robots.txt returns Disallow-all and no sitemap pointer", async () => {
+    const res = await app.request("/robots.txt", {}, { IS_STAGING: "1" });
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("User-agent: *");
+    expect(body).toContain("Disallow: /");
+    expect(body).not.toContain("Allow:");
+    expect(body).not.toContain("Sitemap:");
+  });
 });
 
 describe("/check meta tags and noindex gating", () => {

--- a/test/staging-marker.test.ts
+++ b/test/staging-marker.test.ts
@@ -1,0 +1,77 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import type { Env } from "../src/env.js";
+import { stagingMarker } from "../src/middleware/staging-marker.js";
+
+function makeApp(env: Partial<Env>) {
+  const app = new Hono<{ Bindings: Env }>();
+  app.use("*", stagingMarker);
+  app.get("/html", (c) =>
+    c.html(
+      "<!doctype html><html><head><title>x</title></head><body><p>x</p></body></html>",
+    ),
+  );
+  app.get("/json", (c) => c.json({ ok: true }));
+  app.get("/text", (c) => c.text("hello"));
+  return {
+    request: (path: string) =>
+      app.request(path, {}, env as unknown as Record<string, unknown>),
+  };
+}
+
+describe("middleware/staging-marker", () => {
+  it("injects the noindex meta and STAGING banner into HTML when IS_STAGING=1", async () => {
+    const { request } = makeApp({ IS_STAGING: "1" });
+    const res = await request("/html");
+    const body = await res.text();
+    expect(body).toContain('<meta name="robots" content="noindex,nofollow">');
+    expect(body).toContain("data-staging-banner");
+    expect(body).toContain("STAGING — not production");
+    expect(body.indexOf('<meta name="robots"')).toBeLessThan(
+      body.indexOf("</head>"),
+    );
+    expect(body.indexOf("data-staging-banner")).toBeGreaterThan(
+      body.indexOf("<body"),
+    );
+  });
+
+  it("does not modify HTML when IS_STAGING is unset (prod)", async () => {
+    const { request } = makeApp({});
+    const res = await request("/html");
+    const body = await res.text();
+    expect(body).not.toContain("noindex,nofollow");
+    expect(body).not.toContain("data-staging-banner");
+  });
+
+  it("does not modify HTML when IS_STAGING is '0' or any non-'1' value", async () => {
+    const { request } = makeApp({ IS_STAGING: "0" });
+    const res = await request("/html");
+    const body = await res.text();
+    expect(body).not.toContain("data-staging-banner");
+  });
+
+  it("leaves non-HTML responses untouched even on staging", async () => {
+    const { request } = makeApp({ IS_STAGING: "1" });
+    const json = await request("/json");
+    expect(await json.text()).toBe('{"ok":true}');
+    const text = await request("/text");
+    expect(await text.text()).toBe("hello");
+  });
+
+  it("preserves the original status code and headers", async () => {
+    const app = new Hono<{ Bindings: Env }>();
+    app.use("*", stagingMarker);
+    app.get("/notfound", (c) =>
+      c.html("<!doctype html><html><body>nope</body></html>", 404, {
+        "X-Custom": "yes",
+      }),
+    );
+    const res = await app.request("/notfound", {}, {
+      IS_STAGING: "1",
+    } as unknown as Record<string, unknown>);
+    expect(res.status).toBe(404);
+    expect(res.headers.get("X-Custom")).toBe("yes");
+    const body = await res.text();
+    expect(body).toContain("data-staging-banner");
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -29,3 +29,35 @@ migrations_dir = "src/db/migrations"
 [[send_email]]
 name = "EMAIL"
 allowed_sender_addresses = ["alerts@dmarc.mx"]
+
+# Staging environment. Mirrors prod with three deliberate differences:
+#   - separate D1 (dmarcheck-db-staging) so migrations land here first
+#   - no cron triggers (staging is for migration smoke + manual e2e only)
+#   - IS_STAGING=1 surfaces a noindex meta tag, a STAGING banner, and tags
+#     Sentry events with environment=staging at sample rate 1.0
+#
+# Deployment pattern: a single Cloudflare Workers Builds connection on main
+# runs `wrangler deploy --env staging` first, then a /health smoke check,
+# then `wrangler deploy` for prod. See README "Deployment" for the
+# production-branch deploy-command string.
+[env.staging]
+name = "dmarcheck-staging"
+routes = [
+  { pattern = "staging.dmarc.mx", custom_domain = true },
+]
+
+[env.staging.vars]
+IS_STAGING = "1"
+
+[[env.staging.d1_databases]]
+binding = "DB"
+database_name = "dmarcheck-db-staging"
+database_id = "8f1e2627-1a4b-43f2-87c3-8acf2792128c"
+migrations_dir = "src/db/migrations"
+
+# Mirror the prod email binding so the dispatcher's no-op-on-unverified-sender
+# fallback is the only thing that fires on staging unless a sender is
+# explicitly verified for the staging worker.
+[[env.staging.send_email]]
+name = "EMAIL"
+allowed_sender_addresses = ["alerts@dmarc.mx"]


### PR DESCRIPTION
First half of [#195](https://github.com/schmug/dmarcheck/issues/195). Adds the staging worker config, env-aware behavior (banner/noindex/robots), and Sentry environment tagging. Migration workflow split lands in PR-B once staging is verified live.

## Summary

- `[env.staging]` block in `wrangler.toml`: worker name `dmarcheck-staging`, `staging.dmarc.mx` custom domain, the new D1 binding (`dmarcheck-db-staging`, id `8f1e2627-1a4b-43f2-87c3-8acf2792128c`), `IS_STAGING = "1"`, **no cron triggers** (staging is for migration smoke + manual e2e, not nightly rescans).
- New `src/middleware/staging-marker.ts` post-processes every HTML response on the staging worker — injects `<meta name="robots" content="noindex,nofollow">` and a sticky red banner linking back to dmarc.mx. Non-HTML responses pass through. Lives as middleware so per-page render functions stay env-agnostic.
- `/robots.txt` returns `Disallow: /` when `IS_STAGING=1`.
- Sentry: `environment` tagged `staging` vs `production`; `tracesSampler` set to 1.0 on staging (everything is interesting there).

## Live verification

`npx wrangler dev --env staging --port 8792` against this branch:

```
GET /                → 200, banner div + noindex meta in body
GET /robots.txt      → "User-agent: *\nDisallow: /"
GET /api/check?domain=dmarc.mx → JSON unchanged from prod
```

Visual check: banner sits sticky at the top, full width, red, links to dmarc.mx. Landing page renders normally underneath.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` — 734/734 pass, 6 new tests:
  - 5 `stagingMarker` middleware tests (HTML injection, prod no-op, IS_STAGING="0" no-op, non-HTML passthrough, status/header preservation)
  - 1 robots.txt test that staging returns Disallow-all
- [x] Live verified the banner + noindex + robots.txt flip with `wrangler dev --env staging`

## What you still need to do before this branch goes to prod

After merge, the staging worker won't actually deploy until the Cloudflare Workers Builds production deploy command is updated to:

```
npx wrangler deploy --env staging && curl -fsS https://staging.dmarc.mx/health && npx wrangler deploy
```

In parallel, a one-time setup pass in dashboards:
- WorkOS sandbox environment, redirect `https://staging.dmarc.mx/auth/callback`
- Stripe test-mode webhook endpoint at `https://staging.dmarc.mx/webhooks/stripe`
- `npx wrangler secret put --env staging` for `WORKOS_API_KEY`, `WORKOS_CLIENT_ID`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PRICE_ID_PRO`, `SESSION_SECRET`, optionally `SENTRY_DSN`
- DNS for `staging.dmarc.mx` (the `custom_domain = true` route in `wrangler.toml` should auto-provision; if not, add a proxied CNAME manually)
- A separate `CLOUDFLARE_D1_TOKEN` for staging (added to GitHub repo secrets as `CLOUDFLARE_D1_TOKEN_STAGING` for PR-B's workflow split)

## Out of scope (PR-B)

- `.github/workflows/migrate.yml` split into `migrate-staging` → smoke → `migrate-prod` gated on a GitHub `prod` environment with Cory as required reviewer
- README "Deployment" section documenting the chained Cloudflare Workers Builds command
- The CLAUDE.md update warning that "all deploys go through the chained build command — no separate `npm run deploy` ever" (today's note stays as-is until PR-B lands the new flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)