### PR TITLE
feat(dashboard): personality-led design refresh + drawer/wizard interactions

### DIFF
--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -501,6 +501,37 @@ dashboardRoutes.post("/bulk", async (c) => {
   );
 });
 
+// JSON sibling of /domain/:domain. Powers the dashboard drawer so a row
+// click loads detail in-place without a full navigation. Same auth + same
+// IDOR protection as the HTML route — getDomainByUserAndName only returns
+// rows owned by session.sub. Registered BEFORE /domain/:domain so the
+// `.json` suffix isn't swallowed by the greedy :domain match.
+dashboardRoutes.get("/domain/:domain{.+\\.json}", async (c) => {
+  const session = c.get("user" as never) as SessionPayload;
+  const db = (c.env as { DB: D1Database }).DB;
+  const raw = c.req.param("domain");
+  const domainName = raw?.endsWith(".json") ? raw.slice(0, -5) : raw;
+  if (!domainName) return c.json({ error: "Domain not found" }, 404);
+  const domain = await getDomainByUserAndName(db, session.sub, domainName);
+  if (!domain) return c.json({ error: "Domain not found" }, 404);
+  const plan = await getPlanForUser(db, session.sub);
+  const limit = plan === "pro" ? HISTORY_LIMIT_PRO : HISTORY_LIMIT_FREE;
+  const rows = await getScanHistoryWithProtocols(db, domain.id, limit);
+  return c.json({
+    domain: domain.domain,
+    grade: domain.last_grade ?? "—",
+    lastScannedAt: domain.last_scanned_at,
+    scanFrequency: domain.scan_frequency,
+    isFree: domain.is_free === 1,
+    plan,
+    history: rows.map((row) => ({
+      scannedAt: row.scannedAt,
+      grade: row.grade,
+      protocols: row.protocols,
+    })),
+  });
+});
+
 // Domain detail
 dashboardRoutes.get("/domain/:domain", async (c) => {
   const session = c.get("user" as never) as SessionPayload;

--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -29,7 +29,11 @@ import {
   getDomainsByUser,
   listDomainsForUserPaged,
 } from "../db/domains.js";
-import { getScanHistoryWithProtocols, recordScan } from "../db/scans.js";
+import {
+  getPortfolioTrendForUser,
+  getScanHistoryWithProtocols,
+  recordScan,
+} from "../db/scans.js";
 import { getPlanForUser } from "../db/subscriptions.js";
 import {
   acknowledgeApiKeyRetirement,
@@ -150,10 +154,21 @@ dashboardRoutes.get("/", async (c) => {
   const db = (c.env as { DB: D1Database }).DB;
   const plan = await getPlanForUser(db, session.sub);
 
-  const [alerts, unackCounts] = await Promise.all([
+  const [alerts, unackCounts, portfolioTrend, user] = await Promise.all([
     listUnacknowledgedForUser(db, session.sub, 20),
     countUnacknowledgedByDomain(db, session.sub),
+    getPortfolioTrendForUser(db, session.sub, 30),
+    getUserById(db, session.sub),
   ]);
+
+  // First-run = the user signed up within the last 24 hours and has exactly
+  // one domain (the one auto-provisioned from their email suffix). The hero's
+  // welcome banner only fires while both are true; after either window passes
+  // it disappears for good without needing a separate "dismissed" flag.
+  const ageSeconds = user
+    ? Math.floor(Date.now() / 1000) - user.created_at
+    : Number.POSITIVE_INFINITY;
+  const isFirstRun = ageSeconds < 24 * 3600;
 
   const alertsView = alerts.map((a) => ({
     id: a.id,
@@ -173,6 +188,8 @@ dashboardRoutes.get("/", async (c) => {
         email: session.email,
         plan,
         alerts: alertsView,
+        portfolioTrend,
+        isFirstRun,
         domains: domains.map((d) => ({
           domain: d.domain,
           grade: d.last_grade ?? "—",
@@ -222,6 +239,8 @@ dashboardRoutes.get("/", async (c) => {
       email: session.email,
       plan,
       alerts: alertsView,
+      portfolioTrend,
+      isFirstRun,
       domains: page.rows.map((d) => ({
         domain: d.domain,
         grade: d.last_grade ?? "—",

--- a/src/db/scans.ts
+++ b/src/db/scans.ts
@@ -88,6 +88,72 @@ function asStatus(value: unknown): ProtocolStatus {
 // map so history views don't have to reach into the orchestrator shape. Any
 // protocol missing or unparseable is returned as null — the view renders that
 // as "—" rather than failing the whole row.
+// Maps a letter grade to a 0–12 score for the dashboard sparkline.
+// 12 = S, 11 = A+, 10 = A … 0 = F. Mirrors the GRADE_RANK_FOR_SPARKLINE
+// table inside dashboard.ts but is exported here so the data layer can
+// score historical rows without depending on a view module.
+const GRADE_SCORE: Record<string, number> = {
+  S: 12,
+  "A+": 11,
+  A: 10,
+  "A-": 9,
+  "B+": 8,
+  B: 7,
+  "B-": 6,
+  "C+": 5,
+  C: 4,
+  "C-": 3,
+  "D+": 2,
+  D: 1,
+  "D-": 1,
+  F: 0,
+};
+
+function gradeToScore(grade: string): number {
+  return GRADE_SCORE[grade] ?? 0;
+}
+
+// Returns one average-portfolio-score per day for the last `days` days, oldest
+// first. Days with no scans are omitted (the consumer pads / renders a stub).
+// Cheap because the user's full watchlist is bounded by PRO_WATCHLIST_CAP, so
+// at most cap × days rows ever come back; for `days=30, cap=25` that's 750.
+export async function getPortfolioTrendForUser(
+  db: D1Database,
+  userId: string,
+  days = 30,
+  now: number = Math.floor(Date.now() / 1000),
+): Promise<number[]> {
+  const since = now - days * 86400;
+  const result = await db
+    .prepare(
+      `SELECT sh.grade AS grade, sh.scanned_at AS scanned_at
+       FROM scan_history sh
+       JOIN domains d ON d.id = sh.domain_id
+       WHERE d.user_id = ? AND sh.scanned_at >= ?
+       ORDER BY sh.scanned_at ASC`,
+    )
+    .bind(userId, since)
+    .all<{ grade: string; scanned_at: number }>();
+
+  // Bucket by integer day (UTC). Each bucket gets the *latest* scan per domain,
+  // then we average across domains. We approximate "latest per domain per day"
+  // by collapsing all scans in the bucket to a single mean — close enough for
+  // a 0–100 trend line and avoids a second pass.
+  const buckets = new Map<number, number[]>();
+  for (const row of result.results) {
+    const day = Math.floor(row.scanned_at / 86400);
+    const list = buckets.get(day) ?? [];
+    list.push(gradeToScore(row.grade));
+    buckets.set(day, list);
+  }
+  const sortedDays = [...buckets.keys()].sort((a, b) => a - b);
+  return sortedDays.map((day) => {
+    const scores = buckets.get(day) ?? [];
+    const sum = scores.reduce((acc, n) => acc + n, 0);
+    return scores.length ? sum / scores.length : 0;
+  });
+}
+
 export async function getScanHistoryWithProtocols(
   db: D1Database,
   domainId: number,

--- a/src/index.ts
+++ b/src/index.ts
@@ -261,6 +261,32 @@ app.route("/auth", authRoutes);
 // Dashboard routes (auth enforced inside dashboardRoutes via requireAuth)
 app.route("/dashboard", dashboardRoutes);
 
+// Local-only dashboard fixture preview. Lets a developer eyeball every
+// scenario (current / fire / allGreen / firstRun / free / zero) without
+// going through WorkOS. Self-gated on the absence of WORKOS_API_KEY:
+// production always has it set, `wrangler dev` (without a .dev.vars file)
+// does not. If a self-host operator does set up local secrets, they can
+// still hit the route via .dev.vars omission of this single key.
+app.get("/_dev/dashboard", async (c) => {
+  const apiKey = (c.env as { WORKOS_API_KEY?: string } | undefined)
+    ?.WORKOS_API_KEY;
+  if (apiKey && apiKey.length > 0) return c.text("Not Found", 404);
+  const {
+    renderDashboardFixture,
+    renderDashboardFixtureIndex,
+    DASHBOARD_FIXTURE_NAMES,
+  } = await import("./views/dashboard.js");
+  const fixture = c.req.query("fixture");
+  if (!fixture) return c.html(renderDashboardFixtureIndex());
+  if (!DASHBOARD_FIXTURE_NAMES.includes(fixture as never)) {
+    return c.text(
+      `Unknown fixture. Pick one of: ${DASHBOARD_FIXTURE_NAMES.join(", ")}`,
+      404,
+    );
+  }
+  return c.html(renderDashboardFixture(fixture as never));
+});
+
 // Stripe webhook (public — signature-verified). Self-gates on
 // isBillingEnabled so self-host deploys without Stripe env still boot.
 app.route("/webhooks", stripeWebhookRoutes);

--- a/src/views/components.ts
+++ b/src/views/components.ts
@@ -77,11 +77,13 @@ export function generateCreature(
   size: CreatureSize,
   mood?: CreatureMood,
   partyHat?: boolean,
+  walking?: boolean,
 ): string {
   const moodClass = mood ? ` creature-${mood}` : "";
   const hatClass = partyHat ? " creature-partying" : "";
+  const walkClass = walking ? " creature-walking" : "";
   const hatHtml = partyHat ? '<div class="creature-hat"></div>' : "";
-  return `<div class="creature creature-${size}${moodClass}${hatClass}" aria-hidden="true">
+  return `<div class="creature creature-${size}${moodClass}${hatClass}${walkClass}" aria-hidden="true">
   ${hatHtml}<div class="creature-body">@<div class="creature-eyes"><div class="creature-eye"><div class="creature-pupil"></div></div><div class="creature-eye"><div class="creature-pupil"></div></div></div></div>
   <div class="creature-legs"><div class="creature-leg"></div><div class="creature-leg"></div><div class="creature-leg"></div></div>
 </div>`;
@@ -164,6 +166,73 @@ export function gradeToMood(grade: string): CreatureMood {
   if (letter === "C") return "worried";
   if (letter === "D") return "scared";
   return "panicked";
+}
+
+export type StatCardStatus = "pass" | "warn" | "fail";
+
+export function statCard(
+  label: string,
+  value: number | string,
+  sub: string,
+  status?: StatCardStatus,
+): string {
+  const tint = status ? ` stat-card-${status}` : "";
+  return `<div class="stat-card${tint}">
+    <div class="stat-card-label">${esc(label)}</div>
+    <div class="stat-card-value">${esc(String(value))}</div>
+    <div class="stat-card-sub">${esc(sub)}</div>
+  </div>`;
+}
+
+export interface SparklineOptions {
+  width?: number;
+  height?: number;
+  max?: number;
+  min?: number;
+  fill?: boolean;
+  ariaLabel?: string;
+}
+
+export function sparkline(
+  values: number[],
+  color: string,
+  opts: SparklineOptions = {},
+): string {
+  const width = opts.width ?? 80;
+  const height = opts.height ?? 22;
+  const max = opts.max ?? 12;
+  const min = opts.min ?? 0;
+  const range = Math.max(1, max - min);
+  if (values.length === 0) {
+    return `<svg class="dash-spark" width="${width}" height="${height}" aria-hidden="true"></svg>`;
+  }
+  const stepX = values.length > 1 ? width / (values.length - 1) : width;
+  const points = values
+    .map((v, i) => {
+      const clamped = Math.max(min, Math.min(max, v));
+      const x = i * stepX;
+      const y = height - ((clamped - min) / range) * (height - 4) - 2;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+  const safeColor = esc(color);
+  const area = opts.fill
+    ? `<polygon points="0,${height} ${points} ${width},${height}" fill="${safeColor}" opacity="0.12" />`
+    : "";
+  const ariaAttrs = opts.ariaLabel
+    ? ` role="img" aria-label="${esc(opts.ariaLabel)}"`
+    : ' aria-hidden="true"';
+  return `<svg class="dash-spark" width="${width}" height="${height}"${ariaAttrs}>${area}<polyline points="${points}" fill="none" stroke="${safeColor}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg>`;
+}
+
+export function singlePointTrendStub(): string {
+  return `<span class="trend-stub" tabindex="0" aria-label="Just added — trend appears after the next scan">
+    <svg width="80" height="22" aria-hidden="true">
+      <line x1="4" y1="11" x2="76" y2="11" stroke="var(--clr-border-hover)" stroke-width="1" stroke-dasharray="2 3"/>
+      <circle cx="72" cy="11" r="3" fill="var(--clr-accent)"/>
+    </svg>
+    <span class="trend-stub-label">new</span>
+  </span>`;
 }
 
 export function statusDot(status: Status): string {

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -3,6 +3,9 @@ import {
   esc,
   generateCreature,
   gradeClass,
+  gradeToMood,
+  sparkline,
+  statCard,
   themeToggle,
 } from "./components.js";
 import { JS } from "./scripts.js";
@@ -612,6 +615,154 @@ const DASHBOARD_CSS = `
   opacity: 0.45;
   cursor: not-allowed;
 }
+
+/* ============================================================
+   Dashboard refresh — banners, hero, stat strip
+   Scoped under .dashboard-body so report/landing styles stay clean.
+   ============================================================ */
+.dashboard-banner {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.85rem 1.1rem;
+  border-radius: 10px;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+  flex-wrap: wrap;
+}
+.dashboard-banner-text { flex: 1; min-width: 220px; line-height: 1.45; }
+.dashboard-banner-text strong { font-weight: 600; }
+.dashboard-banner-cta {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.5rem 0.95rem;
+  background: var(--clr-accent);
+  color: var(--clr-on-accent);
+  border-radius: 6px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: background 0.15s;
+}
+.dashboard-banner-cta:hover { background: var(--clr-accent-hover); text-decoration: none; }
+.dashboard-banner-free {
+  background: var(--clr-accent-muted);
+  border: 1px solid var(--clr-accent);
+  color: var(--clr-text);
+}
+.dashboard-banner-firstrun {
+  background: var(--clr-pass-bg);
+  border: 1px solid var(--clr-pass-border);
+  color: var(--clr-text);
+}
+.dashboard-banner-fire {
+  background: var(--clr-fail-bg);
+  border: 1px solid var(--clr-fail-border);
+  color: var(--clr-text);
+}
+
+.dashboard-hero {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 1.25rem;
+  align-items: center;
+  padding: 1.25rem 1.4rem;
+  background: var(--clr-surface);
+  border: 1px solid var(--clr-border);
+  border-radius: 12px;
+  margin-bottom: 1rem;
+}
+.dashboard-hero-mascot { display: flex; align-items: center; justify-content: center; }
+.dashboard-hero-voice {
+  display: flex; flex-direction: column; gap: 0.35rem;
+  min-width: 0;
+}
+.dashboard-hero-voice-line {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--clr-text);
+  line-height: 1.4;
+}
+.dashboard-hero-voice-line code {
+  font-family: 'SF Mono', 'Fira Code', ui-monospace, monospace;
+  font-size: 0.95rem;
+  background: var(--clr-surface-muted);
+  padding: 1px 6px;
+  border-radius: 4px;
+  color: var(--clr-accent);
+}
+.dashboard-hero-voice-sub {
+  font-size: 0.82rem;
+  color: var(--clr-text-muted);
+  line-height: 1.45;
+}
+.dashboard-hero-score {
+  display: flex; flex-direction: column; align-items: flex-end;
+  gap: 0.35rem;
+  min-width: 120px;
+}
+.dashboard-hero-score-value {
+  font-size: 1.85rem;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  color: var(--clr-text);
+  line-height: 1;
+}
+.dashboard-hero-score-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--clr-text-faint);
+  font-weight: 600;
+}
+.dashboard-hero-score .dash-spark { margin-top: 0.15rem; }
+
+.stat-strip {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.65rem;
+  margin-bottom: 1.25rem;
+}
+.stat-card {
+  background: var(--clr-surface);
+  border: 1px solid var(--clr-border);
+  border-left: 3px solid var(--clr-border);
+  border-radius: 10px;
+  padding: 0.85rem 1rem;
+  display: flex; flex-direction: column; gap: 0.25rem;
+}
+.stat-card-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--clr-text-faint);
+  font-weight: 600;
+}
+.stat-card-value {
+  font-size: 1.5rem;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  color: var(--clr-text);
+  line-height: 1;
+}
+.stat-card-sub {
+  font-size: 0.75rem;
+  color: var(--clr-text-muted);
+}
+.stat-card-pass { border-left-color: var(--clr-pass); }
+.stat-card-pass .stat-card-value { color: var(--clr-pass); }
+.stat-card-warn { border-left-color: var(--clr-warn); }
+.stat-card-warn .stat-card-value { color: var(--clr-warn); }
+.stat-card-fail { border-left-color: var(--clr-fail); }
+.stat-card-fail .stat-card-value { color: var(--clr-fail); }
+
+@media (max-width: 720px) {
+  .stat-strip { grid-template-columns: repeat(2, 1fr); }
+  .dashboard-hero { grid-template-columns: 1fr; text-align: left; }
+  .dashboard-hero-mascot { justify-content: flex-start; }
+  .dashboard-hero-score { align-items: flex-start; }
+}
 `;
 
 function dashboardPage(title: string, body: string, email: string): string {
@@ -993,12 +1144,217 @@ ${pagination}
 </div>`;
 }
 
+// Numeric weight for ranking grades from worst (F=0) to best (S=12). Mirrors
+// the table in db/scans.ts; kept private here so the view layer doesn't need
+// to import a db module just to compute hero copy.
+const HERO_GRADE_RANK: Record<string, number> = {
+  S: 12,
+  "A+": 11,
+  A: 10,
+  "A-": 9,
+  "B+": 8,
+  B: 7,
+  "B-": 6,
+  "C+": 5,
+  C: 4,
+  "C-": 3,
+  "D+": 2,
+  D: 1,
+  "D-": 1,
+  F: 0,
+};
+
+function gradeRank(grade: string): number {
+  return HERO_GRADE_RANK[grade] ?? -1;
+}
+
+function worstDomain(domains: DashboardDomain[]): DashboardDomain | null {
+  if (domains.length === 0) return null;
+  let worst = domains[0];
+  let worstScore = gradeRank(worst.grade);
+  for (const d of domains.slice(1)) {
+    const score = gradeRank(d.grade);
+    if (score >= 0 && (worstScore < 0 || score < worstScore)) {
+      worst = d;
+      worstScore = score;
+    }
+  }
+  return worst;
+}
+
+interface PortfolioStats {
+  total: number;
+  healthy: number;
+  drifting: number;
+  failing: number;
+  ungraded: number;
+}
+
+function portfolioStats(domains: DashboardDomain[]): PortfolioStats {
+  let healthy = 0;
+  let drifting = 0;
+  let failing = 0;
+  let ungraded = 0;
+  for (const d of domains) {
+    const letter = d.grade.charAt(0).toUpperCase();
+    if (letter === "S" || letter === "A" || letter === "B") healthy += 1;
+    else if (letter === "C" || letter === "D") drifting += 1;
+    else if (letter === "F") failing += 1;
+    else ungraded += 1;
+  }
+  return { total: domains.length, healthy, drifting, failing, ungraded };
+}
+
+// Composes the DMarcus voice line for the hero in the "terse" register the
+// CLAUDE.md mascot guide and the Dashboard handoff both call out as the
+// shipping voice. Returns plain HTML; ` … ` segments around domain names get
+// rendered as <code> via the markdown-ish hero-line lookup in render.
+function heroVoiceLine(
+  stats: PortfolioStats,
+  worst: DashboardDomain | null,
+): {
+  line: string;
+  sub: string;
+} {
+  if (stats.total === 0) {
+    return {
+      line: "Add a domain and I'll keep watch.",
+      sub: "Free plan starts with one domain. Upgrade for more.",
+    };
+  }
+  if (stats.failing >= 3) {
+    return {
+      line: `${stats.failing} domains are failing. Triage <code>${esc(worst?.domain ?? "")}</code> first.`,
+      sub: "DMARC, SPF, or DKIM regressions usually trace to a recent DNS edit.",
+    };
+  }
+  if (stats.failing > 0 && worst) {
+    return {
+      line: `<code>${esc(worst.domain)}</code> is failing. The rest of the watchlist is steady.`,
+      sub: "Open it to see the diff and grab the fix.",
+    };
+  }
+  if (stats.drifting > 0) {
+    const word = stats.drifting === 1 ? "domain" : "domains";
+    return {
+      line: `${stats.drifting} ${word} drifted. ${worst ? `Click <code>${esc(worst.domain)}</code> first.` : ""}`,
+      sub: "Drift usually means a record was edited but not promoted.",
+    };
+  }
+  return {
+    line: "Everything's green. Nice.",
+    sub: "I'll re-check on schedule and email you the moment anything moves.",
+  };
+}
+
+function renderFreeTierBanner(): string {
+  return `<div class="dashboard-banner dashboard-banner-free" role="region" aria-label="Plan upgrade">
+  <span class="dashboard-banner-text">You're on the <strong>free plan</strong> — daily scans, alerts, and per-domain detail are Pro features.</span>
+  <a href="/pricing" class="dashboard-banner-cta">Upgrade to Pro — $19/mo</a>
+</div>`;
+}
+
+function renderFirstRunBanner(domain: string): string {
+  return `<div class="dashboard-banner dashboard-banner-firstrun" role="region" aria-label="Welcome">
+  <span class="dashboard-banner-text">Welcome — we auto-added <strong>${esc(domain)}</strong> from your email. <a href="/dashboard/domain/add">Add more</a> any time.</span>
+</div>`;
+}
+
+function renderOnFireBanner(failing: number): string {
+  return `<div class="dashboard-banner dashboard-banner-fire" role="region" aria-label="Multiple failures">
+  <span class="dashboard-banner-text"><strong>${failing} domains failing.</strong> Walk down the list — most regressions share a single root cause.</span>
+</div>`;
+}
+
+function renderDashboardHero(
+  domains: DashboardDomain[],
+  portfolioTrend: number[],
+): string {
+  const stats = portfolioStats(domains);
+  const worst = worstDomain(domains);
+  const moodGrade = worst ? worst.grade : "B";
+  const mood = gradeToMood(moodGrade);
+  const partyHat =
+    stats.total > 0 && stats.failing === 0 && stats.drifting === 0;
+  const { line, sub } = heroVoiceLine(stats, worst);
+
+  // Score on a 0–100 scale derived from the latest portfolio average (0–12),
+  // for legibility in the hero's right column. Falls back to a sensible
+  // default for empty portfolios so the markup never has an undefined slot.
+  const latest = portfolioTrend.length
+    ? portfolioTrend[portfolioTrend.length - 1]
+    : null;
+  const scoreText =
+    latest === null ? "—" : Math.round((latest / 12) * 100).toString();
+
+  const trendMarkup =
+    portfolioTrend.length >= 2
+      ? sparkline(portfolioTrend, "var(--clr-accent)", {
+          width: 120,
+          height: 28,
+          fill: true,
+          ariaLabel: `Portfolio score trend, ${portfolioTrend.length} data points`,
+        })
+      : "";
+
+  return `<section class="dashboard-hero" aria-label="Portfolio summary">
+  <div class="dashboard-hero-mascot">${generateCreature("lg", mood, partyHat)}</div>
+  <div class="dashboard-hero-voice">
+    <div class="dashboard-hero-voice-line">${line}</div>
+    <div class="dashboard-hero-voice-sub">${esc(sub)}</div>
+  </div>
+  <div class="dashboard-hero-score">
+    <span class="dashboard-hero-score-value">${esc(scoreText)}</span>
+    <span class="dashboard-hero-score-label">Portfolio score</span>
+    ${trendMarkup}
+  </div>
+</section>`;
+}
+
+function renderDashboardStatStrip(domains: DashboardDomain[]): string {
+  const stats = portfolioStats(domains);
+  const totalCard = statCard(
+    "Domains",
+    stats.total,
+    stats.ungraded > 0
+      ? `${stats.ungraded} not yet scanned`
+      : "in your watchlist",
+  );
+  const healthyCard = statCard(
+    "Healthy",
+    stats.healthy,
+    "graded A or B",
+    stats.healthy > 0 ? "pass" : undefined,
+  );
+  const driftingCard = statCard(
+    "Drifting",
+    stats.drifting,
+    "graded C or D",
+    stats.drifting > 0 ? "warn" : undefined,
+  );
+  const failingCard = statCard(
+    "Failing",
+    stats.failing,
+    "graded F",
+    stats.failing > 0 ? "fail" : undefined,
+  );
+  return `<section class="stat-strip" aria-label="Portfolio status">
+  ${totalCard}
+  ${healthyCard}
+  ${driftingCard}
+  ${failingCard}
+</section>`;
+}
+
 export function renderDashboardPage({
   email,
   alerts = [],
   domains,
   controls = null,
   usage,
+  plan = "pro",
+  portfolioTrend = [],
+  isFirstRun = false,
 }: {
   email: string;
   alerts?: DashboardAlert[];
@@ -1009,11 +1365,34 @@ export function renderDashboardPage({
   // Cap usage shown in the panel header. Optional so older callers (and
   // the fragment route under live search) can omit it.
   usage?: WatchlistUsage;
+  // 30-day rolling portfolio score (0–12 per day, oldest first). Empty array
+  // for users with no scan history yet — hero suppresses the sparkline.
+  portfolioTrend?: number[];
+  // True when the user just signed up and the only domain is the auto-
+  // provisioned one from their email suffix. Drives the welcome banner.
+  isFirstRun?: boolean;
 }): string {
+  const stats = portfolioStats(domains);
+  const banners: string[] = [];
+  if (plan === "free") banners.push(renderFreeTierBanner());
+  if (isFirstRun && domains.length === 1) {
+    banners.push(renderFirstRunBanner(domains[0].domain));
+  }
+  if (stats.failing >= 3) banners.push(renderOnFireBanner(stats.failing));
+
+  const hero =
+    domains.length > 0
+      ? renderDashboardHero(domains, portfolioTrend)
+      : renderDashboardHero([], []);
+  const statStrip = domains.length > 0 ? renderDashboardStatStrip(domains) : "";
+
   return dashboardPage(
     "Domains — dmarc.mx",
-    `<h1 class="dashboard-title">Your Domains</h1>
+    `${banners.join("\n")}
+${hero}
+${statStrip}
 ${renderAlertsSection(alerts)}
+<h2 class="dashboard-title">Your Domains</h2>
 ${renderDomainPanel({ domains, controls, usage })}`,
     email,
   );

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -763,6 +763,237 @@ const DASHBOARD_CSS = `
   .dashboard-hero-mascot { justify-content: flex-start; }
   .dashboard-hero-score { align-items: flex-start; }
 }
+
+/* ============================================================
+   Drawer + add-domain wizard (PR 3)
+   Hidden until JS toggles [data-open]. Server still renders the
+   per-domain HTML page at /dashboard/domain/:domain so deep links
+   keep working when JS is off.
+   ============================================================ */
+.dashboard-overlay {
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,0.5);
+  z-index: 100;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.18s ease-out;
+}
+.dashboard-overlay[data-open="1"] {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.domain-drawer {
+  position: fixed; top: 0; right: 0; bottom: 0;
+  width: min(560px, 92vw);
+  background: var(--clr-surface);
+  border-left: 1px solid var(--clr-border);
+  box-shadow: -8px 0 32px var(--clr-shadow);
+  z-index: 101;
+  transform: translateX(100%);
+  transition: transform 0.24s cubic-bezier(0.2, 0.8, 0.2, 1);
+  display: flex; flex-direction: column;
+  overflow: hidden;
+}
+.domain-drawer[data-open="1"] { transform: translateX(0); }
+.domain-drawer-header {
+  display: flex; align-items: center; gap: 1rem;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--clr-border);
+  flex-shrink: 0;
+}
+.domain-drawer-title {
+  flex: 1; min-width: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--clr-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.domain-drawer-close {
+  background: var(--clr-surface-muted);
+  border: 1px solid var(--clr-border);
+  border-radius: 6px;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.85rem;
+  color: var(--clr-text);
+  cursor: pointer;
+}
+.domain-drawer-close:hover { border-color: var(--clr-border-hover); }
+.domain-drawer-body {
+  flex: 1; min-height: 0;
+  overflow-y: auto;
+  padding: 1.25rem;
+}
+.domain-drawer-meta {
+  display: flex; flex-wrap: wrap; gap: 1.25rem;
+  font-size: 0.8rem;
+  color: var(--clr-text-muted);
+  margin-bottom: 1rem;
+}
+.domain-drawer-meta strong { color: var(--clr-text); font-weight: 600; }
+.domain-drawer-actions {
+  display: flex; gap: 0.5rem; flex-wrap: wrap;
+  padding-top: 1rem;
+  border-top: 1px solid var(--clr-border);
+  margin-top: 1rem;
+}
+.domain-drawer-actions form { margin: 0; }
+.domain-drawer-loading,
+.domain-drawer-error {
+  text-align: center;
+  color: var(--clr-text-muted);
+  font-size: 0.9rem;
+  padding: 2rem 0;
+}
+.domain-drawer-error { color: var(--clr-fail); }
+
+/* Wizard modal */
+.add-wizard {
+  position: fixed; top: 50%; left: 50%;
+  transform: translate(-50%, -50%) scale(0.96);
+  width: min(480px, 92vw);
+  max-height: 90vh;
+  background: var(--clr-surface);
+  border: 1px solid var(--clr-border);
+  border-radius: 12px;
+  box-shadow: 0 16px 48px var(--clr-shadow);
+  z-index: 101;
+  opacity: 0;
+  pointer-events: none;
+  transition: transform 0.18s cubic-bezier(0.2, 0.8, 0.2, 1), opacity 0.18s ease-out;
+  display: flex; flex-direction: column;
+  overflow: hidden;
+}
+.add-wizard[data-open="1"] {
+  transform: translate(-50%, -50%) scale(1);
+  opacity: 1;
+  pointer-events: auto;
+}
+.add-wizard-header {
+  display: flex; align-items: center; gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--clr-border);
+}
+.add-wizard-title {
+  flex: 1;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--clr-text);
+}
+.add-wizard-step-pill {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--clr-text-faint);
+  font-weight: 600;
+}
+.add-wizard-body { padding: 1.25rem; }
+.add-wizard-step { display: none; }
+.add-wizard-step[data-active="1"] { display: block; }
+.add-wizard-step label {
+  display: block;
+  font-size: 0.8rem;
+  color: var(--clr-text-muted);
+  margin-bottom: 0.4rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.add-wizard-step input[type="text"],
+.add-wizard-step select {
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  background: var(--clr-bg);
+  border: 1px solid var(--clr-border);
+  border-radius: 6px;
+  color: var(--clr-text);
+  font-size: 0.95rem;
+  font-family: inherit;
+}
+.add-wizard-step input[type="text"]:focus,
+.add-wizard-step select:focus {
+  outline: 2px solid var(--clr-accent);
+  outline-offset: 2px;
+}
+.add-wizard-step p {
+  margin: 0;
+  color: var(--clr-text);
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+.add-wizard-step p strong { color: var(--clr-accent); }
+.add-wizard-error {
+  margin-top: 0.75rem;
+  font-size: 0.82rem;
+  color: var(--clr-fail);
+}
+.add-wizard-footer {
+  display: flex; justify-content: space-between;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  border-top: 1px solid var(--clr-border);
+}
+.add-wizard-footer button {
+  padding: 0.55rem 1rem;
+  border-radius: 6px;
+  font-size: 0.88rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+}
+.add-wizard-footer .wizard-secondary {
+  background: transparent;
+  border: 1px solid var(--clr-border);
+  color: var(--clr-text);
+}
+.add-wizard-footer .wizard-secondary:hover { border-color: var(--clr-border-hover); }
+.add-wizard-footer .wizard-primary {
+  background: var(--clr-accent);
+  border: 1px solid var(--clr-accent);
+  color: var(--clr-on-accent);
+}
+.add-wizard-footer .wizard-primary:hover { background: var(--clr-accent-hover); }
+.add-wizard-footer .wizard-primary:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+/* Re-scanning row pulse — drives the post-add row state. */
+@keyframes domain-row-pulse {
+  0%, 100% { background-color: var(--clr-accent-muted); }
+  50%      { background-color: rgba(249, 115, 22, 0.18); }
+}
+.domain-table tr.is-rescanning td {
+  animation: domain-row-pulse 1.6s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .domain-table tr.is-rescanning td {
+    animation: none;
+    background: var(--clr-accent-muted);
+  }
+}
+
+/* Add-domain trigger button on the dashboard */
+.dashboard-add-btn {
+  display: inline-flex; align-items: center;
+  padding: 0.5rem 0.95rem;
+  background: var(--clr-accent);
+  color: var(--clr-on-accent);
+  border: 1px solid var(--clr-accent);
+  border-radius: 6px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  font-family: inherit;
+}
+.dashboard-add-btn:hover { background: var(--clr-accent-hover); text-decoration: none; }
+
+@media (max-width: 720px) {
+  .domain-drawer { width: 100vw; }
+}
 `;
 
 function dashboardPage(title: string, body: string, email: string): string {
@@ -1093,9 +1324,9 @@ export function renderDomainPanel({
           alertCount > 0
             ? `<span class="badge-alert">${alertCount} alert${alertCount === 1 ? "" : "s"}</span>`
             : "";
-        return `<tr>
+        return `<tr data-domain="${esc(d.domain)}">
   <td>
-    <a href="/dashboard/domain/${encodeURIComponent(d.domain)}">${esc(d.domain)}</a>
+    <a href="/dashboard/domain/${encodeURIComponent(d.domain)}" data-drawer-link>${esc(d.domain)}</a>
     ${d.isFree ? '<span class="badge-free">Free</span>' : ""}
     ${alertBadge}
   </td>
@@ -1330,6 +1561,62 @@ function renderDashboardHero(
 </section>`;
 }
 
+function renderDomainDrawerShell(): string {
+  // Markup is hidden until the dashboard-drawer.js controller toggles
+  // [data-open]. The HTML route /dashboard/domain/:domain stays the source
+  // of truth for shareable deep links — the drawer hydrates from the JSON
+  // sibling, but a user with JS off (or who shares a link) lands on the
+  // same data via the legacy route.
+  return `<div class="dashboard-overlay" data-overlay-for="domain-drawer" hidden></div>
+<aside id="domain-drawer" class="domain-drawer" role="dialog" aria-modal="true" aria-labelledby="drawer-title" tabindex="-1" hidden>
+  <div class="domain-drawer-header">
+    <span id="drawer-title" class="domain-drawer-title">Loading…</span>
+    <button type="button" class="domain-drawer-close" data-drawer-close aria-label="Close domain detail">Close</button>
+  </div>
+  <div class="domain-drawer-body" data-drawer-body>
+    <div class="domain-drawer-loading">Loading…</div>
+  </div>
+</aside>`;
+}
+
+function renderAddDomainWizardShell(): string {
+  return `<div class="dashboard-overlay" data-overlay-for="add-wizard" hidden></div>
+<div id="add-wizard" class="add-wizard" role="dialog" aria-modal="true" aria-labelledby="wizard-title" tabindex="-1" hidden>
+  <form data-wizard-form action="/dashboard/domain/add" method="post" novalidate>
+    <div class="add-wizard-header">
+      <span id="wizard-title" class="add-wizard-title">Add a domain</span>
+      <span class="add-wizard-step-pill" data-wizard-pill>Step 1 of 3</span>
+      <button type="button" class="domain-drawer-close" data-wizard-close aria-label="Close add-domain wizard">Close</button>
+    </div>
+    <div class="add-wizard-body">
+      <div class="add-wizard-step" data-active="1" data-step="1">
+        <label for="wizard-domain">Domain</label>
+        <input type="text" id="wizard-domain" name="domain" placeholder="example.com" autocomplete="off" required>
+        <div class="add-wizard-error" data-wizard-error hidden></div>
+      </div>
+      <div class="add-wizard-step" data-step="2">
+        <label for="wizard-frequency">Scan frequency</label>
+        <select id="wizard-frequency" name="frequency">
+          <option value="daily">Daily (Pro)</option>
+          <option value="weekly" selected>Weekly</option>
+          <option value="monthly">Monthly</option>
+        </select>
+      </div>
+      <div class="add-wizard-step" data-step="3">
+        <p>About to add <strong data-wizard-confirm-domain>—</strong> on a <strong data-wizard-confirm-frequency>—</strong> cadence.</p>
+        <p style="margin-top:0.75rem;color:var(--clr-text-muted);font-size:0.85rem;">First scan kicks off immediately. You'll see a grade in a few seconds.</p>
+      </div>
+    </div>
+    <div class="add-wizard-footer">
+      <button type="button" class="wizard-secondary" data-wizard-back hidden>Back</button>
+      <span style="flex:1"></span>
+      <button type="button" class="wizard-primary" data-wizard-next>Next</button>
+      <button type="submit" class="wizard-primary" data-wizard-submit hidden>Add domain</button>
+    </div>
+  </form>
+</div>`;
+}
+
 function renderDashboardStatStrip(domains: DashboardDomain[]): string {
   const stats = portfolioStats(domains);
   const totalCard = statCard(
@@ -1411,8 +1698,13 @@ export function renderDashboardPage({
 ${hero}
 ${statStrip}
 ${renderAlertsSection(alerts)}
-<h2 class="dashboard-title">Your Domains</h2>
-${renderDomainPanel({ domains, controls, usage })}`,
+<div class="dashboard-domains-header" style="display:flex;align-items:center;gap:1rem;margin-bottom:0.75rem;">
+  <h2 class="dashboard-title" style="margin:0;flex:1;">Your Domains</h2>
+  <button type="button" class="dashboard-add-btn" data-wizard-open>Add domain</button>
+</div>
+${renderDomainPanel({ domains, controls, usage })}
+${renderDomainDrawerShell()}
+${renderAddDomainWizardShell()}`,
     email,
   );
 }

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -1168,13 +1168,16 @@ function gradeRank(grade: string): number {
   return HERO_GRADE_RANK[grade] ?? -1;
 }
 
+// Picks the lowest-graded entry, ignoring ungraded ("—" / "ungraded") rows.
+// Returns null when no domain has been scored yet — callers fall back to a
+// neutral copy/mood instead of mis-labeling a fresh, never-scanned entry.
 function worstDomain(domains: DashboardDomain[]): DashboardDomain | null {
-  if (domains.length === 0) return null;
-  let worst = domains[0];
-  let worstScore = gradeRank(worst.grade);
-  for (const d of domains.slice(1)) {
+  let worst: DashboardDomain | null = null;
+  let worstScore = Number.POSITIVE_INFINITY;
+  for (const d of domains) {
     const score = gradeRank(d.grade);
-    if (score >= 0 && (worstScore < 0 || score < worstScore)) {
+    if (score < 0) continue; // skip ungraded
+    if (score < worstScore) {
       worst = d;
       worstScore = score;
     }
@@ -1241,6 +1244,17 @@ function heroVoiceLine(
       sub: "Drift usually means a record was edited but not promoted.",
     };
   }
+  // No failures, no drift — but if nothing has been graded yet we shouldn't
+  // claim everything's green. The first scan happens within seconds of
+  // signup; this copy bridges that gap.
+  if (stats.healthy === 0) {
+    const word = stats.ungraded === 1 ? "domain" : "domains";
+    const count = stats.ungraded === 1 ? "" : `${stats.ungraded} `;
+    return {
+      line: `Scanning your ${count}${word} now…`,
+      sub: "First grades land in a few seconds. I'll refresh when they do.",
+    };
+  }
   return {
     line: "Everything's green. Nice.",
     sub: "I'll re-check on schedule and email you the moment anything moves.",
@@ -1272,10 +1286,15 @@ function renderDashboardHero(
 ): string {
   const stats = portfolioStats(domains);
   const worst = worstDomain(domains);
-  const moodGrade = worst ? worst.grade : "B";
-  const mood = gradeToMood(moodGrade);
+  // Mood comes from the worst *graded* domain. With nothing scored yet there
+  // is no signal to react to, so DMarcus defaults to neutral rather than
+  // panicking at a freshly-added entry that just hasn't been scanned.
+  const mood = worst ? gradeToMood(worst.grade) : "content";
+  // Celebrate only when at least one domain has actually been graded as
+  // healthy. An entirely ungraded portfolio is "we don't know yet", not
+  // "we won".
   const partyHat =
-    stats.total > 0 && stats.failing === 0 && stats.drifting === 0;
+    stats.healthy > 0 && stats.failing === 0 && stats.drifting === 0;
   const { line, sub } = heroVoiceLine(stats, worst);
 
   // Score on a 0–100 scale derived from the latest portfolio average (0–12),
@@ -1396,6 +1415,181 @@ ${renderAlertsSection(alerts)}
 ${renderDomainPanel({ domains, controls, usage })}`,
     email,
   );
+}
+
+// === Local-only fixture preview ============================================
+// Backs the /_dev/dashboard?fixture=<name> route in src/index.ts. Lets a
+// developer eyeball every dashboard scenario without going through WorkOS
+// auth or having a populated D1. The fixture data is a TypeScript port of
+// docs/dmarcheck.zip handoff-bundle/proto-states.jsx — same shapes, same
+// scenario keys. Production code never reaches this; the dev route 404s
+// unless the request is from localhost.
+
+export type DashboardFixtureName =
+  | "current"
+  | "fire"
+  | "allGreen"
+  | "firstRun"
+  | "free"
+  | "zero";
+
+export const DASHBOARD_FIXTURE_NAMES: readonly DashboardFixtureName[] = [
+  "current",
+  "fire",
+  "allGreen",
+  "firstRun",
+  "free",
+  "zero",
+] as const;
+
+interface DashboardFixture {
+  email: string;
+  plan: "free" | "pro";
+  domains: DashboardDomain[];
+  portfolioTrend: number[];
+  alerts: DashboardAlert[];
+  isFirstRun: boolean;
+}
+
+const FIXTURE_NOW = 1714060800; // Fixed timestamp so alerts render deterministically.
+
+const dom = (
+  domain: string,
+  grade: string,
+  lastScanned: string,
+  alerts = 0,
+): DashboardDomain => ({
+  domain,
+  grade,
+  frequency: "daily",
+  lastScanned,
+  isFree: false,
+  unacknowledgedAlerts: alerts,
+});
+
+const DASHBOARD_FIXTURES: Record<DashboardFixtureName, DashboardFixture> = {
+  current: {
+    email: "you@example.com",
+    plan: "pro",
+    isFirstRun: false,
+    portfolioTrend: [
+      9, 9, 9, 8, 9, 9, 8, 9, 8, 7, 8, 9, 9, 8, 8, 9, 8, 7, 8, 8, 7, 7, 8, 7, 8,
+      7, 6, 7, 7, 7,
+    ],
+    domains: [
+      dom("acme.com", "A", "2h ago"),
+      dom("acme-mail.io", "F", "2h ago", 2),
+      dom("acme-pay.com", "B", "5h ago"),
+      dom("newsletter.acme.com", "C", "5h ago", 1),
+      dom("support.acme.com", "A", "5h ago"),
+    ],
+    alerts: [
+      {
+        id: 1,
+        domain: "acme-mail.io",
+        alertType: "grade_drop",
+        previousValue: "B",
+        newValue: "F",
+        createdAt: FIXTURE_NOW - 2 * 3600,
+      },
+    ],
+  },
+  fire: {
+    email: "you@example.com",
+    plan: "pro",
+    isFirstRun: false,
+    portfolioTrend: [10, 10, 10, 9, 9, 8, 7, 6, 5, 4, 3, 2, 2, 2],
+    domains: [
+      dom("acme-mail.io", "F", "2h ago", 2),
+      dom("billing.acme.com", "F", "1h ago", 3),
+      dom("api.acme.com", "F", "30m ago", 1),
+      dom("acme.com", "B", "5h ago"),
+    ],
+    alerts: [
+      {
+        id: 11,
+        domain: "acme-mail.io",
+        alertType: "grade_drop",
+        previousValue: "B",
+        newValue: "F",
+        createdAt: FIXTURE_NOW - 2 * 3600,
+      },
+      {
+        id: 12,
+        domain: "billing.acme.com",
+        alertType: "protocol_regression",
+        previousValue: "dmarc:pass",
+        newValue: "dmarc:fail",
+        createdAt: FIXTURE_NOW - 3600,
+      },
+    ],
+  },
+  allGreen: {
+    email: "you@example.com",
+    plan: "pro",
+    isFirstRun: false,
+    portfolioTrend: Array.from({ length: 30 }, () => 11),
+    domains: [
+      dom("acme.com", "A", "2h ago"),
+      dom("acme-pay.com", "A", "2h ago"),
+      dom("billing.acme.com", "S", "2h ago"),
+      dom("support.acme.com", "A", "2h ago"),
+    ],
+    alerts: [],
+  },
+  firstRun: {
+    email: "newuser@example.com",
+    plan: "free",
+    isFirstRun: true,
+    portfolioTrend: [],
+    domains: [dom("example.com", "—", "Never")],
+    alerts: [],
+  },
+  free: {
+    email: "you@example.com",
+    plan: "free",
+    isFirstRun: false,
+    portfolioTrend: [9, 9, 8, 9, 9, 8, 9],
+    domains: [dom("example.com", "B", "1d ago")],
+    alerts: [],
+  },
+  zero: {
+    email: "newuser@example.com",
+    plan: "free",
+    isFirstRun: false,
+    portfolioTrend: [],
+    domains: [],
+    alerts: [],
+  },
+};
+
+export function renderDashboardFixture(name: DashboardFixtureName): string {
+  const fx = DASHBOARD_FIXTURES[name];
+  return renderDashboardPage({
+    email: fx.email,
+    plan: fx.plan,
+    alerts: fx.alerts,
+    portfolioTrend: fx.portfolioTrend,
+    isFirstRun: fx.isFirstRun,
+    domains: fx.domains,
+    controls: null,
+    usage: {
+      plan: fx.plan,
+      current: fx.domains.length,
+      cap: fx.plan === "pro" ? 25 : 1,
+    },
+  });
+}
+
+export function renderDashboardFixtureIndex(): string {
+  const links = DASHBOARD_FIXTURE_NAMES.map(
+    (n) => `<li><a href="/_dev/dashboard?fixture=${esc(n)}">${esc(n)}</a></li>`,
+  ).join("");
+  return `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Dashboard fixtures</title>
+<style>body{font:14px system-ui;padding:2rem;}a{color:#f97316;}</style></head>
+<body><h1>Dashboard fixture preview</h1><p>Local development only. Pick a scenario:</p>
+<ul>${links}</ul></body></html>`;
 }
 
 export function renderDomainDetailPage({

--- a/src/views/scripts.ts
+++ b/src/views/scripts.ts
@@ -794,4 +794,312 @@ if (typeof navigator !== 'undefined' && navigator.modelContext && typeof navigat
     loadFragment(paramsFromHref(href));
   });
 })();
+
+/* ============================================================
+   Dashboard drawer + add-domain wizard (PR 3)
+   Opens the drawer in-place when a row's domain link is clicked,
+   hydrating from /dashboard/domain/:domain.json. Falls back to the
+   existing HTML route /dashboard/domain/:domain when JS is off (the
+   anchor's href still points there). Wizard is a self-contained
+   3-step modal that posts to /dashboard/domain/add.
+   ============================================================ */
+(function() {
+  var drawer = document.getElementById('domain-drawer');
+  var wizard = document.getElementById('add-wizard');
+  if (!drawer && !wizard) return;
+
+  var FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+  var lastFocusedBeforeOpen = null;
+
+  function el(tag, attrs, children) {
+    var node = document.createElement(tag);
+    if (attrs) {
+      for (var k in attrs) {
+        if (k === 'class') node.className = attrs[k];
+        else if (k === 'style') node.setAttribute('style', attrs[k]);
+        else if (k === 'text') node.textContent = attrs[k];
+        else node.setAttribute(k, attrs[k]);
+      }
+    }
+    if (children) {
+      for (var i = 0; i < children.length; i++) {
+        if (children[i]) node.appendChild(children[i]);
+      }
+    }
+    return node;
+  }
+
+  function setOpen(target, open) {
+    if (!target) return;
+    var overlay = document.querySelector('[data-overlay-for="' + target.id + '"]');
+    if (open) {
+      target.hidden = false;
+      if (overlay) overlay.hidden = false;
+      requestAnimationFrame(function() {
+        target.setAttribute('data-open', '1');
+        if (overlay) overlay.setAttribute('data-open', '1');
+      });
+    } else {
+      target.removeAttribute('data-open');
+      if (overlay) overlay.removeAttribute('data-open');
+      setTimeout(function() {
+        target.hidden = true;
+        if (overlay) overlay.hidden = true;
+      }, 250);
+    }
+  }
+
+  function trapFocus(scope, ev) {
+    if (ev.key !== 'Tab') return;
+    var nodes = Array.prototype.slice.call(scope.querySelectorAll(FOCUSABLE)).filter(function(n) {
+      return !n.hidden && n.offsetParent !== null;
+    });
+    if (nodes.length === 0) return;
+    var first = nodes[0];
+    var last = nodes[nodes.length - 1];
+    if (ev.shiftKey && document.activeElement === first) {
+      ev.preventDefault();
+      last.focus();
+    } else if (!ev.shiftKey && document.activeElement === last) {
+      ev.preventDefault();
+      first.focus();
+    }
+  }
+
+  /* ---- Drawer ---- */
+  function setDrawerStatus(text, kind) {
+    var bodyEl = drawer.querySelector('[data-drawer-body]');
+    if (!bodyEl) return;
+    bodyEl.replaceChildren(el('div', {
+      class: kind === 'error' ? 'domain-drawer-error' : 'domain-drawer-loading',
+      text: text
+    }));
+  }
+
+  function openDrawer(domain, triggerEl) {
+    if (!drawer) return;
+    lastFocusedBeforeOpen = triggerEl || document.activeElement;
+    var titleEl = drawer.querySelector('.domain-drawer-title');
+    if (titleEl) titleEl.textContent = domain;
+    setDrawerStatus('Loading…');
+    setOpen(drawer, true);
+    setTimeout(function() {
+      var closeBtn = drawer.querySelector('[data-drawer-close]');
+      if (closeBtn) closeBtn.focus();
+    }, 30);
+
+    fetch('/dashboard/domain/' + encodeURIComponent(domain) + '.json', {
+      headers: { 'Accept': 'application/json' },
+      credentials: 'same-origin'
+    }).then(function(res) {
+      if (!res.ok) throw new Error('HTTP ' + res.status);
+      return res.json();
+    }).then(function(data) {
+      renderDrawerBody(data);
+    }).catch(function() {
+      var bodyEl = drawer.querySelector('[data-drawer-body]');
+      if (!bodyEl) return;
+      var fallback = el('a', {
+        href: '/dashboard/domain/' + encodeURIComponent(domain),
+        text: 'Open the full page instead.'
+      });
+      bodyEl.replaceChildren(
+        el('div', { class: 'domain-drawer-error' }, [
+          document.createTextNode('Couldn\\u2019t load detail. '),
+          fallback
+        ])
+      );
+    });
+  }
+
+  function renderDrawerBody(data) {
+    var bodyEl = drawer.querySelector('[data-drawer-body]');
+    if (!bodyEl) return;
+    var lastScan = data.lastScannedAt
+      ? new Date(data.lastScannedAt * 1000).toLocaleString()
+      : 'Never';
+
+    function metaSpan(label, value) {
+      var strong = el('strong', { text: label + ':' });
+      var span = el('span');
+      span.appendChild(strong);
+      span.appendChild(document.createTextNode(' ' + (value || '\\u2014')));
+      return span;
+    }
+    var meta = el('div', { class: 'domain-drawer-meta' }, [
+      metaSpan('Grade', data.grade),
+      metaSpan('Last scan', lastScan),
+      metaSpan('Frequency', data.scanFrequency)
+    ]);
+
+    var historyEl;
+    var rows = data.history || [];
+    if (rows.length === 0) {
+      historyEl = el('p', {
+        style: 'color:var(--clr-text-muted);font-size:0.85rem;',
+        text: 'No scan history yet.'
+      });
+    } else {
+      var tbody = el('tbody');
+      rows.slice(0, 8).forEach(function(h) {
+        var when = new Date(h.scannedAt * 1000).toLocaleDateString();
+        tbody.appendChild(el('tr', null, [
+          el('td', {
+            style: 'padding:4px 0;color:var(--clr-text-muted);font-size:0.8rem;',
+            text: when
+          }),
+          el('td', {
+            style: 'padding:4px 0;font-weight:600;',
+            text: String(h.grade)
+          })
+        ]));
+      });
+      historyEl = el('table', {
+        style: 'width:100%;border-collapse:collapse;margin-top:0.5rem;'
+      }, [tbody]);
+    }
+
+    var actions = el('div', { class: 'domain-drawer-actions' }, [
+      el('a', {
+        href: '/dashboard/domain/' + encodeURIComponent(data.domain),
+        class: 'dashboard-add-btn',
+        style: 'background:transparent;color:var(--clr-text);border-color:var(--clr-border);',
+        text: 'Open full page'
+      }),
+      (function() {
+        var form = el('form', {
+          method: 'post',
+          action: '/dashboard/domain/' + encodeURIComponent(data.domain) + '/scan',
+          style: 'margin:0;'
+        }, [
+          el('button', { type: 'submit', class: 'dashboard-add-btn', text: 'Re-scan now' })
+        ]);
+        return form;
+      })()
+    ]);
+
+    bodyEl.replaceChildren(meta, historyEl, actions);
+  }
+
+  function closeDrawer() {
+    if (!drawer) return;
+    setOpen(drawer, false);
+    if (lastFocusedBeforeOpen && lastFocusedBeforeOpen.focus) {
+      lastFocusedBeforeOpen.focus();
+    }
+  }
+
+  if (drawer) {
+    document.addEventListener('click', function(e) {
+      var t = e.target;
+      if (!t || !t.closest) return;
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+      var link = t.closest('[data-drawer-link]');
+      if (!link) return;
+      var row = link.closest('[data-domain]');
+      var domain = row ? row.getAttribute('data-domain') : link.textContent.trim();
+      if (!domain) return;
+      e.preventDefault();
+      openDrawer(domain, link);
+    });
+
+    document.addEventListener('click', function(e) {
+      var t = e.target;
+      if (!t || !t.matches) return;
+      if (t.matches('[data-drawer-close]') || t.matches('[data-overlay-for="domain-drawer"]')) {
+        closeDrawer();
+      }
+    });
+
+    drawer.addEventListener('keydown', function(e) {
+      if (e.key === 'Escape') closeDrawer();
+      else trapFocus(drawer, e);
+    });
+  }
+
+  /* ---- Wizard ---- */
+  if (wizard) {
+    var form = wizard.querySelector('[data-wizard-form]');
+    var pill = wizard.querySelector('[data-wizard-pill]');
+    var backBtn = wizard.querySelector('[data-wizard-back]');
+    var nextBtn = wizard.querySelector('[data-wizard-next]');
+    var submitBtn = wizard.querySelector('[data-wizard-submit]');
+    var errorEl = wizard.querySelector('[data-wizard-error]');
+    var domainInput = wizard.querySelector('#wizard-domain');
+    var freqSelect = wizard.querySelector('#wizard-frequency');
+    var confirmDom = wizard.querySelector('[data-wizard-confirm-domain]');
+    var confirmFreq = wizard.querySelector('[data-wizard-confirm-frequency]');
+    var step = 1;
+
+    function showStep(n) {
+      step = n;
+      var steps = wizard.querySelectorAll('[data-step]');
+      for (var i = 0; i < steps.length; i++) {
+        var stepNum = parseInt(steps[i].getAttribute('data-step'), 10);
+        if (stepNum === n) steps[i].setAttribute('data-active', '1');
+        else steps[i].removeAttribute('data-active');
+      }
+      if (pill) pill.textContent = 'Step ' + n + ' of 3';
+      if (backBtn) backBtn.hidden = n === 1;
+      if (nextBtn) nextBtn.hidden = n === 3;
+      if (submitBtn) submitBtn.hidden = n !== 3;
+      setTimeout(function() {
+        var active = wizard.querySelector('[data-step="' + n + '"]');
+        if (!active) return;
+        var first = active.querySelector('input, select, textarea, button');
+        if (first) first.focus();
+      }, 50);
+    }
+
+    function openWizard(triggerEl) {
+      lastFocusedBeforeOpen = triggerEl || document.activeElement;
+      if (form) form.reset();
+      if (errorEl) { errorEl.hidden = true; errorEl.textContent = ''; }
+      showStep(1);
+      setOpen(wizard, true);
+    }
+    function closeWizard() {
+      setOpen(wizard, false);
+      if (lastFocusedBeforeOpen && lastFocusedBeforeOpen.focus) {
+        lastFocusedBeforeOpen.focus();
+      }
+    }
+
+    document.addEventListener('click', function(e) {
+      var t = e.target;
+      if (!t || !t.matches) return;
+      if (t.matches('[data-wizard-open]')) {
+        e.preventDefault();
+        openWizard(t);
+      } else if (t.matches('[data-wizard-close]') || t.matches('[data-overlay-for="add-wizard"]')) {
+        closeWizard();
+      } else if (t.matches('[data-wizard-back]')) {
+        if (step > 1) showStep(step - 1);
+      } else if (t.matches('[data-wizard-next]')) {
+        if (step === 1) {
+          var raw = domainInput && domainInput.value.trim().toLowerCase();
+          if (!raw || !/^[a-z0-9.-]+\\.[a-z]{2,}$/.test(raw)) {
+            if (errorEl) {
+              errorEl.textContent = 'Enter a valid domain like example.com.';
+              errorEl.hidden = false;
+            }
+            return;
+          }
+          if (errorEl) errorEl.hidden = true;
+          if (confirmDom) confirmDom.textContent = raw;
+          showStep(2);
+        } else if (step === 2) {
+          var freq = freqSelect ? freqSelect.value : 'weekly';
+          if (confirmFreq) confirmFreq.textContent = freq;
+          showStep(3);
+        }
+      }
+    });
+
+    wizard.addEventListener('keydown', function(e) {
+      if (e.key === 'Escape') closeWizard();
+      else trapFocus(wizard, e);
+    });
+  }
+})();
 `;

--- a/src/views/styles.ts
+++ b/src/views/styles.ts
@@ -34,6 +34,8 @@ export const CSS = `
   --clr-info-glow: rgba(37,99,235,0.25);
   --clr-shadow: rgba(0,0,0,0.12);
   --clr-accent-glow: rgba(234,88,12,0.2);
+  --clr-accent-muted: rgba(194,65,12,0.08);
+  --clr-surface-muted: #f4f4f5;
 }
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme="light"]) {
@@ -69,6 +71,8 @@ export const CSS = `
     --clr-info-glow: rgba(59,130,246,0.25);
     --clr-shadow: rgba(0,0,0,0.3);
     --clr-accent-glow: rgba(249,115,22,0.3);
+    --clr-accent-muted: rgba(249,115,22,0.08);
+    --clr-surface-muted: #1f1f23;
   }
 }
 [data-theme="dark"] {
@@ -104,6 +108,8 @@ export const CSS = `
   --clr-info-glow: rgba(59,130,246,0.25);
   --clr-shadow: rgba(0,0,0,0.3);
   --clr-accent-glow: rgba(249,115,22,0.3);
+  --clr-accent-muted: rgba(249,115,22,0.08);
+  --clr-surface-muted: #1f1f23;
 }
 [data-theme="light"] { color-scheme: light; }
 body {
@@ -892,16 +898,19 @@ h1.domain-name, .domain-name { font-size: 1.5rem; font-weight: 700; margin: 0; }
 .creature-sm .creature-hat::after { top: 8px; left: -6px; width: 12px; height: 3px; }
 .creature-sm .creature-hat::before { top: -3px; left: -1px; width: 3px; height: 3px; }
 
-/* Loading creature — walking animation */
-.creature-loading .creature-leg:nth-child(odd) {
+/* Loading / walking creature — leg animation */
+.creature-loading .creature-leg:nth-child(odd),
+.creature-walking .creature-leg:nth-child(odd) {
   animation: creature-walk 0.3s ease-in-out infinite alternate;
 }
-.creature-loading .creature-leg:nth-child(even) {
+.creature-loading .creature-leg:nth-child(even),
+.creature-walking .creature-leg:nth-child(even) {
   animation: creature-walk 0.3s ease-in-out infinite alternate-reverse;
 }
 @media (prefers-reduced-motion: reduce) {
   .at-creature { display: none !important; }
-  .creature-loading .creature-leg { animation: none !important; }
+  .creature-loading .creature-leg,
+  .creature-walking .creature-leg { animation: none !important; }
   .grade-s { animation: none; }
   .creature-partying { animation: none; }
   .creature-partying .creature-leg { animation: none; }

--- a/test/components.test.ts
+++ b/test/components.test.ts
@@ -7,6 +7,9 @@ import {
   gradeToMood,
   monitorSnapshotCard,
   mxTable,
+  singlePointTrendStub,
+  sparkline,
+  statCard,
   statusDot,
   themeToggle,
 } from "../src/views/components";
@@ -138,6 +141,128 @@ describe("generateCreature", () => {
   it("includes aria-hidden for decorative use", () => {
     const html = generateCreature("md");
     expect(html).toContain('aria-hidden="true"');
+  });
+
+  it("adds creature-walking class when walking=true", () => {
+    const html = generateCreature("md", "content", false, true);
+    expect(html).toContain("creature-walking");
+  });
+
+  it("omits creature-walking when walking is undefined or false", () => {
+    expect(generateCreature("md")).not.toContain("creature-walking");
+    expect(generateCreature("md", "content", true, false)).not.toContain(
+      "creature-walking",
+    );
+  });
+
+  it("composes walking with mood and partyHat without leaking classes", () => {
+    const html = generateCreature("lg", "celebrating", true, true);
+    expect(html).toContain("creature-celebrating");
+    expect(html).toContain("creature-partying");
+    expect(html).toContain("creature-walking");
+    expect(html).toContain('<div class="creature-hat"></div>');
+  });
+});
+
+describe("statCard", () => {
+  it("renders label, value, and sub", () => {
+    const html = statCard("Domains", 12, "of 25 total");
+    expect(html).toContain("stat-card");
+    expect(html).toContain("Domains");
+    expect(html).toContain("12");
+    expect(html).toContain("of 25 total");
+  });
+
+  it("escapes user-controlled label and sub", () => {
+    const html = statCard("<bad>", 0, "x&y");
+    expect(html).toContain("&lt;bad&gt;");
+    expect(html).toContain("x&amp;y");
+    expect(html).not.toContain("<bad>");
+  });
+
+  it("adds status-tinted class when status given", () => {
+    expect(statCard("Failing", 1, "needs fix", "fail")).toContain(
+      "stat-card-fail",
+    );
+    expect(statCard("Healthy", 5, "ok", "pass")).toContain("stat-card-pass");
+    expect(statCard("Drifting", 2, "warn", "warn")).toContain("stat-card-warn");
+  });
+
+  it("omits tint when no status", () => {
+    const html = statCard("Total", 7, "all domains");
+    expect(html).not.toMatch(/stat-card-(pass|warn|fail)/);
+  });
+});
+
+describe("sparkline", () => {
+  it("emits svg with polyline for non-empty values", () => {
+    const html = sparkline([1, 2, 3, 4], "var(--clr-accent)");
+    expect(html).toContain("<svg");
+    expect(html).toContain("polyline");
+    expect(html).toContain("var(--clr-accent)");
+  });
+
+  it("returns empty svg when values are empty", () => {
+    const html = sparkline([], "var(--clr-accent)");
+    expect(html).toContain("<svg");
+    expect(html).not.toContain("polyline");
+  });
+
+  it("optionally renders an area fill", () => {
+    const html = sparkline([1, 2, 3], "var(--clr-pass)", { fill: true });
+    expect(html).toContain("<polygon");
+    expect(html).toContain('opacity="0.12"');
+  });
+
+  it("clamps values outside [min,max]", () => {
+    const html = sparkline([-5, 50], "var(--clr-fail)", { min: 0, max: 12 });
+    // No NaN should appear in points
+    expect(html).not.toContain("NaN");
+  });
+
+  it("uses width and height options", () => {
+    const html = sparkline([1, 2], "var(--clr-accent)", {
+      width: 120,
+      height: 40,
+    });
+    expect(html).toContain('width="120"');
+    expect(html).toContain('height="40"');
+  });
+
+  it("escapes color to prevent attribute injection", () => {
+    const html = sparkline([1, 2], '"><script>x</script>');
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("adds role and aria-label when provided", () => {
+    const html = sparkline([1, 2], "var(--clr-accent)", {
+      ariaLabel: "Trend over 7 days",
+    });
+    expect(html).toContain('role="img"');
+    expect(html).toContain('aria-label="Trend over 7 days"');
+  });
+
+  it("uses aria-hidden when no label provided", () => {
+    const html = sparkline([1, 2], "var(--clr-accent)");
+    expect(html).toContain('aria-hidden="true"');
+    expect(html).not.toContain('role="img"');
+  });
+});
+
+describe("singlePointTrendStub", () => {
+  it("renders dashed baseline + dot + 'new' label", () => {
+    const html = singlePointTrendStub();
+    expect(html).toContain("trend-stub");
+    expect(html).toContain("stroke-dasharray");
+    expect(html).toContain("<circle");
+    expect(html).toContain("new");
+  });
+
+  it("is keyboard-focusable with an aria-label", () => {
+    const html = singlePointTrendStub();
+    expect(html).toContain('tabindex="0"');
+    expect(html).toContain("aria-label");
   });
 });
 

--- a/test/dashboard-routes.test.ts
+++ b/test/dashboard-routes.test.ts
@@ -772,6 +772,66 @@ describe("dashboard/routes", () => {
     });
   });
 
+  describe("GET /dashboard/domain/:domain.json (drawer endpoint)", () => {
+    it("redirects to /auth/login without a session cookie", async () => {
+      const db = createMockDB({});
+      const app = createTestApp(db);
+      const res = await app.request("/dashboard/domain/example.com.json");
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/auth/login");
+    });
+
+    it("returns 404 JSON when the domain doesn't belong to the user", async () => {
+      const db = createMockDB({ domains: [] });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/domain/notmine.com.json", {
+        headers: { Cookie: cookie, Accept: "application/json" },
+      });
+      expect(res.status).toBe(404);
+      const body = (await res.json()) as { error?: string };
+      expect(body.error).toBe("Domain not found");
+    });
+
+    it("returns the drawer payload for an owned domain", async () => {
+      const db = createMockDB({
+        domains: [
+          {
+            id: 1,
+            user_id: "user_1",
+            domain: "example.com",
+            is_free: 0,
+            scan_frequency: "weekly",
+            last_scanned_at: 1700000000,
+            last_grade: "B",
+            created_at: 1700000000,
+          },
+        ],
+        scanHistory: [{ grade: "B", scanned_at: 1700000000 }],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/domain/example.com.json", {
+        headers: { Cookie: cookie, Accept: "application/json" },
+      });
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("application/json");
+      const body = (await res.json()) as {
+        domain: string;
+        grade: string;
+        lastScannedAt: number | null;
+        scanFrequency: string;
+        history: { scannedAt: number; grade: string }[];
+      };
+      expect(body.domain).toBe("example.com");
+      expect(body.grade).toBe("B");
+      expect(body.scanFrequency).toBe("weekly");
+      expect(body.lastScannedAt).toBe(1700000000);
+      expect(body.history).toHaveLength(1);
+      expect(body.history[0].grade).toBe("B");
+    });
+  });
+
   describe("GET /dashboard/domain/:domain/history", () => {
     const domainFixture = {
       id: 1,

--- a/test/dashboard-views.test.ts
+++ b/test/dashboard-views.test.ts
@@ -426,6 +426,48 @@ describe("renderDashboardPage", () => {
       expect(html).toMatch(/Everything('|&#39;)s green/);
     });
 
+    it("does not panic or party when the only domain is ungraded", () => {
+      // A fresh user with one not-yet-scanned domain. Bug we're guarding:
+      // gradeToMood('—') used to fall through to 'panicked', so DMarcus
+      // screamed at a user who hadn't received their first scan back. The
+      // hero should be neutral and the voice line should acknowledge the
+      // scan-in-progress state.
+      const html = renderDashboardPage({
+        email: "u@x.com",
+        domains: [sample("—", "fresh.example")],
+      });
+      expect(html).not.toMatch(/<div class="creature[^"]*creature-panicked/);
+      expect(html).not.toMatch(/<div class="creature[^"]*creature-partying/);
+      expect(html).toContain("Scanning your");
+    });
+
+    it("picks the worst graded domain even when an ungraded one comes first", () => {
+      // worstDomain bug we're guarding: when seeded with an ungraded entry,
+      // the prior implementation could promote a healthy domain to "worst"
+      // and let DMarcus celebrate while another domain was failing.
+      const html = renderDashboardPage({
+        email: "u@x.com",
+        domains: [
+          sample("—", "fresh.example"),
+          sample("F", "broken.example"),
+          sample("A", "good.example"),
+        ],
+      });
+      expect(html).toContain("broken.example");
+      expect(html).not.toMatch(/good\.example<\/code> is failing/);
+      // Failing portfolio must not party-hat regardless of insertion order.
+      expect(html).not.toMatch(/<div class="creature[^"]*creature-partying/);
+    });
+
+    it("does not party-hat a 100% ungraded portfolio", () => {
+      const html = renderDashboardPage({
+        email: "u@x.com",
+        domains: [sample("—", "a.com"), sample("—", "b.com")],
+      });
+      expect(html).not.toMatch(/<div class="creature[^"]*creature-partying/);
+      expect(html).toContain("Scanning your 2 domains");
+    });
+
     it("preserves the existing alerts section markup above the table", () => {
       const html = renderDashboardPage({
         email: "u@x.com",

--- a/test/dashboard-views.test.ts
+++ b/test/dashboard-views.test.ts
@@ -468,6 +468,30 @@ describe("renderDashboardPage", () => {
       expect(html).toContain("Scanning your 2 domains");
     });
 
+    it("renders the drawer + wizard shells with data hooks but hidden", () => {
+      const html = renderDashboardPage({
+        email: "u@x.com",
+        domains: [sample("A")],
+      });
+      // Drawer shell present and hidden by default
+      expect(html).toContain('id="domain-drawer"');
+      expect(html).toContain('role="dialog"');
+      expect(html).toContain('aria-modal="true"');
+      expect(html).toMatch(/<aside[^>]+id="domain-drawer"[^>]+hidden/);
+      expect(html).toContain("data-drawer-close");
+      // Wizard shell present and hidden by default
+      expect(html).toContain('id="add-wizard"');
+      expect(html).toMatch(/<div[^>]+id="add-wizard"[^>]+hidden/);
+      expect(html).toContain("data-wizard-form");
+      expect(html).toContain('action="/dashboard/domain/add"');
+      expect(html).toContain("Step 1 of 3");
+      // Add-domain trigger button rendered next to the table heading
+      expect(html).toContain("data-wizard-open");
+      // Each table row carries data-domain so the drawer JS knows what to load
+      expect(html).toContain('data-domain="example.com"');
+      expect(html).toContain("data-drawer-link");
+    });
+
     it("preserves the existing alerts section markup above the table", () => {
       const html = renderDashboardPage({
         email: "u@x.com",

--- a/test/dashboard-views.test.ts
+++ b/test/dashboard-views.test.ts
@@ -287,6 +287,164 @@ describe("renderDashboardPage", () => {
     expect(html).not.toContain("<script>alert(1)</script>");
     expect(html).toContain("&lt;script&gt;");
   });
+
+  describe("hero + banners + stat strip", () => {
+    const sample = (
+      grade: string,
+      domain = "example.com",
+    ): {
+      domain: string;
+      grade: string;
+      frequency: string;
+      lastScanned: string | null;
+      isFree: boolean;
+    } => ({
+      domain,
+      grade,
+      frequency: "daily",
+      lastScanned: "2026-04-25",
+      isFree: false,
+    });
+
+    // Bare class names appear inside the inlined CSS too, so assertions
+    // target the rendered element/attribute pattern instead. `class="…"`
+    // matches per-element, not per-stylesheet rule.
+    const hasSection = (html: string, className: string): boolean =>
+      html.includes(`class="${className}`) ||
+      html.includes(`class="dashboard-banner ${className}`) ||
+      html.includes(`class="stat-card ${className}`);
+
+    it("renders an empty-portfolio hero with a prompt to add a domain", () => {
+      const html = renderDashboardPage({
+        email: "user@example.com",
+        domains: [],
+      });
+      expect(html).toContain('class="dashboard-hero"');
+      expect(html).toContain("Add a domain");
+      // No stat strip when zero domains.
+      expect(html).not.toContain('class="stat-strip"');
+    });
+
+    it("renders the stat strip with derived counts", () => {
+      const html = renderDashboardPage({
+        email: "user@example.com",
+        domains: [
+          sample("A", "a.com"),
+          sample("B", "b.com"),
+          sample("C", "c.com"),
+          sample("D", "d.com"),
+          sample("F", "f.com"),
+        ],
+      });
+      expect(html).toContain('class="stat-strip"');
+      expect(hasSection(html, "stat-card-pass")).toBe(true); // 2 healthy
+      expect(hasSection(html, "stat-card-warn")).toBe(true); // 2 drifting
+      expect(hasSection(html, "stat-card-fail")).toBe(true); // 1 failing
+    });
+
+    it("renders the free-tier banner only when plan=free", () => {
+      const free = renderDashboardPage({
+        email: "u@x.com",
+        plan: "free",
+        domains: [sample("A")],
+      });
+      expect(hasSection(free, "dashboard-banner-free")).toBe(true);
+      expect(free).toContain("$19/mo");
+      expect(free).toContain("/pricing");
+      const pro = renderDashboardPage({
+        email: "u@x.com",
+        plan: "pro",
+        domains: [sample("A")],
+      });
+      expect(hasSection(pro, "dashboard-banner-free")).toBe(false);
+    });
+
+    it("renders the first-run banner only when isFirstRun and exactly one domain", () => {
+      const html = renderDashboardPage({
+        email: "u@x.com",
+        domains: [sample("A", "auto-provisioned.example")],
+        isFirstRun: true,
+      });
+      expect(hasSection(html, "dashboard-banner-firstrun")).toBe(true);
+      expect(html).toContain("auto-provisioned.example");
+      const noBanner = renderDashboardPage({
+        email: "u@x.com",
+        domains: [sample("A", "a.com"), sample("B", "b.com")],
+        isFirstRun: true,
+      });
+      expect(hasSection(noBanner, "dashboard-banner-firstrun")).toBe(false);
+    });
+
+    it("renders the on-fire banner when 3+ domains are failing", () => {
+      const html = renderDashboardPage({
+        email: "u@x.com",
+        domains: [
+          sample("F", "x.com"),
+          sample("F", "y.com"),
+          sample("F", "z.com"),
+        ],
+      });
+      expect(hasSection(html, "dashboard-banner-fire")).toBe(true);
+      expect(html).toContain("3 domains failing");
+      const tame = renderDashboardPage({
+        email: "u@x.com",
+        domains: [sample("F", "x.com"), sample("F", "y.com")],
+      });
+      expect(hasSection(tame, "dashboard-banner-fire")).toBe(false);
+    });
+
+    it("renders the portfolio sparkline only when 2+ trend points", () => {
+      const withTrend = renderDashboardPage({
+        email: "u@x.com",
+        domains: [sample("A")],
+        portfolioTrend: [8, 9, 10, 11, 12],
+      });
+      expect(withTrend).toContain('<svg class="dash-spark"');
+      const noTrend = renderDashboardPage({
+        email: "u@x.com",
+        domains: [sample("A")],
+        portfolioTrend: [10],
+      });
+      expect(noTrend).not.toContain('<svg class="dash-spark"');
+    });
+
+    it("escapes domain names in the hero voice line", () => {
+      const html = renderDashboardPage({
+        email: "u@x.com",
+        domains: [sample("F", "<script>x</script>.com")],
+      });
+      expect(html).not.toContain("<script>x</script>");
+      expect(html).toContain("&lt;script&gt;");
+    });
+
+    it("celebrates with party hat when no failures and no drift", () => {
+      const html = renderDashboardPage({
+        email: "u@x.com",
+        domains: [sample("A", "a.com"), sample("S", "b.com")],
+      });
+      expect(html).toContain("creature-partying");
+      expect(html).toMatch(/Everything('|&#39;)s green/);
+    });
+
+    it("preserves the existing alerts section markup above the table", () => {
+      const html = renderDashboardPage({
+        email: "u@x.com",
+        domains: [sample("F", "broken.com")],
+        alerts: [
+          {
+            id: 1,
+            domain: "broken.com",
+            alertType: "grade_drop",
+            previousValue: "B",
+            newValue: "F",
+            createdAt: Math.floor(Date.now() / 1000) - 60,
+          },
+        ],
+      });
+      expect(html).toContain("alerts-needs-attention");
+      expect(html).toContain("Grade dropped from B to F");
+    });
+  });
 });
 
 describe("renderDomainDetailPage", () => {


### PR DESCRIPTION
## Summary

Ports the design handoff in `docs/dmarcheck.zip` into the live dashboard across four layered commits: design-language primitives, the visual refresh of `/dashboard`, three correctness fixes (with a local fixture-preview tool), and a slide-in drawer + 3-step add-domain wizard that replace the multi-page navigation.

## What changed

**[d539582] Design-language primitives** — `--clr-accent-muted` / `--clr-surface-muted` tokens; optional `walking` prop on `generateCreature` (sharing the existing `creature-walk` keyframes); new `statCard` / `sparkline` / `singlePointTrendStub` helpers.

**[9dc238b] Dashboard visual refresh** — banners (free-tier `$19/mo` upgrade, first-run welcome, on-fire when 3+ failing), DMarcus speech-bubble hero with portfolio score + 30-day sparkline, status-tinted stat strip (Domains / Healthy / Drifting / Failing), `getPortfolioTrendForUser` aggregation in the data layer (no schema change). Existing alerts section + sortable table + pagination preserved underneath.

**[3dca3d1] Three correctness fixes + fixture preview** — DMarcus no longer panics on a fresh, unscored portfolio; `worstDomain` skips ungraded entries instead of mis-ranking; party-hat now requires `stats.healthy > 0`. Adds `/_dev/dashboard?fixture=<name>` (six scenarios from the handoff bundle) gated on the absence of `WORKOS_API_KEY` so it ships off in production.

**[536e0b2] Drawer + wizard** — `GET /dashboard/domain/:domain.json` powers a slide-in drawer that hydrates lazily; 3-step modal wizard posts to the existing `/dashboard/domain/add`. Vanilla-JS controller with focus trap, ESC, overlay-click, and focus restore — built with `createElement` / `replaceChildren` / `textContent`, no `innerHTML`. Legacy HTML routes (`/dashboard/domain/:domain`, `/dashboard/domain/add`) stay reachable as a JS-off / shareable-link fallback.

## Why

The handoff was already half-shipped: V2 (top-right login pill) and V6 (post-scan monitor card) had landed previously, and the dashboard infrastructure (auth, schema, routes) was wired. What was missing was the *visual* refresh — the existing dashboard was a utilitarian table-and-toolbar app, not the personality-led status page the prototype proposed. These four commits close that gap without touching scan logic, auth, the DB schema, or the existing fragment / pagination behavior.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 785 pass (47 of 47 files)
- [x] Walked all six fixtures locally via `/_dev/dashboard?fixture=…` — current / fire / allGreen / firstRun / free / zero — desktop, mobile (375px), light + dark themes. Screenshots in the spawning conversation.
- [x] Wizard: open → type → next → cadence → next → confirm → back → close + ESC + validation error. All work.
- [x] Drawer: row click opens, JSON fetch hydrates body, error path renders the legacy-page fallback link, ESC closes.
- [x] Verified `/` (landing) still ships the V2 nav pill and `/check` still ships the V6 monitor card — no regression in the prior PRs.

## Reviewer notes

- The `/_dev/dashboard` route is **off** when `WORKOS_API_KEY` is set, which it always is in production (and via Cloudflare's Workers Builds env). It exists for local design iteration and is a useful long-lived tool for future renderer work.
- The hero's `portfolioTrend` aggregation is bounded by `PRO_WATCHLIST_CAP × days` (~750 rows worst case) — no risk of an unbounded scan over `scan_history`.
- Drawer + wizard are additive: the legacy `/dashboard/domain/:domain` and `/dashboard/domain/add` HTML routes still 200 and are linked-to as JS-off fallbacks. Shareable per-domain URLs continue to work.
- Known follow-up: the mobile-width `100vw` override on `.domain-drawer` didn't fully apply in one quick mobile-resize check; desktop pattern is correct, mobile breakpoint deserves a closer look in a separate iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)