### PR TITLE
🎨 Palette: [Add aria-controls and aria-labelledby for expandable cards]

### DIFF
--- a/src/views/components.ts
+++ b/src/views/components.ts
@@ -231,17 +231,21 @@ export function protocolCard(
   expanded = false,
   learnSlug?: string,
 ): string {
+  const safeId = name.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+  const headerId = `card-header-${safeId}`;
+  const bodyId = `card-body-${safeId}`;
+
   const learnLink = learnSlug
     ? `<div class="card-learn-link"><a href="/learn/${esc(learnSlug)}">Learn about ${esc(name)} &rarr;</a></div>`
     : "";
   return `<div class="card${expanded ? " expanded" : ""}">
-  <div class="card-header" role="button" tabindex="0" aria-expanded="${expanded ? "true" : "false"}">
+  <div class="card-header" id="${headerId}" role="button" tabindex="0" aria-expanded="${expanded ? "true" : "false"}" aria-controls="${bodyId}">
     ${statusDot(status)}
     <div class="card-title">${esc(name)}</div>
     <div class="card-subtitle">${esc(subtitle)}</div>
     <div class="card-chevron" aria-hidden="true">&#9654;</div>
   </div>
-  <div class="card-body">${body}${learnLink}</div>
+  <div class="card-body" id="${bodyId}" role="region" aria-labelledby="${headerId}">${body}${learnLink}</div>
 </div>`;
 }
 
@@ -258,13 +262,28 @@ export function spfTree(node: SpfIncludeNode): string {
     .join("");
 
   const includes = node.includes
-    .map((child) => {
+    .map((child, i) => {
       const inner = spfTreeInner(child);
       const isExpandable = inner !== "";
+      const safeId = child.domain.replace(/[^a-z0-9]+/g, "-");
+      const listId = `spf-list-${safeId}-${i}`;
       const attrs = isExpandable
-        ? ` role="button" tabindex="0" aria-expanded="true"`
+        ? ' role="button" tabindex="0" aria-expanded="true" aria-controls="' +
+          listId +
+          '"'
         : "";
-      return `<li><span class="spf-node include"${attrs}>${esc(`include:${child.domain}`)}</span>${inner}</li>`;
+      const innerWithId = isExpandable
+        ? inner.replace("<ul>", `<ul id="${listId}">`)
+        : inner;
+      return (
+        '<li><span class="spf-node include"' +
+        attrs +
+        ">" +
+        esc(`include:${child.domain}`) +
+        "</span>" +
+        innerWithId +
+        "</li>"
+      );
     })
     .join("");
 
@@ -284,13 +303,28 @@ function spfTreeInner(node: SpfIncludeNode): string {
     .join("");
 
   const includes = node.includes
-    .map((child) => {
+    .map((child, i) => {
       const inner = spfTreeInner(child);
       const isExpandable = inner !== "";
+      const safeId = child.domain.replace(/[^a-z0-9]+/g, "-");
+      const listId = `spf-list-${safeId}-${i}`;
       const attrs = isExpandable
-        ? ` role="button" tabindex="0" aria-expanded="true"`
+        ? ' role="button" tabindex="0" aria-expanded="true" aria-controls="' +
+          listId +
+          '"'
         : "";
-      return `<li><span class="spf-node include"${attrs}>${esc(`include:${child.domain}`)}</span>${inner}</li>`;
+      const innerWithId = isExpandable
+        ? inner.replace("<ul>", `<ul id="${listId}">`)
+        : inner;
+      return (
+        '<li><span class="spf-node include"' +
+        attrs +
+        ">" +
+        esc(`include:${child.domain}`) +
+        "</span>" +
+        innerWithId +
+        "</li>"
+      );
     })
     .join("");
 


### PR DESCRIPTION
### 💡 What
Added proper ARIA region bindings to the custom expandable protocol cards and nested SPF tree nodes in `src/views/components.ts`.

### 🎯 Why
The protocol cards and SPF tree nodes use custom HTML/JS to mimic the behavior of native `<details>`/`<summary>` elements. While they previously correctly toggled `aria-expanded`, they did not link the toggle trigger to the content it controls. This meant screen reader users were informed a button could expand something, but couldn't easily navigate to the newly revealed content.

### 📸 Before/After
*(Visuals remain identical as this is a purely semantic/accessibility update)*

### ♿ Accessibility
- Added generated `id`s to the `.card-header` and `.card-body` elements.
- Added `aria-controls="{bodyId}"` to the `.card-header` trigger.
- Added `role="region"` and `aria-labelledby="{headerId}"` to the `.card-body` content container.
- Added similar dynamically generated `id`s and `aria-controls` bindings to the nested `<ul>` elements within the `spfTree` component.
- These changes bring the custom components into compliance with the standard WAI-ARIA Accordion pattern, ensuring robust screen reader support.

---
*PR created automatically by Jules for task [446652103467147591](https://jules.google.com/task/446652103467147591) started by @schmug*