### PR TITLE
feat(auth): Cloudflare Access JWT on workers.dev preview deploys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "@sentry/cloudflare": "^10.47.0",
-        "hono": "^4.12.14"
+        "hono": "^4.12.14",
+        "jose": "^6.2.2"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.10",
@@ -322,7 +323,8 @@
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260423.1.tgz",
       "integrity": "sha512-SHIc0NeJMtn0sW043eWtMxYFbJ9VPSLkcx+FEqCk0uZLD3HrWT+5xWhm6EYiOYDg0vnrlXNHcu2ly/01zDh3bw==",
       "devOptional": true,
-      "license": "MIT OR Apache-2.0"
+      "license": "MIT OR Apache-2.0",
+      "peer": true
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -343,6 +345,7 @@
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -354,6 +357,7 @@
       "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1770,6 +1774,7 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -1838,6 +1843,7 @@
       "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.4",
         "pathe": "^2.0.3"
@@ -1852,6 +1858,7 @@
       "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "4.1.4",
         "@vitest/utils": "4.1.4",
@@ -2071,6 +2078,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/kleur": {
@@ -2432,6 +2448,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2692,6 +2709,7 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -2702,6 +2720,7 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -2780,6 +2799,7 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -2888,6 +2908,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@sentry/cloudflare": "^10.47.0",
-    "hono": "^4.12.14"
+    "hono": "^4.12.14",
+    "jose": "^6.2.2"
   }
 }

--- a/src/auth/access-jwt.ts
+++ b/src/auth/access-jwt.ts
@@ -1,0 +1,167 @@
+import type { Context, Next } from "hono";
+import { getCookie } from "hono/cookie";
+import {
+  createRemoteJWKSet,
+  type JWTPayload,
+  type JWTVerifyGetKey,
+  jwtVerify,
+} from "jose";
+
+// Cloudflare Access JWT validator for preview-branch deploys served on
+// `*.workers.dev`. The production custom domain (`dmarc.mx`) is intentionally
+// not protected by Access — public scanning is the whole product. This
+// middleware exists so the preview URLs (which Cloudflare Access guards via a
+// Self-Hosted application) cannot be reached out-of-band even if Access ever
+// failed to attach to a hostname (defense-in-depth, not the primary control).
+//
+// Verification is delegated to `jose` — pinning `algorithms: ["RS256"]`
+// closes the alg-confusion / `alg: none` foot-guns that hand-rolled JWT
+// verification typically misses.
+
+const jwksResolvers = new Map<string, JWTVerifyGetKey>();
+
+function getJwksResolver(teamDomain: string): JWTVerifyGetKey {
+  let resolver = jwksResolvers.get(teamDomain);
+  if (!resolver) {
+    resolver = createRemoteJWKSet(
+      new URL(`https://${teamDomain}/cdn-cgi/access/certs`),
+    );
+    jwksResolvers.set(teamDomain, resolver);
+  }
+  return resolver;
+}
+
+export type VerifyFailReason =
+  | "malformed"
+  | "expired"
+  | "bad_signature"
+  | "bad_aud"
+  | "bad_iss"
+  | "unsupported_alg"
+  | "jwks_unavailable"
+  | "verify_error";
+
+export type AccessVerifyResult =
+  | { ok: true; payload: JWTPayload }
+  | { ok: false; reason: VerifyFailReason };
+
+export interface AccessVerifyOptions {
+  aud: string;
+  teamDomain: string;
+  // Inject a JWKS resolver (e.g. `createLocalJWKSet`) for tests so we can
+  // verify against an in-process keypair instead of fetching.
+  jwks?: JWTVerifyGetKey;
+}
+
+interface JoseLikeError {
+  code?: string;
+  claim?: string;
+}
+
+function classifyError(err: unknown): VerifyFailReason {
+  if (typeof err !== "object" || err === null) return "verify_error";
+  const code = (err as JoseLikeError).code;
+  switch (code) {
+    case "ERR_JWT_EXPIRED":
+      return "expired";
+    case "ERR_JWS_SIGNATURE_VERIFICATION_FAILED":
+    case "ERR_JWKS_NO_MATCHING_KEY":
+    case "ERR_JWKS_MULTIPLE_MATCHING_KEYS":
+      return "bad_signature";
+    case "ERR_JOSE_ALG_NOT_ALLOWED":
+      return "unsupported_alg";
+    case "ERR_JWS_INVALID":
+    case "ERR_JWT_INVALID":
+    case "ERR_JWK_INVALID":
+    case "ERR_JWKS_INVALID":
+      return "malformed";
+    case "ERR_JWKS_TIMEOUT":
+      return "jwks_unavailable";
+    case "ERR_JWT_CLAIM_VALIDATION_FAILED": {
+      const claim = (err as JoseLikeError).claim;
+      if (claim === "aud") return "bad_aud";
+      if (claim === "iss") return "bad_iss";
+      return "verify_error";
+    }
+    default:
+      return "verify_error";
+  }
+}
+
+export async function verifyAccessJwt(
+  token: string,
+  opts: AccessVerifyOptions,
+): Promise<AccessVerifyResult> {
+  const jwks = opts.jwks ?? getJwksResolver(opts.teamDomain);
+  try {
+    const { payload } = await jwtVerify(token, jwks, {
+      issuer: `https://${opts.teamDomain}`,
+      audience: opts.aud,
+      algorithms: ["RS256"],
+    });
+    return { ok: true, payload };
+  } catch (err) {
+    return { ok: false, reason: classifyError(err) };
+  }
+}
+
+export type VerifyFn = (
+  token: string,
+  opts: AccessVerifyOptions,
+) => Promise<AccessVerifyResult>;
+
+export interface AccessMiddlewareOptions {
+  isProtectedHost?: (host: string) => boolean;
+  verify?: VerifyFn;
+}
+
+const defaultIsProtectedHost = (host: string) => host.endsWith(".workers.dev");
+
+interface AccessEnv {
+  ACCESS_AUD?: string;
+  ACCESS_TEAM_DOMAIN?: string;
+}
+
+// Hono middleware. Passes through when the request hostname is not in the
+// "preview deploy" set. On preview hostnames, requires a valid Cloudflare
+// Access JWT (header `Cf-Access-Jwt-Assertion` first, then `CF_Authorization`
+// cookie). When the hostname is preview-shaped but the env vars are missing,
+// returns 503 — fail-CLOSED is the right default here, since the cost of
+// silently serving unauthenticated requests on a workers.dev URL is much
+// worse than a misconfigured preview being unreachable.
+export function accessJwtMiddleware(options: AccessMiddlewareOptions = {}) {
+  const isProtected = options.isProtectedHost ?? defaultIsProtectedHost;
+  const verify = options.verify ?? verifyAccessJwt;
+
+  return async (c: Context, next: Next) => {
+    const host = (c.req.header("host") ?? "").toLowerCase();
+    if (!isProtected(host)) {
+      await next();
+      return;
+    }
+
+    const env = c.env as AccessEnv;
+    const aud = env.ACCESS_AUD;
+    const teamDomain = env.ACCESS_TEAM_DOMAIN;
+    if (!aud || !teamDomain) {
+      return c.text(
+        "Preview auth misconfigured: ACCESS_AUD and ACCESS_TEAM_DOMAIN must be set.",
+        503,
+      );
+    }
+
+    const token =
+      c.req.header("Cf-Access-Jwt-Assertion") ??
+      getCookie(c, "CF_Authorization");
+    if (!token) {
+      return c.text("Unauthorized: missing Access JWT", 401);
+    }
+
+    const result = await verify(token, { aud, teamDomain });
+    if (!result.ok) {
+      return c.text(`Unauthorized: ${result.reason}`, 401);
+    }
+
+    await next();
+  };
+}

--- a/src/env.ts
+++ b/src/env.ts
@@ -21,4 +21,10 @@ export interface Env {
   // but lives here so self-host forks don't accidentally ship data to the
   // hosted tier's dashboard.
   CF_ANALYTICS_TOKEN?: string;
+  // Cloudflare Access enforcement on `*.workers.dev` preview-branch deploys.
+  // Both must be set together — the middleware fail-CLOSEDs (503) on a
+  // workers.dev hostname when either is missing. The production custom
+  // domain (`dmarc.mx`) is not affected by these vars.
+  ACCESS_AUD?: string;
+  ACCESS_TEAM_DOMAIN?: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import {
 import { API_CATALOG_JSON, CANONICAL_ORIGIN } from "./api/catalog.js";
 import { clampHistoryLimit, fetchDomainHistory } from "./api/history.js";
 import { OPENAPI_JSON } from "./api/openapi.js";
+import { accessJwtMiddleware } from "./auth/access-jwt.js";
 import { type BearerIdentity, resolveBearer } from "./auth/api-key.js";
 import { authRoutes } from "./auth/routes.js";
 import { stripeWebhookRoutes } from "./billing/routes.js";
@@ -128,6 +129,12 @@ app.use("*", async (c, next) => {
 
   await next();
 });
+
+// Cloudflare Access JWT enforcement for `*.workers.dev` preview-branch
+// deploys. No-ops on the production custom domain (dmarc.mx). See
+// src/auth/access-jwt.ts for the protected-host predicate and fail-CLOSED
+// posture when ACCESS_AUD / ACCESS_TEAM_DOMAIN are missing.
+app.use("*", accessJwtMiddleware());
 
 // Security headers middleware (HSTS is handled at Cloudflare edge)
 

--- a/test/access-jwt.test.ts
+++ b/test/access-jwt.test.ts
@@ -1,0 +1,317 @@
+import { Hono } from "hono";
+import {
+  createLocalJWKSet,
+  exportJWK,
+  generateKeyPair,
+  type JWK,
+  type JWTVerifyGetKey,
+  SignJWT,
+} from "jose";
+import { describe, expect, it, vi } from "vitest";
+import {
+  type AccessVerifyResult,
+  accessJwtMiddleware,
+  type VerifyFn,
+  verifyAccessJwt,
+} from "../src/auth/access-jwt.js";
+
+const PROTECTED_HOST = "abc-dmarcheck.cory7593.workers.dev";
+const PROD_HOST = "dmarc.mx";
+const ENV_OK = {
+  ACCESS_AUD: "test-aud",
+  ACCESS_TEAM_DOMAIN: "team.example.com",
+};
+
+function makeApp(verify: VerifyFn) {
+  const app = new Hono();
+  app.use("*", accessJwtMiddleware({ verify }));
+  app.get("/", (c) => c.text("ok"));
+  return app;
+}
+
+describe("accessJwtMiddleware", () => {
+  it("passes through on the production hostname without invoking the verifier", async () => {
+    const verify = vi.fn();
+    const app = makeApp(verify as unknown as VerifyFn);
+    const res = await app.request("/", { headers: { host: PROD_HOST } }, {});
+    expect(res.status).toBe(200);
+    expect(verify).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 when env vars are missing on a workers.dev hostname", async () => {
+    const verify = vi.fn();
+    const app = makeApp(verify as unknown as VerifyFn);
+    const res = await app.request(
+      "/",
+      { headers: { host: PROTECTED_HOST } },
+      {},
+    );
+    expect(res.status).toBe(503);
+    expect(verify).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 when only one of the two env vars is set (fail-closed)", async () => {
+    const verify = vi.fn();
+    const app = makeApp(verify as unknown as VerifyFn);
+    const res = await app.request(
+      "/",
+      { headers: { host: PROTECTED_HOST } },
+      { ACCESS_AUD: "x" },
+    );
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 401 when no JWT is present on a protected hostname", async () => {
+    const verify = vi.fn();
+    const app = makeApp(verify as unknown as VerifyFn);
+    const res = await app.request(
+      "/",
+      { headers: { host: PROTECTED_HOST } },
+      ENV_OK,
+    );
+    expect(res.status).toBe(401);
+    expect(verify).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 surfacing the verifier's reason when the JWT fails validation", async () => {
+    const verify = vi.fn().mockResolvedValue({
+      ok: false,
+      reason: "bad_aud",
+    } as AccessVerifyResult);
+    const app = makeApp(verify as unknown as VerifyFn);
+    const res = await app.request(
+      "/",
+      {
+        headers: {
+          host: PROTECTED_HOST,
+          "Cf-Access-Jwt-Assertion": "header.payload.sig",
+        },
+      },
+      ENV_OK,
+    );
+    expect(res.status).toBe(401);
+    expect(await res.text()).toContain("bad_aud");
+    expect(verify).toHaveBeenCalledWith(
+      "header.payload.sig",
+      expect.objectContaining({
+        aud: "test-aud",
+        teamDomain: "team.example.com",
+      }),
+    );
+  });
+
+  it("passes the request through when the verifier accepts the JWT", async () => {
+    const verify = vi.fn().mockResolvedValue({
+      ok: true,
+      payload: {
+        aud: "test-aud",
+        iss: "https://team.example.com",
+        exp: 9_999_999_999,
+      },
+    } as AccessVerifyResult);
+    const app = makeApp(verify as unknown as VerifyFn);
+    const res = await app.request(
+      "/",
+      {
+        headers: {
+          host: PROTECTED_HOST,
+          "Cf-Access-Jwt-Assertion": "header.payload.sig",
+        },
+      },
+      ENV_OK,
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("falls back to the CF_Authorization cookie when the header is absent", async () => {
+    const verify = vi.fn().mockResolvedValue({
+      ok: true,
+      payload: {
+        aud: "test-aud",
+        iss: "https://team.example.com",
+        exp: 99_999_999_999,
+      },
+    } as AccessVerifyResult);
+    const app = makeApp(verify as unknown as VerifyFn);
+    const res = await app.request(
+      "/",
+      {
+        headers: {
+          host: PROTECTED_HOST,
+          Cookie: "other=1; CF_Authorization=cookie.token.value; foo=bar",
+        },
+      },
+      ENV_OK,
+    );
+    expect(res.status).toBe(200);
+    expect(verify).toHaveBeenCalledWith(
+      "cookie.token.value",
+      expect.any(Object),
+    );
+  });
+
+  it("prefers the header over the cookie when both are present", async () => {
+    const verify = vi.fn().mockResolvedValue({
+      ok: true,
+      payload: {
+        aud: "test-aud",
+        iss: "https://team.example.com",
+        exp: 99_999_999_999,
+      },
+    } as AccessVerifyResult);
+    const app = makeApp(verify as unknown as VerifyFn);
+    await app.request(
+      "/",
+      {
+        headers: {
+          host: PROTECTED_HOST,
+          "Cf-Access-Jwt-Assertion": "from-header",
+          Cookie: "CF_Authorization=from-cookie",
+        },
+      },
+      ENV_OK,
+    );
+    expect(verify).toHaveBeenCalledWith("from-header", expect.any(Object));
+  });
+});
+
+// End-to-end verifier tests using a real RS256 keypair plus jose's
+// `createLocalJWKSet` so we never hit the network. Covers the canonical
+// claim-error variants and asserts that the alg-confusion class of attacks
+// (HS256 token signed with the public key, `alg: none`) is rejected.
+describe("verifyAccessJwt (real RS256)", () => {
+  const TEAM = "team.example.com";
+  const AUD = "test-aud";
+
+  async function setup() {
+    const { privateKey, publicKey } = await generateKeyPair("RS256", {
+      extractable: true,
+    });
+    const jwk = (await exportJWK(publicKey)) as JWK;
+    jwk.kid = "test-kid";
+    jwk.alg = "RS256";
+    jwk.use = "sig";
+    const jwks: JWTVerifyGetKey = createLocalJWKSet({ keys: [jwk] });
+    return { privateKey, jwks };
+  }
+
+  function baseClaims() {
+    return {
+      iat: Math.floor(Date.now() / 1000),
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    };
+  }
+
+  it("accepts a valid token", async () => {
+    const { privateKey, jwks } = await setup();
+    const token = await new SignJWT(baseClaims())
+      .setProtectedHeader({ alg: "RS256", kid: "test-kid" })
+      .setIssuer(`https://${TEAM}`)
+      .setAudience(AUD)
+      .sign(privateKey);
+    const result = await verifyAccessJwt(token, {
+      aud: AUD,
+      teamDomain: TEAM,
+      jwks,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects an expired token", async () => {
+    const { privateKey, jwks } = await setup();
+    const token = await new SignJWT({ iat: 1, exp: 2 })
+      .setProtectedHeader({ alg: "RS256", kid: "test-kid" })
+      .setIssuer(`https://${TEAM}`)
+      .setAudience(AUD)
+      .sign(privateKey);
+    const result = await verifyAccessJwt(token, {
+      aud: AUD,
+      teamDomain: TEAM,
+      jwks,
+    });
+    expect(result).toEqual({ ok: false, reason: "expired" });
+  });
+
+  it("rejects a wrong audience", async () => {
+    const { privateKey, jwks } = await setup();
+    const token = await new SignJWT(baseClaims())
+      .setProtectedHeader({ alg: "RS256", kid: "test-kid" })
+      .setIssuer(`https://${TEAM}`)
+      .setAudience("attacker-aud")
+      .sign(privateKey);
+    const result = await verifyAccessJwt(token, {
+      aud: AUD,
+      teamDomain: TEAM,
+      jwks,
+    });
+    expect(result).toEqual({ ok: false, reason: "bad_aud" });
+  });
+
+  it("rejects a wrong issuer", async () => {
+    const { privateKey, jwks } = await setup();
+    const token = await new SignJWT(baseClaims())
+      .setProtectedHeader({ alg: "RS256", kid: "test-kid" })
+      .setIssuer("https://attacker.example.com")
+      .setAudience(AUD)
+      .sign(privateKey);
+    const result = await verifyAccessJwt(token, {
+      aud: AUD,
+      teamDomain: TEAM,
+      jwks,
+    });
+    expect(result).toEqual({ ok: false, reason: "bad_iss" });
+  });
+
+  it("rejects an unknown kid", async () => {
+    const { privateKey, jwks } = await setup();
+    const token = await new SignJWT(baseClaims())
+      .setProtectedHeader({ alg: "RS256", kid: "rotated-kid" })
+      .setIssuer(`https://${TEAM}`)
+      .setAudience(AUD)
+      .sign(privateKey);
+    const result = await verifyAccessJwt(token, {
+      aud: AUD,
+      teamDomain: TEAM,
+      jwks,
+    });
+    expect(result).toEqual({ ok: false, reason: "bad_signature" });
+  });
+
+  it("rejects a tampered signature", async () => {
+    const { privateKey, jwks } = await setup();
+    const token = await new SignJWT(baseClaims())
+      .setProtectedHeader({ alg: "RS256", kid: "test-kid" })
+      .setIssuer(`https://${TEAM}`)
+      .setAudience(AUD)
+      .sign(privateKey);
+    // Flip a character mid-signature. (Last-char flips can be no-ops because
+    // base64url's trailing bits don't always map to signature bytes.)
+    const parts = token.split(".");
+    const sig = parts[2];
+    const mid = Math.floor(sig.length / 2);
+    const swapped = sig[mid] === "A" ? "B" : "A";
+    const tampered = `${parts[0]}.${parts[1]}.${sig.slice(0, mid)}${swapped}${sig.slice(mid + 1)}`;
+    const result = await verifyAccessJwt(tampered, {
+      aud: AUD,
+      teamDomain: TEAM,
+      jwks,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(["bad_signature", "malformed"]).toContain(result.reason);
+    }
+  });
+
+  it("rejects a malformed token", async () => {
+    const { jwks } = await setup();
+    const result = await verifyAccessJwt("not-a-jwt", {
+      aud: AUD,
+      teamDomain: TEAM,
+      jwks,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(["malformed", "verify_error"]).toContain(result.reason);
+    }
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -11,6 +11,16 @@ routes = [
 [dev]
 port = 8790
 
+# Cloudflare Access enforcement for preview-branch deploys served on
+# `*-dmarcheck.cory7593.workers.dev`. Inert on the production custom domain
+# (`dmarc.mx`) — the middleware short-circuits on hostname before reading
+# these. NOTE: top-level [vars] only — never add [env.<name>] blocks here
+# (see feedback_workers_builds_env_pinning: doing so detached dmarc.mx on
+# 2026-04-26 / PRs #203 → #206).
+[vars]
+ACCESS_AUD = "7b283d5d9b56f6fffa342280310a4ae68f13cbb05dc27f3c1d2faec2deae507a"
+ACCESS_TEAM_DOMAIN = "coryrankin.cloudflareaccess.com"
+
 # TEMPORARY test cron — primary fire at 23:33 UTC with a 23:50 UTC safety
 # net to validate the end-to-end alert email pipeline against a seeded
 # alerts row. Revert to ["17 6 * * *"] after verification.


### PR DESCRIPTION
## Summary

- Adds a Hono middleware that enforces Cloudflare Access JWTs on the `*-dmarcheck.cory7593.workers.dev` preview-branch hostnames. Production (`dmarc.mx`) is intentionally untouched — public scanning is the product.
- Verification delegates to [`jose`](https://github.com/panva/jose) with `algorithms: ["RS256"]` pinned, which closes the alg-confusion / `alg: none` foot-guns that hand-rolled JWT code keeps getting wrong. Started with hand-rolled WebCrypto; swapped after a "should we really be doing this ourselves?" pushback — the right call.
- Defense-in-depth: Access already validates the JWT at the Cloudflare edge before the request reaches the worker. The worker re-check is the second line, in case the Access app's hostname pattern ever fails to attach.

## Behavior

| Hostname | Env vars set | Outcome |
|---|---|---|
| `dmarc.mx` | any | pass-through, no env read, no verifier work |
| `*.workers.dev` | both set | require valid JWT (header > cookie); pinned RS256 + iss + aud + exp |
| `*.workers.dev` | missing | **503 fail-CLOSED** |

The fail-CLOSED posture is deliberate: silently accepting unauthenticated requests on a workers.dev URL because someone forgot to set an env var is a much worse outcome than a misconfigured preview being unreachable.

## Config

Top-level `[vars]` in `wrangler.toml`:

- `ACCESS_AUD` — the Access application audience tag
- `ACCESS_TEAM_DOMAIN` — `coryrankin.cloudflareaccess.com`

Explicitly **not** added as `[env.<name>]` blocks — that pattern caused the 2026-04-26 dmarc.mx outage (#203 → #206 revert) because Workers Builds is pinned to the prod worker. Top-level `[vars]` ships with every deploy, including previews, and is inert on prod via the hostname short-circuit.

## Token sources

- `Cf-Access-Jwt-Assertion` header (preferred — service tokens use this)
- `CF_Authorization` cookie (browser fallback)

## Tests

15 new tests in `test/access-jwt.test.ts`:

- Middleware: hostname routing, fail-closed env handling, header-vs-cookie precedence (uses DI'd verifier — no crypto in these)
- Verifier: real RS256 keypair via `jose.generateKeyPair` + `createLocalJWKSet`. Covers valid token, expired, bad audience, bad issuer, unknown kid, tampered signature, malformed token.

767/767 total tests pass. Lint + typecheck clean.

## Operational footguns to know about

1. Any uptime monitor wired to a preview URL will 401. None currently exist; prod monitoring at `dmarc.mx` is unaffected.
2. Third-party webhooks (Stripe, WorkOS) sent to a preview URL will 401. None currently are; webhooks are wired to `dmarc.mx`.

## Test plan

Code-level checks all pass. After merge + deploy, three smoke curls verify the Access-app config (which only the dashboard knows about):

- [ ] `curl -i https://<branch>-dmarcheck.cory7593.workers.dev/` from incognito → expect Access login redirect (Access is in front)
- [ ] `curl -i -H "Cf-Access-Jwt-Assertion: garbage" https://<branch>-dmarcheck.cory7593.workers.dev/` → expect `401 Unauthorized: malformed` (worker validator runs as the second line)
- [ ] `curl -i https://dmarc.mx/health` → expect `200` (prod untouched)

If smoke #1 returns the worker's own 503, the Access app's wildcard pattern doesn't match this branch's URL shape — that's a dashboard fix, not a code fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)