### PR TITLE
feat(dashboard): rich drawer detail per design handoff

### DIFF
--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -31,6 +31,7 @@ import {
 } from "../db/domains.js";
 import {
   getPortfolioTrendForUser,
+  getScanHistory,
   getScanHistoryWithProtocols,
   recordScan,
 } from "../db/scans.js";
@@ -44,6 +45,7 @@ import { getRecentDeliveriesForUser } from "../db/webhook-deliveries.js";
 import { scan } from "../orchestrator.js";
 import { normalizeDomain } from "../shared/domain.js";
 import { PRO_WATCHLIST_CAP, watchlistCapForPlan } from "../shared/limits.js";
+import { computeGradeBreakdown } from "../shared/scoring.js";
 import {
   renderAddDomainPage,
   renderApiKeysPage,
@@ -97,6 +99,213 @@ const VALID_SORT_COLUMNS = new Set<DomainSortColumn>([
   "last_scanned",
   "created",
 ]);
+
+// Powers the dashboard drawer's enriched payload: per-protocol summary lines
+// + raw records, scoring recommendations, and a "what changed today" diff
+// when the latest DMARC record drifted from the previous scan within 24h.
+// All derivation is pure JSON parsing + a re-run of computeGradeBreakdown
+// against the persisted protocol_results blob — no extra DB calls.
+interface DrawerProtocolSummary {
+  status: "pass" | "warn" | "fail" | "info" | null;
+  summary: string;
+  record: string | null;
+}
+
+interface DrawerDetail {
+  protocols: {
+    dmarc: DrawerProtocolSummary;
+    spf: DrawerProtocolSummary;
+    dkim: DrawerProtocolSummary;
+    bimi: DrawerProtocolSummary;
+    mta_sts: DrawerProtocolSummary;
+  };
+  recommendations: import("../shared/scoring.js").Recommendation[];
+  diff: {
+    change: string;
+    previous: string;
+    current: string;
+  } | null;
+}
+
+const EMPTY_PROTOCOL: DrawerProtocolSummary = {
+  status: null,
+  summary: "no data yet",
+  record: null,
+};
+
+function asProtocolStatus(
+  v: unknown,
+): "pass" | "warn" | "fail" | "info" | null {
+  return v === "pass" || v === "warn" || v === "fail" || v === "info"
+    ? v
+    : null;
+}
+
+function buildDrawerDetail(
+  rawScanRows: import("../db/scans.js").ScanHistoryRow[],
+): DrawerDetail {
+  const empty: DrawerDetail = {
+    protocols: {
+      dmarc: EMPTY_PROTOCOL,
+      spf: EMPTY_PROTOCOL,
+      dkim: EMPTY_PROTOCOL,
+      bimi: EMPTY_PROTOCOL,
+      mta_sts: EMPTY_PROTOCOL,
+    },
+    recommendations: [],
+    diff: null,
+  };
+  if (rawScanRows.length === 0) return empty;
+
+  const latest = rawScanRows[0];
+  const parsed = safeParseProtocols(latest.protocol_results);
+  if (!parsed) return empty;
+
+  // Stringly-typed reach into the parsed JSON: D1 stored what the orchestrator
+  // wrote, but TypeScript can't follow it through the JSON round-trip.
+  const dmarc = parsed.dmarc as
+    | { status?: unknown; record?: unknown; tags?: Record<string, unknown> }
+    | undefined;
+  const spf = parsed.spf as
+    | {
+        status?: unknown;
+        record?: unknown;
+        lookups_used?: unknown;
+        lookup_limit?: unknown;
+      }
+    | undefined;
+  const dkim = parsed.dkim as
+    | {
+        status?: unknown;
+        selectors?: Record<
+          string,
+          { found?: unknown; key_bits?: unknown; key_type?: unknown }
+        >;
+      }
+    | undefined;
+  const bimi = parsed.bimi as
+    | { status?: unknown; record?: unknown; tags?: Record<string, unknown> }
+    | undefined;
+  const mta = parsed.mta_sts as
+    | {
+        status?: unknown;
+        dns_record?: unknown;
+        policy?: { mode?: unknown } | null;
+      }
+    | undefined;
+
+  const dmarcPolicy = typeof dmarc?.tags?.p === "string" ? dmarc.tags.p : null;
+  const spfLookupsUsed =
+    typeof spf?.lookups_used === "number" ? spf.lookups_used : null;
+  const spfLookupLimit =
+    typeof spf?.lookup_limit === "number" ? spf.lookup_limit : 10;
+  const dkimSelectors = dkim?.selectors ?? {};
+  const dkimFound = Object.values(dkimSelectors).filter(
+    (s) => s?.found === true,
+  );
+  const dkimKeyBits = dkimFound
+    .map((s) => (typeof s.key_bits === "number" ? s.key_bits : 0))
+    .filter((n) => n > 0);
+  const bimiConfigured = !!(bimi?.tags && Object.keys(bimi.tags).length > 0);
+  const mtaMode =
+    typeof mta?.policy?.mode === "string" ? mta.policy.mode : null;
+  const mtaConfigured = !!(mta?.dns_record || mta?.policy);
+
+  const protocols: DrawerDetail["protocols"] = {
+    dmarc: {
+      status: asProtocolStatus(dmarc?.status),
+      summary: dmarcPolicy ? `policy: p=${dmarcPolicy}` : "no policy",
+      record: typeof dmarc?.record === "string" ? dmarc.record : null,
+    },
+    spf: {
+      status: asProtocolStatus(spf?.status),
+      summary:
+        spfLookupsUsed !== null
+          ? `${spfLookupsUsed}/${spfLookupLimit} DNS lookups`
+          : "not set",
+      record: typeof spf?.record === "string" ? spf.record : null,
+    },
+    dkim: {
+      status: asProtocolStatus(dkim?.status),
+      summary:
+        dkimFound.length > 0
+          ? `${dkimFound.length} selector${dkimFound.length === 1 ? "" : "s"}` +
+            (dkimKeyBits.length ? ` · ${Math.min(...dkimKeyBits)}-bit` : "")
+          : "no selectors found",
+      record: null,
+    },
+    bimi: {
+      status: asProtocolStatus(bimi?.status),
+      summary: bimiConfigured ? "configured" : "not configured",
+      record: typeof bimi?.record === "string" ? bimi.record : null,
+    },
+    mta_sts: {
+      status: asProtocolStatus(mta?.status),
+      summary: mtaConfigured
+        ? `configured${mtaMode ? ` · mode=${mtaMode}` : ""}`
+        : "not configured",
+      record: typeof mta?.dns_record === "string" ? mta.dns_record : null,
+    },
+  };
+
+  // Recommendations are derived on the fly so we don't have to migrate the
+  // scan_history schema. computeGradeBreakdown is pure — given the persisted
+  // protocol blobs it produces the same recommendation list the orchestrator
+  // would have at scan time.
+  let recommendations: import("../shared/scoring.js").Recommendation[] = [];
+  try {
+    const breakdown = computeGradeBreakdown(
+      parsed as Parameters<typeof computeGradeBreakdown>[0],
+    );
+    recommendations = breakdown.recommendations;
+  } catch {
+    recommendations = [];
+  }
+
+  // Diff: surface only when DMARC drifted within ~26h (slack on 24h cron) and
+  // the previous record was non-empty. SPF/DKIM diffs add noise — DMARC is
+  // the field most worth a "you broke this, paste this back" prompt.
+  let diff: DrawerDetail["diff"] = null;
+  if (rawScanRows.length >= 2 && protocols.dmarc.record) {
+    const prev = rawScanRows[1];
+    const prevParsed = safeParseProtocols(prev.protocol_results);
+    const prevDmarcRecord =
+      typeof (prevParsed?.dmarc as { record?: unknown } | undefined)?.record ===
+      "string"
+        ? ((prevParsed?.dmarc as { record: string }).record ?? null)
+        : null;
+    const ageSec = latest.scanned_at - prev.scanned_at;
+    if (
+      prevDmarcRecord &&
+      prevDmarcRecord !== protocols.dmarc.record &&
+      ageSec < 26 * 3600
+    ) {
+      diff = {
+        change: dmarcPolicy
+          ? `DMARC record changed (now p=${dmarcPolicy})`
+          : "DMARC record changed",
+        previous: prevDmarcRecord,
+        current: protocols.dmarc.record,
+      };
+    }
+  }
+
+  return { protocols, recommendations, diff };
+}
+
+function safeParseProtocols(
+  json: string | null,
+): Record<string, unknown> | null {
+  if (!json) return null;
+  try {
+    const parsed = JSON.parse(json);
+    return parsed && typeof parsed === "object"
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
 
 interface DomainListQuery {
   search: string;
@@ -516,7 +725,11 @@ dashboardRoutes.get("/domain/:domain{.+\\.json}", async (c) => {
   if (!domain) return c.json({ error: "Domain not found" }, 404);
   const plan = await getPlanForUser(db, session.sub);
   const limit = plan === "pro" ? HISTORY_LIMIT_PRO : HISTORY_LIMIT_FREE;
-  const rows = await getScanHistoryWithProtocols(db, domain.id, limit);
+  const [withStatus, rawRows] = await Promise.all([
+    getScanHistoryWithProtocols(db, domain.id, limit),
+    getScanHistory(db, domain.id, 2),
+  ]);
+  const detail = buildDrawerDetail(rawRows);
   return c.json({
     domain: domain.domain,
     grade: domain.last_grade ?? "—",
@@ -524,7 +737,10 @@ dashboardRoutes.get("/domain/:domain{.+\\.json}", async (c) => {
     scanFrequency: domain.scan_frequency,
     isFree: domain.is_free === 1,
     plan,
-    history: rows.map((row) => ({
+    protocols: detail.protocols,
+    recommendations: detail.recommendations,
+    diff: detail.diff,
+    history: withStatus.map((row) => ({
       scannedAt: row.scannedAt,
       grade: row.grade,
       protocols: row.protocols,

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -991,6 +991,364 @@ const DASHBOARD_CSS = `
 }
 .dashboard-add-btn:hover { background: var(--clr-accent-hover); text-decoration: none; }
 
+/* ---- Drawer detail (PR follow-up: protocols, diff, recs, footer) ---- */
+.domain-drawer-body { padding-bottom: 5rem; }
+.drawer-section-title {
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: var(--clr-text-faint);
+  font-family: 'SF Mono', 'Fira Code', ui-monospace, monospace;
+  margin: 1.5rem 0 0.6rem;
+}
+.drawer-section-title:first-child { margin-top: 0; }
+
+/* Header restyle: grade pill + name + cadence sub */
+.domain-drawer-title {
+  display: flex; align-items: center; gap: 0.85rem;
+  flex: 1; min-width: 0;
+  white-space: normal;
+  overflow: visible;
+}
+.drawer-header-stack {
+  display: flex; flex-direction: column; gap: 2px;
+  min-width: 0;
+}
+.drawer-header-name {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--clr-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.drawer-header-sub {
+  font-size: 0.72rem;
+  color: var(--clr-text-faint);
+  text-transform: uppercase;
+  letter-spacing: 1.2px;
+  font-family: 'SF Mono', 'Fira Code', ui-monospace, monospace;
+}
+
+/* Grade pill (drawer header). The detail page's grade-badge is rounded;
+   this is the prototype's rounded-square variant scaled to fit the header. */
+.grade-pill {
+  display: inline-flex; align-items: center; justify-content: center;
+  min-width: 38px; height: 32px;
+  padding: 0 6px;
+  border-radius: 7px;
+  border: 1px solid;
+  font-size: 0.95rem;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+.grade-pill-s {
+  color: #78350f;
+  background: linear-gradient(135deg, #fde68a, #f59e0b, #facc15);
+  border-color: #f59e0b;
+}
+.grade-pill-a {
+  color: var(--clr-pass);
+  background: var(--clr-pass-bg);
+  border-color: var(--clr-pass-border);
+}
+.grade-pill-c {
+  color: var(--clr-warn);
+  background: var(--clr-warn-bg);
+  border-color: var(--clr-warn-border);
+}
+.grade-pill-f {
+  color: var(--clr-fail);
+  background: var(--clr-fail-bg);
+  border-color: var(--clr-fail-border);
+}
+
+/* Status dots inside the drawer */
+.drawer-status-dot {
+  display: inline-block;
+  width: 9px; height: 9px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.drawer-status-pass { background: var(--clr-pass); box-shadow: 0 0 8px var(--clr-pass-glow); }
+.drawer-status-warn { background: var(--clr-warn); box-shadow: 0 0 8px var(--clr-warn-glow); }
+.drawer-status-fail { background: var(--clr-fail); box-shadow: 0 0 8px var(--clr-fail-glow); }
+.drawer-status-info { background: var(--clr-info); box-shadow: 0 0 8px var(--clr-info-glow); }
+.drawer-status-unknown { background: var(--clr-text-faint); }
+
+/* Copy button shared by diff lines + protocol records */
+.drawer-copy-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 9px;
+  background: transparent;
+  color: var(--clr-text-muted);
+  border: 1px solid var(--clr-border);
+  border-radius: 6px;
+  font-size: 0.72rem;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+.drawer-copy-btn:hover {
+  border-color: var(--clr-border-hover);
+  color: var(--clr-text);
+}
+.drawer-copy-btn-copied,
+.drawer-copy-btn-copied:hover {
+  background: var(--clr-pass-bg);
+  color: var(--clr-pass);
+  border-color: var(--clr-pass-border);
+}
+.drawer-copy-btn-suggested {
+  border-color: var(--clr-pass-border);
+  color: var(--clr-pass);
+}
+
+/* Diff card */
+.drawer-diff-card {
+  background: var(--clr-bg);
+  border: 1px solid var(--clr-fail-border);
+  border-left: 3px solid var(--clr-fail);
+  border-radius: 10px;
+  padding: 1rem 1.1rem;
+  margin-bottom: 1.5rem;
+}
+.drawer-diff-label {
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  font-family: 'SF Mono', 'Fira Code', ui-monospace, monospace;
+  color: var(--clr-fail);
+  margin-bottom: 0.5rem;
+}
+.drawer-diff-msg {
+  font-size: 0.9rem;
+  color: var(--clr-text);
+  margin-bottom: 0.7rem;
+}
+.drawer-diff-block {
+  background: var(--clr-surface);
+  border: 1px solid var(--clr-border);
+  border-radius: 6px;
+  font-family: 'SF Mono', 'Fira Code', ui-monospace, monospace;
+  font-size: 0.74rem;
+  line-height: 1.55;
+  overflow: hidden;
+  margin-bottom: 0.75rem;
+}
+.drawer-diff-row {
+  display: flex; align-items: flex-start;
+  gap: 10px;
+  padding: 0.55rem 0.85rem;
+}
+.drawer-diff-row + .drawer-diff-row { border-top: 1px solid var(--clr-border); }
+.drawer-diff-current { color: var(--clr-fail); }
+.drawer-diff-previous {
+  background: var(--clr-pass-bg);
+  color: var(--clr-pass);
+}
+.drawer-diff-line-text {
+  flex: 1; min-width: 0;
+  word-break: break-all;
+}
+.drawer-diff-marker { opacity: 0.7; }
+.drawer-diff-actions {
+  display: flex; flex-wrap: wrap; align-items: center;
+  gap: 0.6rem;
+  margin-top: 0.25rem;
+}
+.drawer-diff-hint {
+  font-size: 0.74rem;
+  color: var(--clr-text-muted);
+  flex: 1;
+  min-width: 220px;
+}
+
+/* Protocol rows */
+.drawer-protocol-list {
+  display: flex; flex-direction: column;
+  gap: 8px;
+  margin-bottom: 0.5rem;
+}
+.drawer-protocol-card {
+  background: var(--clr-bg);
+  border: 1px solid var(--clr-border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.drawer-protocol-head {
+  display: flex; align-items: center;
+  width: 100%;
+  gap: 12px;
+  padding: 0.7rem 1rem;
+  background: transparent;
+  border: 0;
+  color: var(--clr-text);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.drawer-protocol-head[disabled] { cursor: default; }
+.drawer-protocol-head:not([disabled]):hover { background: var(--clr-surface-muted); }
+.drawer-protocol-name {
+  font-weight: 600;
+  font-size: 0.88rem;
+  min-width: 80px;
+}
+.drawer-protocol-summary {
+  flex: 1; min-width: 0;
+  color: var(--clr-text-muted);
+  font-size: 0.8rem;
+  font-family: 'SF Mono', 'Fira Code', ui-monospace, monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.drawer-protocol-chevron {
+  color: var(--clr-text-faint);
+  font-size: 0.75rem;
+  transition: transform 0.15s;
+  display: inline-flex;
+}
+.drawer-protocol-chevron.is-open { transform: rotate(90deg); }
+.drawer-protocol-detail {
+  display: flex; align-items: flex-start;
+  gap: 12px;
+  padding: 0.75rem 1rem;
+  border-top: 1px solid var(--clr-border);
+  background: var(--clr-surface-muted);
+}
+.drawer-protocol-detail[hidden] { display: none; }
+.drawer-protocol-record {
+  flex: 1; min-width: 0;
+  font-family: 'SF Mono', 'Fira Code', ui-monospace, monospace;
+  font-size: 0.74rem;
+  color: var(--clr-text);
+  line-height: 1.5;
+  word-break: break-all;
+}
+
+/* Recommendations */
+.drawer-rec-list { display: flex; flex-direction: column; }
+.drawer-rec-row {
+  display: flex; gap: 12px;
+  padding: 0.85rem 0;
+  border-bottom: 1px solid var(--clr-border);
+}
+.drawer-rec-row:last-child { border-bottom: 0; }
+.drawer-rec-priority {
+  width: 30px; height: 24px;
+  border-radius: 6px;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 0.68rem;
+  font-weight: 700;
+  font-family: 'SF Mono', 'Fira Code', ui-monospace, monospace;
+  flex-shrink: 0;
+  border: 1px solid var(--clr-border);
+}
+.drawer-rec-p1 {
+  background: var(--clr-fail-bg);
+  color: var(--clr-fail);
+  border-color: var(--clr-fail-border);
+}
+.drawer-rec-p2 {
+  background: var(--clr-warn-bg);
+  color: var(--clr-warn);
+  border-color: var(--clr-warn-border);
+}
+.drawer-rec-p3 {
+  background: var(--clr-surface-muted);
+  color: var(--clr-text-muted);
+}
+.drawer-rec-body { flex: 1; min-width: 0; }
+.drawer-rec-title {
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: var(--clr-text);
+}
+.drawer-rec-impact {
+  font-size: 0.78rem;
+  color: var(--clr-text-muted);
+  margin-top: 4px;
+  line-height: 1.45;
+}
+
+/* History rows (replaces the wide-spread table) */
+.drawer-history-list { display: flex; flex-direction: column; }
+.drawer-history-row {
+  display: flex; align-items: center;
+  gap: 12px;
+  padding: 0.55rem 0;
+  border-bottom: 1px solid var(--clr-border);
+  font-size: 0.85rem;
+}
+.drawer-history-row:last-child { border-bottom: 0; }
+.drawer-history-grade {
+  font-weight: 600;
+  color: var(--clr-text);
+  min-width: 36px;
+}
+.drawer-history-time {
+  margin-left: auto;
+  color: var(--clr-text-faint);
+  font-family: 'SF Mono', 'Fira Code', ui-monospace, monospace;
+  font-size: 0.74rem;
+}
+.drawer-history-empty {
+  color: var(--clr-text-muted);
+  font-size: 0.85rem;
+}
+
+/* Sticky footer */
+.drawer-footer {
+  position: sticky;
+  bottom: 0;
+  display: flex; gap: 0.6rem; align-items: center;
+  padding: 0.85rem 1.25rem;
+  border-top: 1px solid var(--clr-border);
+  background: var(--clr-surface);
+  flex-shrink: 0;
+}
+.drawer-footer-form { margin: 0; }
+.drawer-cta-primary,
+.drawer-cta-secondary {
+  display: inline-flex; align-items: center;
+  padding: 0.5rem 0.95rem;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  text-decoration: none;
+  border: 1px solid transparent;
+}
+.drawer-cta-primary {
+  background: var(--clr-accent);
+  color: var(--clr-on-accent);
+  border-color: var(--clr-accent);
+}
+.drawer-cta-primary:hover { background: var(--clr-accent-hover); text-decoration: none; }
+.drawer-cta-secondary {
+  background: transparent;
+  color: var(--clr-text);
+  border-color: var(--clr-border);
+}
+.drawer-cta-secondary:hover {
+  border-color: var(--clr-border-hover);
+  text-decoration: none;
+}
+.drawer-cta-fixed {
+  color: var(--clr-pass);
+  border-color: var(--clr-pass-border);
+}
+
 @media (max-width: 720px) {
   .domain-drawer { width: 100vw; }
 }

--- a/src/views/scripts.ts
+++ b/src/views/scripts.ts
@@ -912,73 +912,309 @@ if (typeof navigator !== 'undefined' && navigator.modelContext && typeof navigat
     });
   }
 
-  function renderDrawerBody(data) {
-    var bodyEl = drawer.querySelector('[data-drawer-body]');
-    if (!bodyEl) return;
+  /* CopyButton — clipboard copy with a transient "Copied!" state. Uses
+     navigator.clipboard.writeText; bails out silently on browsers without it
+     (no-op rather than throwing — older browsers shouldn't break the drawer). */
+  function copyButton(text, opts) {
+    opts = opts || {};
+    var btn = el('button', {
+      type: 'button',
+      class: 'drawer-copy-btn' + (opts.suggested ? ' drawer-copy-btn-suggested' : ''),
+      'aria-label': opts.suggested ? 'Copy suggested fix to clipboard' : 'Copy record to clipboard'
+    });
+    /* Inline SVG clipboard icon — prebuilt as DOM nodes via createElementNS so
+       textContent / replaceChildren stay safe. */
+    function makeIcon(checked) {
+      var ns = 'http://www.w3.org/2000/svg';
+      var svg = document.createElementNS(ns, 'svg');
+      svg.setAttribute('width', '12');
+      svg.setAttribute('height', '12');
+      svg.setAttribute('viewBox', '0 0 16 16');
+      svg.setAttribute('fill', 'none');
+      svg.setAttribute('stroke', 'currentColor');
+      svg.setAttribute('stroke-width', checked ? '2' : '1.5');
+      svg.setAttribute('stroke-linecap', 'round');
+      svg.setAttribute('stroke-linejoin', 'round');
+      svg.setAttribute('aria-hidden', 'true');
+      if (checked) {
+        var p = document.createElementNS(ns, 'path');
+        p.setAttribute('d', 'M3 8l3.5 3.5L13 5');
+        svg.appendChild(p);
+      } else {
+        var rect = document.createElementNS(ns, 'rect');
+        rect.setAttribute('x', '4'); rect.setAttribute('y', '3');
+        rect.setAttribute('width', '8'); rect.setAttribute('height', '11');
+        rect.setAttribute('rx', '1.5');
+        svg.appendChild(rect);
+        var lid = document.createElementNS(ns, 'path');
+        lid.setAttribute('d', 'M6 3V2a1 1 0 011-1h2a1 1 0 011 1v1');
+        svg.appendChild(lid);
+      }
+      return svg;
+    }
+    function paint(label, checked) {
+      btn.replaceChildren(makeIcon(checked), document.createTextNode(' ' + label));
+    }
+    paint(opts.label || 'Copy', false);
+    btn.addEventListener('click', function(e) {
+      e.stopPropagation();
+      if (!navigator.clipboard || !navigator.clipboard.writeText) return;
+      navigator.clipboard.writeText(text).then(function() {
+        btn.classList.add('drawer-copy-btn-copied');
+        paint('Copied', true);
+        setTimeout(function() {
+          btn.classList.remove('drawer-copy-btn-copied');
+          paint(opts.label || 'Copy', false);
+        }, 1600);
+      }, function() {});
+    });
+    return btn;
+  }
+
+  function gradePillEl(grade) {
+    var letter = String(grade || '—').charAt(0).toUpperCase();
+    var cls = 'grade-pill grade-pill-';
+    if (letter === 'S') cls += 's';
+    else if (letter === 'A' || letter === 'B') cls += 'a';
+    else if (letter === 'C' || letter === 'D') cls += 'c';
+    else cls += 'f';
+    return el('span', { class: cls, text: String(grade || '—') });
+  }
+
+  function statusDotEl(status) {
+    var s = (status === 'pass' || status === 'warn' || status === 'fail' || status === 'info')
+      ? status : 'unknown';
+    return el('span', {
+      class: 'drawer-status-dot drawer-status-' + s,
+      'aria-label': 'Status: ' + s,
+      role: 'img'
+    });
+  }
+
+  function sectionTitle(text) {
+    return el('div', { class: 'drawer-section-title', text: text });
+  }
+
+  function diffCardEl(domain, diff, onMarkFixed) {
+    var label = el('div', { class: 'drawer-diff-label', text: 'WHAT CHANGED TODAY' });
+    var msg = el('div', { class: 'drawer-diff-msg', text: diff.change });
+    /* + line: current/broken record */
+    var plusText = el('span', { class: 'drawer-diff-line-text' }, [
+      el('span', { class: 'drawer-diff-marker', text: '+ ' }),
+      document.createTextNode(diff.current)
+    ]);
+    var plusRow = el('div', { class: 'drawer-diff-row drawer-diff-current' }, [
+      plusText,
+      copyButton(diff.current, { label: 'Current' })
+    ]);
+    /* − line: previous/working record (the suggested fix) */
+    var minusText = el('span', { class: 'drawer-diff-line-text' }, [
+      el('span', { class: 'drawer-diff-marker', text: '− ' }),
+      document.createTextNode(diff.previous)
+    ]);
+    var minusRow = el('div', { class: 'drawer-diff-row drawer-diff-previous' }, [
+      minusText,
+      copyButton(diff.previous, { label: 'Copy fix', suggested: true })
+    ]);
+    var diffBlock = el('div', { class: 'drawer-diff-block' }, [plusRow, minusRow]);
+    var fixedBtn = el('button', {
+      type: 'button',
+      class: 'drawer-cta-secondary drawer-cta-fixed'
+    }, [document.createTextNode('✓ I fixed it (re-scan)')]);
+    fixedBtn.addEventListener('click', function() {
+      if (typeof onMarkFixed === 'function') onMarkFixed();
+    });
+    var hint = el('span', {
+      class: 'drawer-diff-hint',
+      text: 'Paste the green line into your DNS as a TXT record on _dmarc.' + domain
+    });
+    var actions = el('div', { class: 'drawer-diff-actions' }, [fixedBtn, hint]);
+    return el('section', { class: 'drawer-diff-card', 'aria-label': 'What changed today' }, [
+      label, msg, diffBlock, actions
+    ]);
+  }
+
+  function protocolRowEl(name, info) {
+    var hasRecord = !!(info && info.record);
+    var statusValue = (info && info.status) || null;
+    var summary = (info && info.summary) || 'no data yet';
+    var dot = statusDotEl(statusValue);
+    var nameEl = el('span', { class: 'drawer-protocol-name', text: name });
+    var summaryEl = el('span', { class: 'drawer-protocol-summary', text: summary });
+    var children = [dot, nameEl, summaryEl];
+    var chevron = null;
+    if (hasRecord) {
+      chevron = el('span', { class: 'drawer-protocol-chevron', 'aria-hidden': 'true', text: '▸' });
+      children.push(chevron);
+    }
+    var headBtnAttrs = {
+      type: 'button',
+      class: 'drawer-protocol-head',
+      'aria-expanded': 'false'
+    };
+    if (!hasRecord) headBtnAttrs.disabled = '';
+    var head = el('button', headBtnAttrs, children);
+    var detail = null;
+    if (hasRecord) {
+      var rec = el('div', { class: 'drawer-protocol-record', text: info.record });
+      detail = el('div', { class: 'drawer-protocol-detail' }, [
+        rec,
+        copyButton(info.record, { label: 'Copy' })
+      ]);
+      detail.hidden = true;
+      head.addEventListener('click', function() {
+        var open = !detail.hidden;
+        if (open) {
+          detail.hidden = true;
+          head.setAttribute('aria-expanded', 'false');
+          if (chevron) chevron.classList.remove('is-open');
+        } else {
+          detail.hidden = false;
+          head.setAttribute('aria-expanded', 'true');
+          if (chevron) chevron.classList.add('is-open');
+        }
+      });
+    }
+    var card = el('div', { class: 'drawer-protocol-card' }, detail ? [head, detail] : [head]);
+    return card;
+  }
+
+  function recommendationRowEl(rec) {
+    var pri = rec.priority === 1 ? 'p1' : rec.priority === 2 ? 'p2' : 'p3';
+    var badge = el('div', {
+      class: 'drawer-rec-priority drawer-rec-' + pri,
+      text: 'P' + rec.priority
+    });
+    var title = el('div', { class: 'drawer-rec-title', text: rec.title });
+    var impact = el('div', { class: 'drawer-rec-impact', text: rec.impact || rec.description || '' });
+    var body = el('div', { class: 'drawer-rec-body' }, [title, impact]);
+    return el('div', { class: 'drawer-rec-row' }, [badge, body]);
+  }
+
+  function historyRowEl(entry) {
+    var when = entry.scannedAt
+      ? new Date(entry.scannedAt * 1000).toLocaleString()
+      : '—';
+    /* Severity dot mirrors the grade letter, not "worst protocol". A B-grade
+       scan with one failing optional protocol (e.g. BIMI not configured)
+       still reads as healthy at a glance. */
+    var letter = String(entry.grade || '').charAt(0).toUpperCase();
+    var sev = 'pass';
+    if (letter === 'F') sev = 'fail';
+    else if (letter === 'C' || letter === 'D') sev = 'warn';
+    var dot = statusDotEl(sev);
+    var grade = el('span', { class: 'drawer-history-grade', text: String(entry.grade || '—') });
+    var time = el('span', { class: 'drawer-history-time', text: when });
+    return el('div', { class: 'drawer-history-row' }, [dot, grade, time]);
+  }
+
+  function setHeader(data) {
+    var titleEl = drawer.querySelector('.domain-drawer-title');
+    if (!titleEl) return;
+    var pill = gradePillEl(data.grade);
+    var name = el('span', { class: 'drawer-header-name', text: data.domain });
     var lastScan = data.lastScannedAt
       ? new Date(data.lastScannedAt * 1000).toLocaleString()
       : 'Never';
+    var sub = el('span', {
+      class: 'drawer-header-sub',
+      text: 'Last scan ' + lastScan + ' · ' + (data.scanFrequency || '—') + ' cadence'
+    });
+    var stack = el('div', { class: 'drawer-header-stack' }, [name, sub]);
+    titleEl.replaceChildren(pill, stack);
+  }
 
-    function metaSpan(label, value) {
-      var strong = el('strong', { text: label + ':' });
-      var span = el('span');
-      span.appendChild(strong);
-      span.appendChild(document.createTextNode(' ' + (value || '\\u2014')));
-      return span;
+  function renderDrawerBody(data) {
+    var bodyEl = drawer.querySelector('[data-drawer-body]');
+    if (!bodyEl) return;
+    setHeader(data);
+    var children = [];
+
+    /* DiffCard — only when the JSON endpoint surfaced a DMARC drift. The
+       "fixed it" button posts to the existing /scan handler. */
+    if (data.diff) {
+      children.push(diffCardEl(data.domain, data.diff, function() {
+        triggerRescan(data.domain);
+      }));
     }
-    var meta = el('div', { class: 'domain-drawer-meta' }, [
-      metaSpan('Grade', data.grade),
-      metaSpan('Last scan', lastScan),
-      metaSpan('Frequency', data.scanFrequency)
-    ]);
 
-    var historyEl;
-    var rows = data.history || [];
-    if (rows.length === 0) {
-      historyEl = el('p', {
-        style: 'color:var(--clr-text-muted);font-size:0.85rem;',
-        text: 'No scan history yet.'
-      });
+    /* Protocols */
+    var protocols = data.protocols || {};
+    children.push(sectionTitle('Protocols'));
+    var protoList = el('div', { class: 'drawer-protocol-list' }, [
+      protocolRowEl('DMARC', protocols.dmarc),
+      protocolRowEl('SPF', protocols.spf),
+      protocolRowEl('DKIM', protocols.dkim),
+      protocolRowEl('BIMI', protocols.bimi),
+      protocolRowEl('MTA-STS', protocols.mta_sts)
+    ]);
+    children.push(protoList);
+
+    /* Recommendations */
+    var recs = data.recommendations || [];
+    if (recs.length > 0) {
+      children.push(sectionTitle('How to improve'));
+      var recList = el('div', { class: 'drawer-rec-list' });
+      recs.forEach(function(r) { recList.appendChild(recommendationRowEl(r)); });
+      children.push(recList);
+    }
+
+    /* History */
+    children.push(sectionTitle('Recent scans'));
+    var hist = data.history || [];
+    if (hist.length === 0) {
+      children.push(el('p', { class: 'drawer-history-empty', text: 'No scan history yet.' }));
     } else {
-      var tbody = el('tbody');
-      rows.slice(0, 8).forEach(function(h) {
-        var when = new Date(h.scannedAt * 1000).toLocaleDateString();
-        tbody.appendChild(el('tr', null, [
-          el('td', {
-            style: 'padding:4px 0;color:var(--clr-text-muted);font-size:0.8rem;',
-            text: when
-          }),
-          el('td', {
-            style: 'padding:4px 0;font-weight:600;',
-            text: String(h.grade)
-          })
-        ]));
-      });
-      historyEl = el('table', {
-        style: 'width:100%;border-collapse:collapse;margin-top:0.5rem;'
-      }, [tbody]);
+      var histList = el('div', { class: 'drawer-history-list' });
+      hist.slice(0, 8).forEach(function(h) { histList.appendChild(historyRowEl(h)); });
+      children.push(histList);
     }
 
-    var actions = el('div', { class: 'domain-drawer-actions' }, [
-      el('a', {
-        href: '/dashboard/domain/' + encodeURIComponent(data.domain),
-        class: 'dashboard-add-btn',
-        style: 'background:transparent;color:var(--clr-text);border-color:var(--clr-border);',
-        text: 'Open full page'
-      }),
-      (function() {
-        var form = el('form', {
-          method: 'post',
-          action: '/dashboard/domain/' + encodeURIComponent(data.domain) + '/scan',
-          style: 'margin:0;'
-        }, [
-          el('button', { type: 'submit', class: 'dashboard-add-btn', text: 'Re-scan now' })
-        ]);
-        return form;
-      })()
-    ]);
+    bodyEl.replaceChildren.apply(bodyEl, children);
 
-    bodyEl.replaceChildren(meta, historyEl, actions);
+    /* Sticky footer — set/replace so a re-render doesn't stack actions. */
+    var existingFooter = drawer.querySelector('.drawer-footer');
+    if (existingFooter) existingFooter.remove();
+    var openLink = el('a', {
+      href: '/dashboard/domain/' + encodeURIComponent(data.domain),
+      class: 'drawer-cta-secondary',
+      text: 'Open full report →'
+    });
+    var rescanForm = el('form', {
+      method: 'post',
+      action: '/dashboard/domain/' + encodeURIComponent(data.domain) + '/scan',
+      class: 'drawer-footer-form'
+    }, [el('button', { type: 'submit', class: 'drawer-cta-primary', text: 'Re-scan now' })]);
+    var footer = el('footer', { class: 'drawer-footer' }, [openLink, rescanForm]);
+    drawer.appendChild(footer);
+  }
+
+  /* "✓ I fixed it" → POST /dashboard/domain/:domain/scan, show a toast-ish
+     loading state, re-fetch the JSON. The rescan endpoint returns 303 redirect
+     to /dashboard, so we deliberately use fetch with redirect:'manual' to
+     avoid navigating the page out from under the drawer. */
+  function triggerRescan(domain) {
+    var bodyEl = drawer.querySelector('[data-drawer-body]');
+    if (bodyEl) {
+      bodyEl.replaceChildren(el('div', { class: 'domain-drawer-loading', text: 'Re-scanning…' }));
+    }
+    fetch('/dashboard/domain/' + encodeURIComponent(domain) + '/scan', {
+      method: 'POST',
+      credentials: 'same-origin',
+      redirect: 'manual'
+    }).then(function() {
+      return fetch('/dashboard/domain/' + encodeURIComponent(domain) + '.json', {
+        headers: { 'Accept': 'application/json' },
+        credentials: 'same-origin'
+      });
+    }).then(function(res) {
+      if (!res.ok) throw new Error('reload failed');
+      return res.json();
+    }).then(function(data) {
+      renderDrawerBody(data);
+    }).catch(function() {
+      setDrawerStatus('Re-scan finished. Refresh to see updated grades.', 'error');
+    });
   }
 
   function closeDrawer() {

--- a/test/dashboard-routes.test.ts
+++ b/test/dashboard-routes.test.ts
@@ -830,6 +830,204 @@ describe("dashboard/routes", () => {
       expect(body.history).toHaveLength(1);
       expect(body.history[0].grade).toBe("B");
     });
+
+    it("surfaces enriched protocol summaries from the latest scan blob", async () => {
+      const protocolBlob = JSON.stringify({
+        mx: { status: "info", records: [], providers: [], validations: [] },
+        dmarc: {
+          status: "pass",
+          record: "v=DMARC1; p=reject; rua=mailto:rua@example.com",
+          tags: { v: "DMARC1", p: "reject", rua: "mailto:rua@example.com" },
+          validations: [],
+        },
+        spf: {
+          status: "pass",
+          record: "v=spf1 include:_spf.google.com ~all",
+          lookups_used: 4,
+          lookup_limit: 10,
+          include_tree: null,
+          validations: [],
+        },
+        dkim: {
+          status: "pass",
+          selectors: {
+            google: { found: true, key_type: "rsa", key_bits: 2048 },
+            other: { found: false },
+          },
+          validations: [],
+        },
+        bimi: { status: "fail", record: null, tags: null, validations: [] },
+        mta_sts: {
+          status: "fail",
+          dns_record: null,
+          policy: null,
+          validations: [],
+        },
+      });
+      const db = createMockDB({
+        domains: [
+          {
+            id: 1,
+            user_id: "user_1",
+            domain: "example.com",
+            is_free: 0,
+            scan_frequency: "weekly",
+            last_scanned_at: 1700000000,
+            last_grade: "A",
+            created_at: 1700000000,
+          },
+        ],
+        scanHistory: [
+          {
+            grade: "A",
+            scanned_at: 1700000000,
+            protocol_results: protocolBlob,
+            score_factors: "[]",
+          },
+        ],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/domain/example.com.json", {
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        protocols: {
+          dmarc: { status: string; record: string | null; summary: string };
+          spf: { status: string; record: string | null; summary: string };
+          dkim: { status: string; record: string | null; summary: string };
+          bimi: { status: string; record: string | null; summary: string };
+          mta_sts: { status: string; record: string | null; summary: string };
+        };
+        recommendations: { priority: number; title: string }[];
+        diff: unknown | null;
+      };
+      expect(body.protocols.dmarc.status).toBe("pass");
+      expect(body.protocols.dmarc.record).toContain("v=DMARC1");
+      expect(body.protocols.dmarc.summary).toBe("policy: p=reject");
+      expect(body.protocols.spf.summary).toBe("4/10 DNS lookups");
+      expect(body.protocols.dkim.summary).toContain("1 selector");
+      expect(body.protocols.dkim.summary).toContain("2048-bit");
+      expect(body.protocols.bimi.summary).toBe("not configured");
+      expect(body.protocols.mta_sts.summary).toBe("not configured");
+      // recommendations is whatever computeGradeBreakdown returns; we just
+      // assert the field is present and is an array — content varies with
+      // scoring tweaks.
+      expect(Array.isArray(body.recommendations)).toBe(true);
+      // No diff with a single history row.
+      expect(body.diff).toBeNull();
+    });
+
+    it("emits a diff when DMARC drifted within 26h of the previous scan", async () => {
+      const previous = JSON.stringify({
+        dmarc: {
+          status: "pass",
+          record: "v=DMARC1; p=quarantine; pct=100",
+          tags: { p: "quarantine" },
+        },
+        spf: { status: "pass", lookups_used: 3 },
+        dkim: { status: "pass", selectors: {} },
+        bimi: { status: "fail" },
+        mta_sts: { status: "fail" },
+      });
+      const current = JSON.stringify({
+        dmarc: {
+          status: "warn",
+          record: "v=DMARC1; p=none",
+          tags: { p: "none" },
+        },
+        spf: { status: "pass", lookups_used: 3 },
+        dkim: { status: "pass", selectors: {} },
+        bimi: { status: "fail" },
+        mta_sts: { status: "fail" },
+      });
+      const now = 1700000000;
+      const db = createMockDB({
+        domains: [
+          {
+            id: 1,
+            user_id: "user_1",
+            domain: "example.com",
+            is_free: 0,
+            scan_frequency: "daily",
+            last_scanned_at: now,
+            last_grade: "F",
+            created_at: now - 86400 * 30,
+          },
+        ],
+        scanHistory: [
+          { grade: "F", scanned_at: now, protocol_results: current },
+          {
+            grade: "B",
+            scanned_at: now - 12 * 3600,
+            protocol_results: previous,
+          },
+        ],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/domain/example.com.json", {
+        headers: { Cookie: cookie },
+      });
+      const body = (await res.json()) as {
+        diff: {
+          change: string;
+          previous: string;
+          current: string;
+        } | null;
+      };
+      expect(body.diff).not.toBeNull();
+      expect(body.diff?.previous).toContain("p=quarantine");
+      expect(body.diff?.current).toContain("p=none");
+      expect(body.diff?.change).toContain("p=none");
+    });
+
+    it("does not emit a diff when the previous scan is older than 26h", async () => {
+      const blob = (policy: string) =>
+        JSON.stringify({
+          dmarc: {
+            status: "pass",
+            record: `v=DMARC1; p=${policy}`,
+            tags: { p: policy },
+          },
+          spf: { status: "pass", lookups_used: 3 },
+          dkim: { status: "pass", selectors: {} },
+          bimi: { status: "fail" },
+          mta_sts: { status: "fail" },
+        });
+      const now = 1700000000;
+      const db = createMockDB({
+        domains: [
+          {
+            id: 1,
+            user_id: "user_1",
+            domain: "example.com",
+            is_free: 0,
+            scan_frequency: "weekly",
+            last_scanned_at: now,
+            last_grade: "B",
+            created_at: now - 86400 * 30,
+          },
+        ],
+        scanHistory: [
+          { grade: "B", scanned_at: now, protocol_results: blob("none") },
+          // 5 days ago — outside the 26h diff window.
+          {
+            grade: "A",
+            scanned_at: now - 5 * 86400,
+            protocol_results: blob("reject"),
+          },
+        ],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/domain/example.com.json", {
+        headers: { Cookie: cookie },
+      });
+      const body = (await res.json()) as { diff: unknown };
+      expect(body.diff).toBeNull();
+    });
   });
 
   describe("GET /dashboard/domain/:domain/history", () => {


### PR DESCRIPTION
## Summary

Follow-up to [#207](https://github.com/schmug/dmarcheck/pull/207). The first drawer shipped minimal — meta line + tiny history table. The handoff bundle's `proto-drawer.jsx` specified a much richer panel; this PR ports the rest of it.

## What's new in the drawer

- **Header**: grade pill (S/A/C/F tinted, rounded-square) + domain name + monospace "Last scan X · Y cadence" subtitle.
- **"What changed today" diff card**: fires when the latest scan's DMARC record drifted from the previous scan within 26h. Shows the broken `+ current` (red) next to the previous working `− previous` (green) with a **Copy fix** button on the green line, plus a **✓ I fixed it (re-scan)** button that POSTs to the existing `/scan` handler and re-hydrates the drawer in place.
- **Protocol section**: 5 rows (DMARC / SPF / DKIM / BIMI / MTA-STS) with status dot + summary line ("policy: p=reject", "5/10 DNS lookups", "2 selectors · 2048-bit"). Rows with a raw record expand to reveal the record + a Copy button.
- **"How to improve" section**: priority-badged recommendations (P1 red / P2 amber / P3 muted) with title + impact text. Derived on the fly by re-running `computeGradeBreakdown` against the persisted `protocol_results` blob — no schema migration.
- **Recent scans**: stacked rows with severity dot (mirroring the grade letter, not "worst protocol", so a B-grade scan with a failing optional protocol doesn't read red) + grade + timestamp. Replaces the 50/50-split table that left huge whitespace gaps.
- **Sticky footer**: "Open full report →" + "Re-scan now" buttons pinned to the bottom.
- **CopyButton**: shared component with clipboard SVG icon and transient "Copied" pass-tinted state. Built with `createElementNS` + `replaceChildren` — no `innerHTML`.

## JSON endpoint

`/dashboard/domain/:domain.json` now returns `protocols`, `recommendations`, and an optional `diff` alongside the existing fields. Recommendations and protocol summaries are pure derivations — no DB changes. The diff compares the latest two `scan_history` rows: if the DMARC record string differs and they're within 26h of each other, we surface previous + current + a human description. SPF/DKIM diffs are intentionally not surfaced — DMARC drift is the case worth a "paste this back" prompt.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm test` — 803 pass (was 800 before; 3 new cases on the JSON endpoint cover enriched summaries, diff present, diff suppressed when prev scan >26h old)
- [x] Visually walked the drawer via `/_dev/dashboard?fixture=current` with a fetch monkey-patch supplying a realistic `DrawerDetail` payload. Header / diff card / protocol rows (collapsed + expanded) / recommendations (P1/P2/P3 visible) / history dots all render correctly in dark and light modes. No console errors.
- [ ] Reviewer to verify on real D1 data after merge — the local fixture preview can't easily fake an authenticated user against D1, so the path I haven't fully exercised end-to-end is "click a real row → fetch real JSON → see real recommendations from the orchestrator's protocol_results blob".

## Reviewer notes

- The Cloudflare Access gate on `*.workers.dev` previews makes the WorkOS auth flow awkward to test there with a personal session cookie — the smoke path is "merge to main, log in to dmarc.mx, click a row".
- `buildDrawerDetail` is a pure function. If the recommendation text needs tweaking later, that lives entirely in `src/shared/scoring.ts`.
- The 26h diff window is a slack on the 24h cron. If you change the rescan cadence (e.g. hourly for Pro), this constant in `routes.ts` should track that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)