### PR TITLE
feat(security): set HSTS header from the worker (#7)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -136,7 +136,12 @@ app.use("*", async (c, next) => {
 // posture when ACCESS_AUD / ACCESS_TEAM_DOMAIN are missing.
 app.use("*", accessJwtMiddleware());
 
-// Security headers middleware (HSTS is handled at Cloudflare edge)
+// HSTS: 2 years + includeSubDomains. The 2-year max-age satisfies the
+// hstspreload.org submission requirement, but `preload` is intentionally
+// omitted — adding it is a one-way commitment that locks every current and
+// future subdomain (including any short-lived `*.workers.dev` previews
+// proxied behind a custom domain) into HTTPS forever. Submit to the preload
+// list as a separate, deliberate change once we're confident.
 
 // Content types that should be hidden from search engines. HTML is the opposite:
 // it's the whole point of the site and must stay crawlable. Images/CSS/JS are
@@ -186,6 +191,10 @@ app.use("*", async (c, next) => {
   c.res.headers.set(
     "Permissions-Policy",
     "camera=(), microphone=(), geolocation=()",
+  );
+  c.res.headers.set(
+    "Strict-Transport-Security",
+    "max-age=63072000; includeSubDomains",
   );
 
   const contentType = c.res.headers.get("content-type") ?? "";

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -405,9 +405,27 @@ describe("security headers", () => {
     expect(csp).toBe("default-src 'none'; frame-ancestors 'none'");
   });
 
-  it("does not include HSTS header (handled by Cloudflare)", async () => {
+  it("sets HSTS with 2-year max-age and includeSubDomains on HTML responses", async () => {
     const res = await app.request("/");
-    expect(res.headers.get("Strict-Transport-Security")).toBeNull();
+    expect(res.headers.get("Strict-Transport-Security")).toBe(
+      "max-age=63072000; includeSubDomains",
+    );
+  });
+
+  it("sets HSTS on non-HTML responses too", async () => {
+    const res = await app.request("/api/check?domain=");
+    expect(res.headers.get("Strict-Transport-Security")).toBe(
+      "max-age=63072000; includeSubDomains",
+    );
+  });
+
+  // `preload` is intentionally omitted — submission to hstspreload.org is a
+  // separate, deliberate decision that locks every subdomain (including
+  // future ones) into HTTPS forever.
+  it("does not include the `preload` directive", async () => {
+    const res = await app.request("/");
+    const hsts = res.headers.get("Strict-Transport-Security") ?? "";
+    expect(hsts).not.toContain("preload");
   });
 
   it("allows same-origin images in CSP", async () => {


### PR DESCRIPTION
## Summary

- Add `Strict-Transport-Security: max-age=63072000; includeSubDomains` to every response in the security-headers middleware (`src/index.ts`).
- Update tests to assert HSTS is set on both HTML and non-HTML responses, and that `preload` is *not* included.
- Removed the stale "HSTS is handled at the Cloudflare edge" comment — the edge isn't actually emitting one on dmarc.mx (verified via `curl -I https://dmarc.mx/`).

Closes #7.

## Why this shape

- **2-year max-age**: matches the [hstspreload.org](https://hstspreload.org/) submission requirement, so we're future-compatible if/when we decide to preload.
- **`includeSubDomains`**: every dmarcheck subdomain (mta-sts., dashboard. eventually) needs HTTPS — confirmed `mta-sts.dmarc.mx` already serves only over HTTPS.
- **No `preload`**: deliberately omitted. Adding it is a one-way commitment that locks every current and future subdomain (including any short-lived `*.workers.dev` preview proxied behind a custom domain) into HTTPS forever. Submission can be a separate, deliberate change later.
- **Worker-emitted, not edge-emitted**: defense-in-depth + makes self-hosters get HSTS without relying on Cloudflare in front.

## Other parts of #7

The issue also asked for IDN/Punycode handling in `normalizeDomain` and CSP. Both are already covered:
- `src/shared/domain.ts` routes input through `new URL()` which Punycode-encodes IDNs (e.g. `münchen.de` → `xn--mnchen-3ya.de`).
- The existing security-headers middleware already sets a strict CSP on every response (HTML and non-HTML variants).

## Test plan

- [x] `npm test -- --run test/index.test.ts` → 119 passed
- [x] `npm run lint` → clean
- [x] `npm run typecheck` → clean
- [ ] After deploy: `curl -I https://dmarc.mx/ | grep -i strict-transport` returns the expected header (will be covered by the prod smoke test in #190 once that lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)