### PR TITLE
feat(api): embeddable email-security grade badge (#21)

### DIFF
--- a/src/api/badge.ts
+++ b/src/api/badge.ts
@@ -1,0 +1,108 @@
+// Embeddable email-security badge for READMEs / dashboards / status pages.
+// Shields.io-style two-tone SVG: grey label on the left, grade on the right
+// in a color that scales with the score.
+//
+// Rendered server-side as a static SVG with hard-coded geometry — we don't
+// run a font metrics pass. The label is fixed to "dmarcheck" and the value
+// is a single grade token (S, A+, A, A-, B+, B, B-, C+, C, C-, D+, D, D-, F),
+// so the column widths are predictable.
+
+const LABEL_TEXT = "dmarcheck";
+
+// Width of each label/value column in SVG user units. Tuned by eye against
+// shields.io output so the badge sits flush next to other shields without
+// looking out of place. If we ever support an arbitrary label override,
+// this becomes a font-metrics computation; until then, fixed widths keep
+// the markup tiny and deterministic.
+const LABEL_WIDTH = 70;
+const HEIGHT = 20;
+
+function valueWidth(grade: string): number {
+  // 6px per char + 12px horizontal padding (6px each side). One-char ("F")
+  // and three-char ("A+") grades both fit cleanly.
+  return Math.max(28, grade.length * 7 + 14);
+}
+
+// Color band keyed off the *tier* (broader than the modifier suffix).
+// Greens for the A band, amber for B, orange for C, red for D/F. The
+// "S" perfect tier gets a deeper green so it stands out from regular A+.
+function colorFor(grade: string): string {
+  if (grade === "S") return "#16a34a"; // emerald 600 — perfect
+  if (grade.startsWith("A")) return "#22c55e"; // green 500
+  if (grade.startsWith("B")) return "#84cc16"; // lime 500
+  if (grade.startsWith("C")) return "#f59e0b"; // amber 500
+  if (grade.startsWith("D")) return "#f97316"; // orange 500 (matches brand)
+  return "#dc2626"; // red 600 — F or unknown
+}
+
+const VALID_GRADES = new Set([
+  "S",
+  "A+",
+  "A",
+  "A-",
+  "B+",
+  "B",
+  "B-",
+  "C+",
+  "C",
+  "C-",
+  "D+",
+  "D",
+  "D-",
+  "F",
+]);
+
+export function isValidGrade(grade: string): boolean {
+  return VALID_GRADES.has(grade);
+}
+
+// XML escape — the only externally-influenced field on the value column is
+// the grade, which we validate against `VALID_GRADES` before rendering.
+// Defensive escaping anyway, in case future variants accept user labels.
+function esc(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+interface BadgeOptions {
+  /** A grade token (S, A+, …, F) or "error"/"unknown" for fallback states. */
+  grade: string;
+  /** Override the right-side color. Defaults to a band derived from the grade. */
+  color?: string;
+}
+
+export function renderBadgeSvg({ grade, color }: BadgeOptions): string {
+  const label = LABEL_TEXT;
+  const value = grade;
+  const valueWidthPx = valueWidth(value);
+  const totalWidth = LABEL_WIDTH + valueWidthPx;
+  const rightColor = color ?? colorFor(value);
+  const labelTextX = LABEL_WIDTH / 2;
+  const valueTextX = LABEL_WIDTH + valueWidthPx / 2;
+
+  // Drop-shadow text shading is the shields.io convention — improves contrast
+  // on both light and dark page backgrounds.
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${totalWidth}" height="${HEIGHT}" role="img" aria-label="${esc(label)}: ${esc(value)}">
+  <title>${esc(label)}: ${esc(value)}</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="r"><rect width="${totalWidth}" height="${HEIGHT}" rx="3" fill="#fff"/></clipPath>
+  <g clip-path="url(#r)">
+    <rect width="${LABEL_WIDTH}" height="${HEIGHT}" fill="#555"/>
+    <rect x="${LABEL_WIDTH}" width="${valueWidthPx}" height="${HEIGHT}" fill="${esc(rightColor)}"/>
+    <rect width="${totalWidth}" height="${HEIGHT}" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="110" text-rendering="geometricPrecision" transform="scale(.1)">
+    <text x="${labelTextX * 10}" y="150" fill="#010101" fill-opacity=".3" textLength="${(LABEL_WIDTH - 12) * 10}">${esc(label)}</text>
+    <text x="${labelTextX * 10}" y="140" textLength="${(LABEL_WIDTH - 12) * 10}">${esc(label)}</text>
+    <text x="${valueTextX * 10}" y="150" fill="#010101" fill-opacity=".3">${esc(value)}</text>
+    <text x="${valueTextX * 10}" y="140">${esc(value)}</text>
+  </g>
+</svg>`;
+}

--- a/src/api/openapi.ts
+++ b/src/api/openapi.ts
@@ -353,6 +353,55 @@ export const OPENAPI_DOCUMENT = {
         },
       },
     },
+    "/badge": {
+      get: {
+        summary: "Embeddable email-security grade badge (SVG)",
+        description:
+          "Returns a shields.io-style SVG badge with the domain's current grade. Cached aggressively (1h max-age + 24h stale-while-revalidate) so a badge embedded in a README does not trigger a scan per viewer. Always returns SVG — invalid input renders an `invalid` badge with a 400 status; scan errors render an `error` badge with a 200 status so README embeds never break.",
+        operationId: "gradeBadge",
+        parameters: [
+          {
+            name: "domain",
+            in: "query",
+            required: true,
+            description: "Domain to scan, lowercase, `[a-z0-9.-]` only.",
+            schema: {
+              type: "string",
+              pattern: "^[a-z0-9.-]+$",
+              maxLength: 253,
+            },
+            example: "dmarc.mx",
+          },
+        ],
+        responses: {
+          "200": {
+            description: "SVG badge",
+            content: {
+              "image/svg+xml": {
+                schema: { type: "string", format: "binary" },
+              },
+            },
+          },
+          "400": {
+            description: "Invalid input (rendered as an SVG `invalid` badge)",
+            content: {
+              "image/svg+xml": {
+                schema: { type: "string", format: "binary" },
+              },
+            },
+          },
+          "429": {
+            description:
+              "Rate limit exceeded (rendered as an SVG `rate limited` badge)",
+            content: {
+              "image/svg+xml": {
+                schema: { type: "string", format: "binary" },
+              },
+            },
+          },
+        },
+      },
+    },
     "/health": {
       get: {
         summary: "Liveness probe",

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import {
   getAgentSkillsIndexJson,
   SCAN_DOMAIN_SKILL_MD,
 } from "./api/agent-skills.js";
+import { isValidGrade, renderBadgeSvg } from "./api/badge.js";
 import {
   BULK_IN_BAND_CAP,
   isCapExceeded,
@@ -471,6 +472,22 @@ app.use(
   ),
 );
 
+// Badge endpoint runs a full scan on cache miss, so it gets the same
+// per-IP limiter as /api/check. Cloudflare edge caches the SVG response
+// (1h max-age), so README-embedded badges collapse to a small number of
+// origin hits regardless of view volume.
+app.use(
+  "/badge",
+  rateLimitMiddleware((c, _result, headers) =>
+    // Even rate-limit responses must be SVG so embeds don't render a JSON
+    // blob in place of the badge. "rate limited" is a fallback grade.
+    c.body(renderBadgeSvg({ grade: "rate limited", color: "#737373" }), {
+      status: 429,
+      headers: { ...headers, "Content-Type": "image/svg+xml; charset=utf-8" },
+    }),
+  ),
+);
+
 const protocolRenderers: Record<
   ProtocolId,
   (result: ProtocolResult) => string
@@ -623,6 +640,55 @@ app.get("/og-image.svg", (c) => {
     "Content-Type": "image/svg+xml",
     "Cache-Control": "public, max-age=86400",
   });
+});
+
+// Embeddable email-security badge for READMEs and dashboards. Always
+// returns a 200 SVG (even for invalid input or scan errors) so a badge
+// embed never renders as a broken image — error states are encoded into
+// the badge text instead.
+app.get("/badge", async (c) => {
+  const domain = normalizeDomain(c.req.query("domain"));
+  const svgHeaders = (): Record<string, string> => ({
+    "Content-Type": "image/svg+xml; charset=utf-8",
+    // 1h browser, 1h edge, generous SWR. Badges live on README pages —
+    // they need to render fast and stay fresh-ish without re-scanning per
+    // viewer. The scan itself is also cached for 5 minutes inside getCachedScan,
+    // but that's a different layer; this header controls what GitHub
+    // (and downstream image proxies like camo) see.
+    "Cache-Control":
+      "public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400",
+    // GitHub's image proxy (camo) won't show user-supplied SVGs unless
+    // the response is a clean SVG with no embedded scripts. Our generator
+    // emits no <script>, but reinforce with CSP.
+    "Content-Security-Policy": "default-src 'none'; style-src 'unsafe-inline'",
+  });
+
+  if (!domain) {
+    return c.body(renderBadgeSvg({ grade: "invalid", color: "#737373" }), 400, {
+      ...svgHeaders(),
+    });
+  }
+
+  try {
+    const cached = await getCachedScan(domain, []);
+    const result = cached ?? (await scan(domain, []));
+    if (!cached) {
+      const pendingCacheWrite = setCachedScan(domain, [], result);
+      if (pendingCacheWrite) {
+        c.executionCtx.waitUntil(pendingCacheWrite.catch(() => {}));
+      }
+    }
+    const grade = isValidGrade(result.grade) ? result.grade : "unknown";
+    return c.body(renderBadgeSvg({ grade }), 200, svgHeaders());
+  } catch (err) {
+    Sentry.captureException(err);
+    return c.body(renderBadgeSvg({ grade: "error", color: "#737373" }), 200, {
+      ...svgHeaders(),
+      // Shorter cache on errors so a transient DNS failure doesn't lock
+      // a domain into the error badge for an hour.
+      "Cache-Control": "public, max-age=60",
+    });
+  }
 });
 
 app.get("/og-image.png", (c) => {

--- a/test/badge.test.ts
+++ b/test/badge.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { isValidGrade, renderBadgeSvg } from "../src/api/badge.js";
+import { app } from "../src/index.js";
+import { _memoryStore } from "../src/rate-limit.js";
+
+vi.mock("../src/cache.js", () => ({
+  getCachedScan: vi.fn().mockResolvedValue(null),
+  setCachedScan: vi.fn(),
+}));
+
+vi.mock("../src/orchestrator.js", async () => ({
+  scan: vi.fn().mockResolvedValue({
+    domain: "example.com",
+    timestamp: "2026-04-27T00:00:00.000Z",
+    grade: "B+",
+    breakdown: {
+      grade: "B+",
+      tier: "B",
+      tierReason: "ok",
+      modifier: 1,
+      modifierLabel: "+",
+      factors: [],
+      recommendations: [],
+    },
+    summary: {
+      mx_records: 1,
+      mx_providers: [],
+      dmarc_policy: "quarantine",
+      spf_result: "pass",
+      spf_lookups: "5/10",
+      dkim_selectors_found: 0,
+      bimi_enabled: false,
+      mta_sts_mode: null,
+    },
+    protocols: {},
+  }),
+}));
+
+vi.mock("../src/dns/client.js", () => ({
+  queryTxt: vi.fn().mockResolvedValue(null),
+  queryMx: vi.fn().mockResolvedValue(null),
+}));
+
+beforeEach(() => {
+  _memoryStore.clear();
+});
+
+describe("renderBadgeSvg", () => {
+  it("emits a well-formed SVG element", () => {
+    const svg = renderBadgeSvg({ grade: "A+" });
+    expect(svg).toMatch(/^<svg [^>]+>/);
+    expect(svg).toContain("</svg>");
+  });
+
+  it("includes the grade and label text twice (shadow + foreground)", () => {
+    const svg = renderBadgeSvg({ grade: "A+" });
+    const labelMatches = svg.match(/dmarcheck/g) ?? [];
+    const valueMatches = svg.match(/>A\+</g) ?? [];
+    expect(labelMatches.length).toBeGreaterThanOrEqual(2);
+    expect(valueMatches.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("includes an aria-label combining label and grade", () => {
+    const svg = renderBadgeSvg({ grade: "B" });
+    expect(svg).toContain('aria-label="dmarcheck: B"');
+  });
+
+  it("color-codes by tier", () => {
+    expect(renderBadgeSvg({ grade: "S" })).toContain("#16a34a");
+    expect(renderBadgeSvg({ grade: "A+" })).toContain("#22c55e");
+    expect(renderBadgeSvg({ grade: "B" })).toContain("#84cc16");
+    expect(renderBadgeSvg({ grade: "C-" })).toContain("#f59e0b");
+    expect(renderBadgeSvg({ grade: "D" })).toContain("#f97316");
+    expect(renderBadgeSvg({ grade: "F" })).toContain("#dc2626");
+  });
+
+  it("escapes the grade value to prevent SVG injection", () => {
+    const svg = renderBadgeSvg({ grade: "<script>" });
+    expect(svg).not.toContain("<script>");
+    expect(svg).toContain("&lt;script&gt;");
+  });
+
+  it("respects an explicit color override", () => {
+    const svg = renderBadgeSvg({ grade: "F", color: "#000000" });
+    expect(svg).toContain("#000000");
+    expect(svg).not.toContain("#dc2626");
+  });
+
+  it("widens the value column for longer grade tokens", () => {
+    const a = renderBadgeSvg({ grade: "F" });
+    const b = renderBadgeSvg({ grade: "rate limited" });
+    const widthOf = (svg: string) =>
+      Number(svg.match(/^<svg [^>]*width="(\d+)"/)?.[1] ?? 0);
+    expect(widthOf(b)).toBeGreaterThan(widthOf(a));
+  });
+});
+
+describe("isValidGrade", () => {
+  it("accepts every grade the scoring engine emits", () => {
+    for (const g of [
+      "S",
+      "A+",
+      "A",
+      "A-",
+      "B+",
+      "B",
+      "B-",
+      "C+",
+      "C",
+      "C-",
+      "D+",
+      "D",
+      "D-",
+      "F",
+    ]) {
+      expect(isValidGrade(g)).toBe(true);
+    }
+  });
+
+  it("rejects unknown tokens", () => {
+    expect(isValidGrade("E")).toBe(false);
+    expect(isValidGrade("A++")).toBe(false);
+    expect(isValidGrade("")).toBe(false);
+    expect(isValidGrade("<script>")).toBe(false);
+  });
+});
+
+describe("/badge route", () => {
+  it("returns 200 SVG for a valid domain", async () => {
+    const res = await app.request("/badge?domain=example.com");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe(
+      "image/svg+xml; charset=utf-8",
+    );
+    const body = await res.text();
+    expect(body).toMatch(/^<svg /);
+    expect(body).toContain(">B+<");
+  });
+
+  it("sets a 1h browser cache + long stale-while-revalidate", async () => {
+    const res = await app.request("/badge?domain=example.com");
+    const cc = res.headers.get("Cache-Control") ?? "";
+    expect(cc).toContain("max-age=3600");
+    expect(cc).toContain("stale-while-revalidate=");
+  });
+
+  it("returns an SVG (not JSON) on missing domain", async () => {
+    const res = await app.request("/badge");
+    expect(res.status).toBe(400);
+    expect(res.headers.get("Content-Type")).toBe(
+      "image/svg+xml; charset=utf-8",
+    );
+    const body = await res.text();
+    expect(body).toMatch(/^<svg /);
+    expect(body).toContain(">invalid<");
+  });
+
+  it("returns an SVG on rejected/invalid domain input", async () => {
+    const res = await app.request("/badge?domain=not%20a%20domain");
+    expect(res.status).toBe(400);
+    expect(res.headers.get("Content-Type")).toBe(
+      "image/svg+xml; charset=utf-8",
+    );
+  });
+
+  it("sets a strict CSP that blocks scripts in the embedded SVG", async () => {
+    const res = await app.request("/badge?domain=example.com");
+    const csp = res.headers.get("Content-Security-Policy") ?? "";
+    expect(csp).toContain("default-src 'none'");
+  });
+
+  it("rate limits repeated requests with an SVG 429", async () => {
+    // Rate limit is 10/60s for anonymous IPs. Burn 11 requests from the
+    // same synthetic IP and expect the 11th to come back as a badge SVG
+    // 429, not JSON.
+    for (let i = 0; i < 10; i++) {
+      const ok = await app.request("/badge?domain=example.com");
+      expect(ok.status).toBe(200);
+    }
+    const limited = await app.request("/badge?domain=example.com");
+    expect(limited.status).toBe(429);
+    expect(limited.headers.get("Content-Type")).toBe(
+      "image/svg+xml; charset=utf-8",
+    );
+    const body = await limited.text();
+    expect(body).toMatch(/^<svg /);
+    expect(body).toContain(">rate limited<");
+  });
+});


### PR DESCRIPTION
## Summary

Adds `/badge?domain=example.com` — a [shields.io](https://shields.io)-style SVG badge with the domain's current email-security grade. Sysadmins can embed it in READMEs, dashboards, or status pages the way a build-status badge would surface CI state. Closes #21.

```markdown
![email-security](https://dmarc.mx/badge?domain=dmarc.mx)
```

## Visual check

Verified locally on light + dark backgrounds:

- `dmarc.mx` → **S** (emerald — perfect tier)
- `cloudflare.com` → **A+** (green)
- `anthropic.com` → **B+** (lime)
- `github.com` → **C+** (amber)
- missing/invalid domain → **invalid** (grey, 400)

## Design choices

- **SVG always**: the response is always SVG, even on error/rate-limit/invalid input. An embed must never render a broken image or a JSON blob in place of the badge — error states are encoded into the badge text.
- **Cache-first scan**: looks up the existing scan cache; runs a full scan only on cache miss. With a 1h browser/edge cache + 24h `stale-while-revalidate`, a README embedded badge collapses to a tiny number of origin hits regardless of view volume.
- **Same rate limiter as /api/check**: cache-miss requests do real DNS work, so they share the per-IP anonymous bucket. The 429 response is also an SVG (\"rate limited\" grey badge).
- **CSP on the SVG**: `default-src 'none'; style-src 'unsafe-inline'` reinforces that the badge contains no executable content. GitHub's image proxy (camo) is pickier about user-supplied SVGs; this stays well within camo's tolerance.
- **Hard-coded geometry**: label is fixed to `dmarcheck` and the value is always a single grade token (S, A+, …, F), so the column widths are predictable. If we later support arbitrary labels, this becomes a font-metrics computation; until then, fixed widths keep the markup tiny and deterministic.
- **No \"flat-square\" / \"for-the-badge\" variants yet**: the issue lists those as ideas to explore, but landing one tight style first avoids over-engineering. Easy follow-up if there's demand.

## Color band

| Grade | Color | Hex |
|---|---|---|
| S | emerald 600 | `#16a34a` |
| A+ / A / A- | green 500 | `#22c55e` |
| B+ / B / B- | lime 500 | `#84cc16` |
| C+ / C / C- | amber 500 | `#f59e0b` |
| D+ / D / D- | orange 500 (matches brand) | `#f97316` |
| F / unknown | red 600 | `#dc2626` |

## OpenAPI

The `/badge` path is added to `src/api/openapi.ts` so agent/discovery clients can find it via the existing OpenAPI 3.1 doc.

## Test plan

- [x] `npm test` — 818 / 818 passed (15 new badge tests)
- [x] `npm run lint` / `npm run typecheck` — clean
- [x] Manual visual check at `/badge?domain=…` against local dev server
- [ ] After deploy: README embed render check on GitHub
- [ ] Post-deploy smoke (#190) will pick up the route as part of the OpenAPI advertisement; can extend with a `/badge` probe in a follow-up if desirable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)