### PR TITLE
feat(analyzer): surface security.txt (RFC 9116) on the scorecard (#40)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Live at dmarc.mx | Repo: github.com/schmug/dmarcheck
 
 - `src/index.ts` — Hono routes, content negotiation, rate limiting middleware
 - `src/dns/client.ts` — DNS abstraction over node:dns (NXDOMAIN returns null)
-- `src/analyzers/` — One module per protocol (dmarc, spf, dkim, bimi, mta-sts)
+- `src/analyzers/` — One module per protocol (dmarc, spf, dkim, bimi, mta-sts, mx, security-txt)
 - `src/orchestrator.ts` — Runs all analyzers in parallel via Promise.allSettled
 - `src/shared/scoring.ts` — Grade computation (F if no DMARC or p=none)
 - `src/cache.ts` — SSE result caching
@@ -85,6 +85,7 @@ Live at dmarc.mx | Repo: github.com/schmug/dmarcheck
 - **Secret scanning:** Secret scanning, push protection, non-provider patterns, and validity checks are all enabled in repo settings. Never commit `.env`, tokens, or wrangler secrets.
 - **Input validation:** User-supplied domains are restricted to `[a-z0-9.-]` in `normalizeDomain` (`src/index.ts`). DKIM selectors are restricted to `[A-Za-z0-9._-]` in `parseSelectors`. HTML output never interpolates raw user input into inline `<script>` blocks — use `data-*` attributes via `esc()` instead.
 - **MTA-STS fetch redirect mode:** `src/analyzers/mta-sts.ts` uses `redirect: "manual"` for the policy fetch. Do NOT change it to `"error"` — that throws in the Cloudflare Workers fetch runtime and breaks every scan (regressed twice via PRs #58 and #92). `"manual"` is RFC 8461 §3.3-compliant: redirects yield an opaque-redirect `Response` rejected by the existing `resp.type === "opaqueredirect"` / `!resp.ok` guards.
+- **security.txt fetch redirect mode:** `src/analyzers/security-txt.ts` deliberately uses `redirect: "follow"` (not `"manual"`) — RFC 9116 §3 does not forbid following redirects, and real-world deployments commonly redirect (e.g. gov.uk → www.gov.uk → vdp.cabinetoffice.gov.uk). MTA-STS's `manual` posture is a security requirement of RFC 8461 §3.3 specifically; security.txt has no equivalent rule, so the user-friendly choice is to follow.
 - **Reporting:** See `SECURITY.md` for the private disclosure process.
 
 ## Database migrations

--- a/src/analyzers/security-txt.ts
+++ b/src/analyzers/security-txt.ts
@@ -1,0 +1,259 @@
+import type {
+  SecurityTxtFields,
+  SecurityTxtResult,
+  Validation,
+} from "./types.js";
+
+// RFC 9116 — security.txt. Informational analyzer (status always "info");
+// does not affect the letter grade. security.txt is general domain-security
+// hygiene, not part of the email authentication stack, so it surfaces as
+// a separate card without nudging the email-security score.
+//
+// Fetch posture intentionally diverges from src/analyzers/mta-sts.ts:
+//   - `redirect: "follow"` (NOT "manual"). RFC 9116 §3 doesn't forbid
+//     redirects, and real-world deployments depend on them
+//     (gov.uk → www.gov.uk → vdp.cabinetoffice.gov.uk). MTA-STS uses
+//     "manual" because RFC 8461 §3.3 specifically forbids following
+//     redirects on the policy fetch — a security-model requirement
+//     security.txt does not share. See CLAUDE.md §Security.
+//   - 3s timeout via AbortSignal.
+//   - All fetch / decode / abort errors collapse to "no file found"
+//     (informational), never throw out of the analyzer.
+
+const FETCH_TIMEOUT_MS = 3000;
+const MAX_BODY_BYTES = 64 * 1024; // RFC 9116 doesn't cap, but a 64KB ceiling
+// is generous (real-world files are <2KB) and keeps a misconfigured server
+// from streaming us megabytes.
+
+function emptyFields(): SecurityTxtFields {
+  return {
+    contact: [],
+    expires: null,
+    encryption: [],
+    policy: [],
+    acknowledgments: [],
+    preferred_languages: null,
+    canonical: [],
+    hiring: [],
+  };
+}
+
+export async function analyzeSecurityTxt(
+  domain: string,
+): Promise<SecurityTxtResult> {
+  // Try /.well-known/security.txt first (RFC 9116 §3 canonical location),
+  // then the legacy /security.txt root fallback. The well-known URL wins
+  // if both exist — that's what RFC 9116 §3 says.
+  const wellKnown = `https://${domain}/.well-known/security.txt`;
+  const fallback = `https://${domain}/security.txt`;
+
+  const wkResp = await fetchSecurityTxt(wellKnown);
+  if (wkResp) return finalize(wellKnown, wkResp);
+
+  const fbResp = await fetchSecurityTxt(fallback);
+  if (fbResp) return finalize(fallback, fbResp);
+
+  return {
+    status: "info",
+    source_url: null,
+    signed: false,
+    fields: null,
+    validations: [
+      {
+        status: "info",
+        message: "No security.txt published (informational, not scored)",
+      },
+    ],
+  };
+}
+
+async function fetchSecurityTxt(url: string): Promise<string | null> {
+  try {
+    const resp = await fetch(url, {
+      headers: { "User-Agent": "dmarcheck/1.0" },
+      // `redirect: "follow"` — diverges from src/analyzers/mta-sts.ts
+      // (which uses "manual") because RFC 9116 §3 does not forbid
+      // redirects, and real-world security.txt deployments commonly
+      // redirect (e.g. gov.uk → www.gov.uk → vdp.cabinetoffice.gov.uk).
+      // RFC 8461 §3.3 specifically forbids following redirects on the
+      // MTA-STS policy fetch for security-model reasons; security.txt
+      // has no such constraint, so the user-friendly choice is to
+      // follow. The fetch runtime caps the redirect chain itself, so
+      // we don't need an explicit hop limit.
+      redirect: "follow",
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+
+    if (!resp.ok) return null;
+
+    // Cap the body size before we decode it — saves both memory and the
+    // cost of running the parser over a runaway response.
+    const buffer = await resp.arrayBuffer();
+    const slice =
+      buffer.byteLength > MAX_BODY_BYTES
+        ? buffer.slice(0, MAX_BODY_BYTES)
+        : buffer;
+    return new TextDecoder("utf-8", {
+      fatal: false,
+      ignoreBOM: false,
+    }).decode(slice);
+  } catch {
+    return null;
+  }
+}
+
+function finalize(sourceUrl: string, raw: string): SecurityTxtResult {
+  const { body, signed } = stripPgpArmor(raw);
+  const fields = parseFields(body);
+
+  const validations: Validation[] = [];
+  validations.push({
+    status: "info",
+    message: `Found at ${sourceUrl}`,
+  });
+  if (signed) {
+    validations.push({
+      status: "info",
+      message: "PGP cleartext-signature armor detected",
+    });
+  }
+
+  // RFC 9116 §2.5.3: Contact is REQUIRED and at least one MUST be present.
+  if (fields.contact.length === 0) {
+    validations.push({
+      status: "warn",
+      message: "Missing required Contact: field (RFC 9116 §2.5.3)",
+    });
+  } else {
+    validations.push({
+      status: "info",
+      message: `${fields.contact.length} Contact entr${
+        fields.contact.length === 1 ? "y" : "ies"
+      }`,
+    });
+  }
+
+  // RFC 9116 §2.5.5: Expires is REQUIRED, ISO 8601 format, MUST NOT be in
+  // the past — and SHOULD be no more than a year out.
+  if (!fields.expires) {
+    validations.push({
+      status: "warn",
+      message: "Missing required Expires: field (RFC 9116 §2.5.5)",
+    });
+  } else {
+    const expiresMs = Date.parse(fields.expires);
+    if (Number.isNaN(expiresMs)) {
+      validations.push({
+        status: "warn",
+        message: `Expires: not parseable as ISO 8601 (got "${fields.expires}")`,
+      });
+    } else if (expiresMs < Date.now()) {
+      validations.push({
+        status: "warn",
+        message: `Expires: ${fields.expires} is in the past — file is stale`,
+      });
+    } else {
+      const oneYearMs = 365 * 24 * 60 * 60 * 1000;
+      if (expiresMs - Date.now() > oneYearMs) {
+        validations.push({
+          status: "info",
+          message: `Expires: ${fields.expires} is more than a year out (RFC 9116 §2.5.5 SHOULD)`,
+        });
+      } else {
+        validations.push({
+          status: "info",
+          message: `Expires: ${fields.expires}`,
+        });
+      }
+    }
+  }
+
+  return {
+    status: "info",
+    source_url: sourceUrl,
+    signed,
+    fields,
+    validations,
+  };
+}
+
+// RFC 9116 §2.3: a security.txt file MAY be PGP-cleartext-signed. Strip
+// the armor headers and trailing signature block before parsing so the
+// signed body parses identically to an unsigned one.
+function stripPgpArmor(raw: string): { body: string; signed: boolean } {
+  const beginCleartext = raw.indexOf("-----BEGIN PGP SIGNED MESSAGE-----");
+  if (beginCleartext === -1) return { body: raw, signed: false };
+
+  const afterCleartextHeader = raw.indexOf("\n\n", beginCleartext);
+  if (afterCleartextHeader === -1) return { body: raw, signed: true };
+
+  const beginSignature = raw.indexOf(
+    "-----BEGIN PGP SIGNATURE-----",
+    afterCleartextHeader,
+  );
+  const bodyEnd = beginSignature === -1 ? raw.length : beginSignature;
+
+  return {
+    body: raw.slice(afterCleartextHeader + 2, bodyEnd),
+    signed: true,
+  };
+}
+
+function parseFields(body: string): SecurityTxtFields {
+  const fields = emptyFields();
+
+  let start = 0;
+  while (start < body.length) {
+    let end = body.indexOf("\n", start);
+    if (end === -1) end = body.length;
+    const line = body.slice(start, end).trim();
+    start = end + 1;
+
+    if (!line) continue;
+    if (line.startsWith("#")) continue;
+    // PGP cleartext-signature dash-escaping: per RFC 4880 §7.1, lines
+    // starting with "- " in the signed body must be unescaped to "".
+    const unescaped = line.startsWith("- ") ? line.slice(2) : line;
+
+    const colonIdx = unescaped.indexOf(":");
+    if (colonIdx === -1) continue;
+
+    const key = unescaped.slice(0, colonIdx).trim().toLowerCase();
+    const value = unescaped.slice(colonIdx + 1).trim();
+    if (!value) continue;
+
+    switch (key) {
+      case "contact":
+        fields.contact.push(value);
+        break;
+      case "expires":
+        // RFC 9116 §2.5.5: at most one Expires field. If multiple are
+        // present, last-write-wins matches what most clients do.
+        fields.expires = value;
+        break;
+      case "encryption":
+        fields.encryption.push(value);
+        break;
+      case "policy":
+        fields.policy.push(value);
+        break;
+      case "acknowledgments":
+      case "acknowledgements": // common misspelling; accept both
+        fields.acknowledgments.push(value);
+        break;
+      case "preferred-languages":
+        fields.preferred_languages = value;
+        break;
+      case "canonical":
+        fields.canonical.push(value);
+        break;
+      case "hiring":
+        fields.hiring.push(value);
+        break;
+      // Unknown fields ignored per RFC 9116 §2.4 ("Extension Fields"
+      // — parsers MUST accept and ignore unrecognized fields).
+    }
+  }
+
+  return fields;
+}

--- a/src/analyzers/types.ts
+++ b/src/analyzers/types.ts
@@ -81,6 +81,27 @@ export interface MxResult {
   validations: Validation[];
 }
 
+export interface SecurityTxtFields {
+  contact: string[];
+  expires: string | null;
+  encryption: string[];
+  policy: string[];
+  acknowledgments: string[];
+  preferred_languages: string | null;
+  canonical: string[];
+  hiring: string[];
+}
+
+export interface SecurityTxtResult {
+  status: Status;
+  /** URL the file was actually fetched from (well-known or root fallback). */
+  source_url: string | null;
+  /** Whether the body carried PGP cleartext-signature armor. */
+  signed: boolean;
+  fields: SecurityTxtFields | null;
+  validations: Validation[];
+}
+
 export interface ScanSummary {
   mx_records: number;
   mx_providers: string[];
@@ -105,5 +126,6 @@ export interface ScanResult {
     dkim: DkimResult;
     bimi: BimiResult;
     mta_sts: MtaStsResult;
+    security_txt: SecurityTxtResult;
   };
 }

--- a/src/api/openapi.ts
+++ b/src/api/openapi.ts
@@ -453,6 +453,9 @@ export const OPENAPI_DOCUMENT = {
           grade: { type: "string" },
           protocols: {
             type: "object",
+            // Per-row history persists pre-#40 rows that don't carry a
+            // security_txt status. Leave it out of `required` so older
+            // history payloads still validate; new scans include it.
             required: ["dmarc", "spf", "dkim", "bimi", "mta_sts"],
             additionalProperties: false,
             properties: {
@@ -481,6 +484,12 @@ export const OPENAPI_DOCUMENT = {
                 ],
               },
               mta_sts: {
+                oneOf: [
+                  { $ref: "#/components/schemas/Status" },
+                  { type: "null" },
+                ],
+              },
+              security_txt: {
                 oneOf: [
                   { $ref: "#/components/schemas/Status" },
                   { type: "null" },
@@ -608,6 +617,45 @@ export const OPENAPI_DOCUMENT = {
           policy: {
             oneOf: [
               { $ref: "#/components/schemas/MtaStsPolicy" },
+              { type: "null" },
+            ],
+          },
+          validations,
+        },
+      },
+      SecurityTxtFields: {
+        type: "object",
+        required: [
+          "contact",
+          "expires",
+          "encryption",
+          "policy",
+          "acknowledgments",
+          "preferred_languages",
+          "canonical",
+          "hiring",
+        ],
+        properties: {
+          contact: { type: "array", items: { type: "string" } },
+          expires: { type: ["string", "null"] },
+          encryption: { type: "array", items: { type: "string" } },
+          policy: { type: "array", items: { type: "string" } },
+          acknowledgments: { type: "array", items: { type: "string" } },
+          preferred_languages: { type: ["string", "null"] },
+          canonical: { type: "array", items: { type: "string" } },
+          hiring: { type: "array", items: { type: "string" } },
+        },
+      },
+      SecurityTxtResult: {
+        type: "object",
+        required: ["status", "source_url", "signed", "fields", "validations"],
+        properties: {
+          status: { $ref: "#/components/schemas/Status" },
+          source_url: { type: ["string", "null"] },
+          signed: { type: "boolean" },
+          fields: {
+            oneOf: [
+              { $ref: "#/components/schemas/SecurityTxtFields" },
               { type: "null" },
             ],
           },
@@ -756,7 +804,15 @@ export const OPENAPI_DOCUMENT = {
           summary: { $ref: "#/components/schemas/ScanSummary" },
           protocols: {
             type: "object",
-            required: ["mx", "dmarc", "spf", "dkim", "bimi", "mta_sts"],
+            required: [
+              "mx",
+              "dmarc",
+              "spf",
+              "dkim",
+              "bimi",
+              "mta_sts",
+              "security_txt",
+            ],
             properties: {
               mx: { $ref: "#/components/schemas/MxResult" },
               dmarc: { $ref: "#/components/schemas/DmarcResult" },
@@ -764,6 +820,7 @@ export const OPENAPI_DOCUMENT = {
               dkim: { $ref: "#/components/schemas/DkimResult" },
               bimi: { $ref: "#/components/schemas/BimiResult" },
               mta_sts: { $ref: "#/components/schemas/MtaStsResult" },
+              security_txt: { $ref: "#/components/schemas/SecurityTxtResult" },
             },
           },
         },

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -67,6 +67,11 @@ export function generateCsv(result: ScanResult): string {
   // BOM + header
   rows.push(`\uFEFF${HEADERS.map(escapeCsvField).join(",")}`);
 
+  // security_txt is intentionally omitted — it's an informational analyzer
+  // (status always "info", does not contribute scoring factors or
+  // recommendations), so CSV consumers focused on the email-security grade
+  // get a tighter export. The full security.txt findings are still
+  // available on the JSON response and the HTML report.
   const protocols = ["mx", "dmarc", "spf", "dkim", "bimi", "mta_sts"] as const;
 
   for (const key of protocols) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import type {
   MtaStsResult,
   MxResult,
   ScanResult,
+  SecurityTxtResult,
   SpfResult,
 } from "./analyzers/types.js";
 import {
@@ -73,6 +74,7 @@ import {
   renderReportHeader,
   renderScoreBreakdown,
   renderScoringRubric,
+  renderSecurityTxtCard,
   renderSpfCard,
   renderStreamingLoading,
 } from "./views/html.js";
@@ -481,6 +483,7 @@ const protocolRenderers: Record<
   dkim: (r) => renderDkimCard(r as DkimResult),
   bimi: (r) => renderBimiCard(r as BimiResult),
   mta_sts: (r) => renderMtaStsCard(r as MtaStsResult),
+  security_txt: (r) => renderSecurityTxtCard(r as SecurityTxtResult),
 };
 
 function tagScanResult(result: ScanResult): void {
@@ -491,6 +494,11 @@ function tagScanResult(result: ScanResult): void {
   scope.setTag("dkim.status", result.protocols.dkim.status);
   scope.setTag("bimi.status", result.protocols.bimi.status);
   scope.setTag("mta_sts.status", result.protocols.mta_sts.status);
+  // Optional access — older cached scans (pre-#40) may not include
+  // security_txt. Drop the tag rather than crash the SSE replay.
+  if (result.protocols.security_txt) {
+    scope.setTag("security_txt.status", result.protocols.security_txt.status);
+  }
 }
 
 app.get("/api/check/stream", async (c) => {
@@ -527,9 +535,14 @@ app.get("/api/check/stream", async (c) => {
         "dkim",
         "bimi",
         "mta_sts",
+        "security_txt",
       ];
       for (const id of protocolIds) {
-        const html = protocolRenderers[id](cached.protocols[id]);
+        const protocolResult = cached.protocols[id];
+        // Older cached scans (pre-#40) may lack security_txt; skip rather
+        // than crashing the replay. Fresh scans always populate it.
+        if (!protocolResult) continue;
+        const html = protocolRenderers[id](protocolResult);
         await stream.writeSSE({
           event: "protocol",
           data: JSON.stringify({ id, html }),

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -4,6 +4,7 @@ import { analyzeDkim } from "./analyzers/dkim.js";
 import { analyzeDmarc } from "./analyzers/dmarc.js";
 import { analyzeMtaSts } from "./analyzers/mta-sts.js";
 import { analyzeMx } from "./analyzers/mx.js";
+import { analyzeSecurityTxt } from "./analyzers/security-txt.js";
 import { analyzeSpf } from "./analyzers/spf.js";
 import type {
   BimiResult,
@@ -12,19 +13,28 @@ import type {
   MtaStsResult,
   MxResult,
   ScanResult,
+  SecurityTxtResult,
   SpfResult,
 } from "./analyzers/types.js";
 import { queryTxt } from "./dns/client.js";
 import { computeGradeBreakdown } from "./shared/scoring.js";
 
-export type ProtocolId = "mx" | "dmarc" | "spf" | "dkim" | "bimi" | "mta_sts";
+export type ProtocolId =
+  | "mx"
+  | "dmarc"
+  | "spf"
+  | "dkim"
+  | "bimi"
+  | "mta_sts"
+  | "security_txt";
 export type ProtocolResult =
   | MxResult
   | DmarcResult
   | SpfResult
   | DkimResult
   | BimiResult
-  | MtaStsResult;
+  | MtaStsResult
+  | SecurityTxtResult;
 
 async function buildScanResult(
   domain: string,
@@ -78,6 +88,7 @@ export async function scan(
   const mtaStsPromise = analyzeMtaSts(domain);
   const bimiDnsPromise = prefetchBimiDns(domain);
   const mxPromise = analyzeMx(domain);
+  const securityTxtPromise = analyzeSecurityTxt(domain);
 
   // Chain DKIM off MX so it starts as soon as MX resolves
   // without blocking on unrelated queries
@@ -106,6 +117,7 @@ export async function scan(
     mtaStsResult,
     bimiResult,
     mxResult,
+    securityTxtResult,
   ] = await Promise.all([
     dmarcPromise,
     spfPromise,
@@ -113,6 +125,7 @@ export async function scan(
     mtaStsPromise,
     bimiPromise,
     mxPromise,
+    securityTxtPromise,
   ]);
 
   Sentry.addBreadcrumb({
@@ -145,6 +158,12 @@ export async function scan(
     data: { protocol: "bimi", status: bimiResult.status },
     level: "info",
   });
+  Sentry.addBreadcrumb({
+    category: "analyzer.complete",
+    message: `security_txt: ${securityTxtResult.status}`,
+    data: { protocol: "security_txt", status: securityTxtResult.status },
+    level: "info",
+  });
 
   return await buildScanResult(domain, {
     mx: mxResult,
@@ -153,6 +172,7 @@ export async function scan(
     dkim: dkimResult,
     bimi: bimiResult,
     mta_sts: mtaStsResult,
+    security_txt: securityTxtResult,
   });
 }
 
@@ -171,6 +191,7 @@ export async function scanStreaming(
   const mtaStsPromise = analyzeMtaSts(domain);
   const bimiDnsPromise = prefetchBimiDns(domain);
   const mxPromise = analyzeMx(domain);
+  const securityTxtPromise = analyzeSecurityTxt(domain);
 
   // Chain DKIM off MX so it starts as soon as MX resolves
   const dkimPromise = mxPromise.then((mxResult) => {
@@ -247,6 +268,16 @@ export async function scanStreaming(
     onResult("bimi", r);
   });
 
+  securityTxtPromise.then((r) => {
+    Sentry.addBreadcrumb({
+      category: "analyzer.complete",
+      message: `security_txt: ${r.status}`,
+      data: { protocol: "security_txt", status: r.status },
+      level: "info",
+    });
+    onResult("security_txt", r);
+  });
+
   const [
     dmarcResult,
     spfResult,
@@ -254,6 +285,7 @@ export async function scanStreaming(
     mtaStsResult,
     bimiResult,
     mxResult,
+    securityTxtResult,
   ] = await Promise.all([
     dmarcPromise,
     spfPromise,
@@ -261,6 +293,7 @@ export async function scanStreaming(
     mtaStsPromise,
     bimiPromise,
     mxPromise,
+    securityTxtPromise,
   ]);
 
   return await buildScanResult(domain, {
@@ -270,5 +303,6 @@ export async function scanStreaming(
     dkim: dkimResult,
     bimi: bimiResult,
     mta_sts: mtaStsResult,
+    security_txt: securityTxtResult,
   });
 }

--- a/src/shared/scoring.ts
+++ b/src/shared/scoring.ts
@@ -3,6 +3,7 @@ import type {
   DkimResult,
   DmarcResult,
   MtaStsResult,
+  SecurityTxtResult,
   SpfResult,
   Status,
 } from "../analyzers/types.js";
@@ -13,6 +14,11 @@ interface Protocols {
   dkim: DkimResult;
   bimi: BimiResult;
   mta_sts: MtaStsResult;
+  // Optional in this internal interface so older test fixtures (which
+  // don't know about security_txt) keep typechecking against this shape.
+  // The orchestrator always populates it; informational only — does not
+  // affect grade resolution.
+  security_txt?: SecurityTxtResult;
   [key: string]: unknown;
 }
 
@@ -347,11 +353,11 @@ function dkimFactors(dkim: DkimResult): ScoringFactor[] {
 function buildProtocolSummaries(
   protocols: Protocols,
 ): GradeBreakdown["protocolSummaries"] {
-  const { dmarc, spf, dkim, bimi, mta_sts } = protocols;
+  const { dmarc, spf, dkim, bimi, mta_sts, security_txt } = protocols;
   const dmarcPolicy = dmarc.tags?.p ?? null;
   const dkimFound = Object.values(dkim.selectors).filter((s) => s.found);
 
-  return {
+  const summaries: GradeBreakdown["protocolSummaries"] = {
     dmarc: {
       status: dmarc.status,
       summary: dmarcPolicy ? `p=${dmarcPolicy}` : "Not configured",
@@ -386,6 +392,15 @@ function buildProtocolSummaries(
           : "Not configured",
     },
   };
+  if (security_txt) {
+    summaries.security_txt = {
+      status: security_txt.status,
+      summary: security_txt.fields
+        ? `${security_txt.fields.contact.length} contact${security_txt.fields.contact.length === 1 ? "" : "s"}${security_txt.signed ? " (signed)" : ""}`
+        : "Not published",
+    };
+  }
+  return summaries;
 }
 
 // ── Recommendations ───────────────────────────────────────────

--- a/src/views/components.ts
+++ b/src/views/components.ts
@@ -482,6 +482,7 @@ const PROTO_LABELS: Record<string, string> = {
   dkim: "DKIM",
   bimi: "BIMI",
   mta_sts: "MTA-STS",
+  security_txt: "security.txt",
 };
 
 export function scoreSnippet(result: ScanResult): string {

--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -5,6 +5,7 @@ import type {
   MtaStsResult,
   MxResult,
   ScanResult,
+  SecurityTxtResult,
   SpfResult,
 } from "../analyzers/types.js";
 import { isIndexableScanDomain } from "../shared/indexable-domains.js";
@@ -270,6 +271,63 @@ export function renderMtaStsCard(mtaSts: MtaStsResult): string {
   );
 }
 
+export function renderSecurityTxtCard(s: SecurityTxtResult): string {
+  const subtitle = s.fields
+    ? `Found${s.signed ? " (signed)" : ""}`
+    : "Not published";
+
+  let body = "";
+  if (s.fields) {
+    const rows: string[] = [];
+    if (s.fields.contact.length > 0) {
+      rows.push(
+        `<div><strong>Contact</strong></div><div>${s.fields.contact
+          .map((v) => `<code>${esc(v)}</code>`)
+          .join("<br>")}</div>`,
+      );
+    }
+    if (s.fields.expires) {
+      rows.push(
+        `<div><strong>Expires</strong></div><div><code>${esc(s.fields.expires)}</code></div>`,
+      );
+    }
+    if (s.fields.policy.length > 0) {
+      rows.push(
+        `<div><strong>Policy</strong></div><div>${s.fields.policy
+          .map((v) => `<code>${esc(v)}</code>`)
+          .join("<br>")}</div>`,
+      );
+    }
+    if (s.fields.encryption.length > 0) {
+      rows.push(
+        `<div><strong>Encryption</strong></div><div>${s.fields.encryption
+          .map((v) => `<code>${esc(v)}</code>`)
+          .join("<br>")}</div>`,
+      );
+    }
+    if (s.fields.preferred_languages) {
+      rows.push(
+        `<div><strong>Preferred-Languages</strong></div><div><code>${esc(s.fields.preferred_languages)}</code></div>`,
+      );
+    }
+    if (rows.length > 0) {
+      body += `<div class="tag-grid">${rows.join("")}</div>`;
+    }
+  }
+  body += validationList(s.validations);
+  if (s.source_url) {
+    body += `<div class="raw-record"><a href="${esc(s.source_url)}" rel="nofollow noopener" target="_blank">${esc(s.source_url)} &nearr;</a></div>`;
+  }
+  return protocolCard(
+    "security.txt",
+    s.status,
+    subtitle,
+    body,
+    false,
+    "security-txt",
+  );
+}
+
 export function renderMxCard(mx: MxResult): string {
   const subtitle =
     mx.records.length > 0
@@ -280,7 +338,8 @@ export function renderMxCard(mx: MxResult): string {
 }
 
 function reportBody(result: ScanResult): string {
-  const { mx, dmarc, spf, dkim, bimi, mta_sts } = result.protocols;
+  const { mx, dmarc, spf, dkim, bimi, mta_sts, security_txt } =
+    result.protocols;
 
   return `<main class="report">
   <div class="report-nav">
@@ -307,6 +366,7 @@ function reportBody(result: ScanResult): string {
   ${renderDkimCard(dkim)}
   ${renderBimiCard(bimi)}
   ${renderMtaStsCard(mta_sts)}
+  ${security_txt ? renderSecurityTxtCard(security_txt) : ""}
   ${monitorSnapshotCard(result)}
   <div class="learn-link" style="margin-top:2.5rem">Analyze message headers: <a href="https://toolbox.googleapps.com/apps/messageheader/" target="_blank" rel="noopener">Google &#8599;</a> &middot; <a href="https://mha.azurewebsites.net/" target="_blank" rel="noopener">Microsoft &#8599;</a></div>
   <div class="learn-link" style="margin-top:0.4rem;margin-bottom:1rem"><a href="/scoring">How is my score calculated?</a> &middot; <a href="https://www.cloudflare.com/learning/email-security/dmarc-dkim-spf/" target="_blank" rel="noopener">What is email security? &#8599;</a></div>
@@ -755,7 +815,7 @@ export function renderApiDocs(): string {
   <div class="bd-card">
     <div class="bd-card-title">Response shape</div>
     <div class="bd-card-body">
-      <p>See <code>ScanResult</code> in <a href="/openapi.json">openapi.json</a>. Top-level keys: <code>domain</code>, <code>timestamp</code>, <code>grade</code>, <code>breakdown</code>, <code>summary</code>, <code>protocols</code> (<code>mx</code>, <code>dmarc</code>, <code>spf</code>, <code>dkim</code>, <code>bimi</code>, <code>mta_sts</code>).</p>
+      <p>See <code>ScanResult</code> in <a href="/openapi.json">openapi.json</a>. Top-level keys: <code>domain</code>, <code>timestamp</code>, <code>grade</code>, <code>breakdown</code>, <code>summary</code>, <code>protocols</code> (<code>mx</code>, <code>dmarc</code>, <code>spf</code>, <code>dkim</code>, <code>bimi</code>, <code>mta_sts</code>, <code>security_txt</code>).</p>
     </div>
   </div>
 

--- a/src/views/markdown.ts
+++ b/src/views/markdown.ts
@@ -1,4 +1,8 @@
-import type { ScanResult, Validation } from "../analyzers/types.js";
+import type {
+  ScanResult,
+  SecurityTxtResult,
+  Validation,
+} from "../analyzers/types.js";
 
 // Markdown renderings for agent consumers that send `Accept: text/markdown`.
 // Output is plain markdown with no HTML fragments — agents are expected to
@@ -13,6 +17,33 @@ function bullet(items: string[]): string {
 function validationLines(validations: Validation[]): string {
   if (validations.length === 0) return "- _(no findings)_";
   return validations.map((v) => `- **${v.status}** — ${v.message}`).join("\n");
+}
+
+function renderSecurityTxtMarkdown(s: SecurityTxtResult): string {
+  if (!s.fields) {
+    return `## security.txt — ${s.status}
+
+_No security.txt published._
+
+${validationLines(s.validations)}`;
+  }
+  const f = s.fields;
+  const fieldLines: string[] = [];
+  if (f.contact.length > 0)
+    fieldLines.push(`- Contact: ${f.contact.join(", ")}`);
+  if (f.expires) fieldLines.push(`- Expires: ${f.expires}`);
+  if (f.policy.length > 0) fieldLines.push(`- Policy: ${f.policy.join(", ")}`);
+  if (f.encryption.length > 0)
+    fieldLines.push(`- Encryption: ${f.encryption.join(", ")}`);
+  if (f.preferred_languages)
+    fieldLines.push(`- Preferred-Languages: ${f.preferred_languages}`);
+  return `## security.txt — ${s.status}
+
+Source: <${s.source_url}>${s.signed ? " (PGP-signed)" : ""}
+
+${fieldLines.join("\n")}
+
+${validationLines(s.validations)}`;
 }
 
 export function renderLandingMarkdown(): string {
@@ -127,6 +158,8 @@ ${bullet(protocols.mx.records.map((r) => `${r.priority} ${r.exchange}${r.provide
 
 ${validationLines(protocols.mx.validations)}
 
+${protocols.security_txt ? renderSecurityTxtMarkdown(protocols.security_txt) : ""}
+
 ---
 
 JSON: <${MD_SITE}/api/check?domain=${encodeURIComponent(domain)}>
@@ -213,7 +246,8 @@ See \`ScanResult\` in <${MD_SITE}/openapi.json>. Summary:
     "spf":     { "status", "record", "lookups_used", "include_tree", ... },
     "dkim":    { "status", "selectors", "validations" },
     "bimi":    { "status", "record", "tags", "validations" },
-    "mta_sts": { "status", "dns_record", "policy", "validations" }
+    "mta_sts": { "status", "dns_record", "policy", "validations" },
+    "security_txt": { "status", "source_url", "signed", "fields", "validations" }
   }
 }
 \`\`\`

--- a/test/security-txt.test.ts
+++ b/test/security-txt.test.ts
@@ -1,0 +1,249 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { analyzeSecurityTxt } from "../src/analyzers/security-txt.js";
+
+// Helper: mock the global fetch with a sequence of responses keyed by URL.
+// First match wins; unmatched URLs return a 404.
+function mockFetchByUrl(
+  responses: Record<string, { body: string; ok?: boolean } | "throw">,
+) {
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    const r = responses[url];
+    if (r === "throw") throw new Error("Network error");
+    if (!r) {
+      return { ok: false, type: "default" } as unknown as Response;
+    }
+    return {
+      ok: r.ok ?? true,
+      type: "default",
+      arrayBuffer: async () => new TextEncoder().encode(r.body).buffer,
+    } as unknown as Response;
+  });
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("analyzeSecurityTxt", () => {
+  it("returns info+null when neither URL responds", async () => {
+    mockFetchByUrl({});
+    const result = await analyzeSecurityTxt("example.com");
+    expect(result.status).toBe("info");
+    expect(result.fields).toBeNull();
+    expect(result.source_url).toBeNull();
+    expect(result.signed).toBe(false);
+    expect(
+      result.validations.some(
+        (v) => v.status === "info" && v.message.includes("No security.txt"),
+      ),
+    ).toBe(true);
+  });
+
+  it("parses a valid file at the well-known URL", async () => {
+    const future = new Date(
+      Date.now() + 30 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    const body = `# Comment line
+Contact: mailto:security@example.com
+Contact: https://example.com/security
+Expires: ${future}
+Encryption: https://example.com/pgp.asc
+Policy: https://example.com/disclosure
+Preferred-Languages: en, de
+`;
+    mockFetchByUrl({
+      "https://example.com/.well-known/security.txt": { body },
+    });
+
+    const result = await analyzeSecurityTxt("example.com");
+    expect(result.status).toBe("info");
+    expect(result.source_url).toBe(
+      "https://example.com/.well-known/security.txt",
+    );
+    expect(result.signed).toBe(false);
+    expect(result.fields).not.toBeNull();
+    expect(result.fields?.contact).toEqual([
+      "mailto:security@example.com",
+      "https://example.com/security",
+    ]);
+    expect(result.fields?.expires).toBe(future);
+    expect(result.fields?.encryption).toEqual(["https://example.com/pgp.asc"]);
+    expect(result.fields?.policy).toEqual(["https://example.com/disclosure"]);
+    expect(result.fields?.preferred_languages).toBe("en, de");
+  });
+
+  it("falls back to /security.txt when /.well-known/ missing", async () => {
+    const future = new Date(
+      Date.now() + 30 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    mockFetchByUrl({
+      "https://example.com/security.txt": {
+        body: `Contact: mailto:s@example.com\nExpires: ${future}\n`,
+      },
+    });
+
+    const result = await analyzeSecurityTxt("example.com");
+    expect(result.source_url).toBe("https://example.com/security.txt");
+    expect(result.fields?.contact).toEqual(["mailto:s@example.com"]);
+  });
+
+  it("falls back to /security.txt when /.well-known/ returns non-OK", async () => {
+    const future = new Date(
+      Date.now() + 30 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    mockFetchByUrl({
+      "https://example.com/.well-known/security.txt": {
+        ok: false,
+        body: "",
+      },
+      "https://example.com/security.txt": {
+        body: `Contact: mailto:s@example.com\nExpires: ${future}\n`,
+      },
+    });
+    const result = await analyzeSecurityTxt("example.com");
+    expect(result.source_url).toBe("https://example.com/security.txt");
+  });
+
+  it("warns when Contact: is missing", async () => {
+    const future = new Date(
+      Date.now() + 30 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    mockFetchByUrl({
+      "https://example.com/.well-known/security.txt": {
+        body: `Expires: ${future}\n`,
+      },
+    });
+    const result = await analyzeSecurityTxt("example.com");
+    expect(
+      result.validations.some(
+        (v) => v.status === "warn" && v.message.includes("Contact"),
+      ),
+    ).toBe(true);
+  });
+
+  it("warns when Expires: is missing", async () => {
+    mockFetchByUrl({
+      "https://example.com/.well-known/security.txt": {
+        body: `Contact: mailto:s@example.com\n`,
+      },
+    });
+    const result = await analyzeSecurityTxt("example.com");
+    expect(
+      result.validations.some(
+        (v) => v.status === "warn" && v.message.includes("Expires"),
+      ),
+    ).toBe(true);
+  });
+
+  it("warns when Expires: is in the past", async () => {
+    const past = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    mockFetchByUrl({
+      "https://example.com/.well-known/security.txt": {
+        body: `Contact: mailto:s@example.com\nExpires: ${past}\n`,
+      },
+    });
+    const result = await analyzeSecurityTxt("example.com");
+    expect(
+      result.validations.some(
+        (v) => v.status === "warn" && v.message.includes("in the past"),
+      ),
+    ).toBe(true);
+  });
+
+  it("informs when Expires: is more than a year out", async () => {
+    const farFuture = new Date(
+      Date.now() + 400 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    mockFetchByUrl({
+      "https://example.com/.well-known/security.txt": {
+        body: `Contact: mailto:s@example.com\nExpires: ${farFuture}\n`,
+      },
+    });
+    const result = await analyzeSecurityTxt("example.com");
+    expect(
+      result.validations.some(
+        (v) => v.status === "info" && v.message.includes("more than a year"),
+      ),
+    ).toBe(true);
+  });
+
+  it("warns on unparseable Expires:", async () => {
+    mockFetchByUrl({
+      "https://example.com/.well-known/security.txt": {
+        body: `Contact: mailto:s@example.com\nExpires: not-a-date\n`,
+      },
+    });
+    const result = await analyzeSecurityTxt("example.com");
+    expect(
+      result.validations.some(
+        (v) => v.status === "warn" && v.message.includes("not parseable"),
+      ),
+    ).toBe(true);
+  });
+
+  it("strips PGP cleartext-signature armor and flags signed", async () => {
+    const future = new Date(
+      Date.now() + 30 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    const signed = `-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA256
+
+Contact: mailto:s@example.com
+Expires: ${future}
+- -----This-line-is-dash-escaped-----
+
+-----BEGIN PGP SIGNATURE-----
+iQE... (snip)
+-----END PGP SIGNATURE-----
+`;
+    mockFetchByUrl({
+      "https://example.com/.well-known/security.txt": { body: signed },
+    });
+    const result = await analyzeSecurityTxt("example.com");
+    expect(result.signed).toBe(true);
+    expect(result.fields?.contact).toEqual(["mailto:s@example.com"]);
+  });
+
+  it("ignores unknown extension fields per RFC 9116 §2.4", async () => {
+    const future = new Date(
+      Date.now() + 30 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    mockFetchByUrl({
+      "https://example.com/.well-known/security.txt": {
+        body: `Contact: mailto:s@example.com\nExpires: ${future}\nFoo-Bar: ignored\n`,
+      },
+    });
+    const result = await analyzeSecurityTxt("example.com");
+    expect(result.status).toBe("info");
+    // No throw, no Foo-Bar surfaced.
+    expect(JSON.stringify(result.fields)).not.toContain("Foo-Bar");
+  });
+
+  it("accepts the British 'Acknowledgements' spelling", async () => {
+    const future = new Date(
+      Date.now() + 30 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    mockFetchByUrl({
+      "https://example.com/.well-known/security.txt": {
+        body: `Contact: mailto:s@example.com\nExpires: ${future}\nAcknowledgements: https://example.com/hall-of-fame\n`,
+      },
+    });
+    const result = await analyzeSecurityTxt("example.com");
+    expect(result.fields?.acknowledgments).toEqual([
+      "https://example.com/hall-of-fame",
+    ]);
+  });
+
+  it("returns info+null when fetch throws", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("DNS error"));
+    const result = await analyzeSecurityTxt("example.com");
+    expect(result.status).toBe("info");
+    expect(result.fields).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a [security.txt (RFC 9116)](https://www.rfc-editor.org/rfc/rfc9116) analyzer as an **informational-only** protocol. Surfaces the file's `Contact` / `Expires` / `Policy` / `Encryption` / `Acknowledgments` / `Preferred-Languages` on the scorecard without nudging the email-security letter grade. Closes #40.

## Why informational

The issue lists two design options: info-only or bonus scoring factor. I went with **info-only** (status `\"info\"`, like MX) for three reasons:
1. security.txt is general domain-security hygiene, not part of the email authentication stack — the issue itself flags this as the key consideration.
2. The grade stays focused on what the site is named for (DMARC / SPF / DKIM / BIMI / MTA-STS).
3. We can promote it to a +1 modifier later if there's demand; the reverse migration would be uglier.

## Highlights

- New analyzer at [src/analyzers/security-txt.ts](src/analyzers/security-txt.ts) — HTTPS fetch with root-path fallback, 3s timeout, 64 KB body cap, RFC 4880 PGP cleartext-signature stripping, RFC 9116 field validation.
- **`redirect: \"follow\"`** (not `\"manual\"`) — diverges from MTA-STS deliberately. RFC 9116 §3 doesn't forbid redirects, and real-world deployments need them (gov.uk → www.gov.uk → vdp.cabinetoffice.gov.uk). Documented in [CLAUDE.md](CLAUDE.md) §Security so it doesn't get \"hardened\" back the way MTA-STS got broken twice.
- Wired everywhere it needs to be: orchestrator (sync + streaming), scoring summaries, Sentry tags, SSE replay, OpenAPI schema, markdown renderer, HTML card, CLAUDE.md, API-docs prose. CSV export intentionally omits the field (grade-focused export) with a comment explaining why.
- 13 new tests covering the spec surface — no-record, well-known happy path, root fallback for both miss and non-OK, missing required fields, past / far-future / unparseable Expires, PGP-armored body with dash-escape, unknown extension fields, British 'Acknowledgements' spelling, fetch throws.

## Backwards compatibility

The internal `Protocols` interface in [src/shared/scoring.ts](src/shared/scoring.ts) makes `security_txt` optional, so:
- Existing scoring test fixtures (which predate #40) still typecheck without modification.
- Older cached scans replayed via SSE or `/check?_direct=1` skip the new card rather than crash. `tagScanResult`, the SSE replay loop, and `reportBody` are all defensive.
- The new field is listed under `ScanResult.protocols.required` in OpenAPI (fresh scans always include it) but left out of `DomainHistoryScan.protocols.required` (pre-#40 history rows don't have it).

## Verification

- [x] `npm test` — 816 / 816 passed (13 new, 0 regressions among the 803 existing)
- [x] `npm run lint` / `npm run typecheck` — clean
- [x] Reviewed by the `analyzer-reviewer` subagent; all blocking and warning items addressed in the same diff
- [x] Live local-dev check: `facebook.com` parses with 1 contact, expires set, policy / hiring / ack populated; `gov.uk` succeeds via redirect chain; missing-file domains surface \"No security.txt published\"
- [ ] Post-deploy spot-check on real domains and the `/check?domain=...` HTML card

## Out of scope

- Promotion to a scoring modifier (deferred — see \"Why informational\")
- `/learn/security-txt` page (small follow-up)
- Adding security.txt to the CSV export (intentional — see csv.ts comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)