### PR TITLE
🎨 Palette: Add danger style to domain delete button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,0 @@
-## 2026-04-30 - Destructive Action Styling
-**Learning:** The application's CSS includes predefined utility classes for critical UI states, specifically `.btn-danger` which utilizes the `var(--clr-fail)` token. Using this semantic class ensures destructive actions (like "Delete") visually stand out and align with the rest of the application's feedback system.
-**Action:** When adding or updating buttons for destructive actions, always check for and apply `.btn-danger` rather than falling back to standard or secondary button styles, ensuring consistent and clear UX signaling.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-30 - Destructive Action Styling
+**Learning:** The application's CSS includes predefined utility classes for critical UI states, specifically `.btn-danger` which utilizes the `var(--clr-fail)` token. Using this semantic class ensures destructive actions (like "Delete") visually stand out and align with the rest of the application's feedback system.
+**Action:** When adding or updating buttons for destructive actions, always check for and apply `.btn-danger` rather than falling back to standard or secondary button styles, ensuring consistent and clear UX signaling.

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -2292,7 +2292,7 @@ export function renderDomainDetailPage({
   </form>
   <a href="/check?domain=${encodeURIComponent(domain)}" class="btn btn-secondary">View Full Report</a>
   <form method="POST" action="/dashboard/domain/${encodeURIComponent(domain)}/delete" style="display:inline" onsubmit="return confirm('Stop monitoring ${esc(domain)}?');">
-    <button type="submit" class="btn btn-secondary" aria-label="Delete domain ${esc(domain)}">Delete</button>
+    <button type="submit" class="btn btn-danger" aria-label="Delete domain ${esc(domain)}">Delete</button>
   </form>
 </div>
 <div class="section-card">


### PR DESCRIPTION
### 💡 What
Updated the "Delete" button on the domain detail page to use the `.btn-danger` CSS class instead of `.btn-secondary`.

### 🎯 Why
Deleting a domain is a destructive action. Previously, the button used the standard secondary style, which blends in with other actions like "View Full Report". Updating it to use the predefined danger style (`.btn-danger`, which utilizes `var(--clr-fail)`) provides clearer visual feedback about the severity of the action, reducing the likelihood of accidental clicks and improving overall user intuition.

### 📸 Before/After
See attached frontend verification screenshots showing the button clearly styled in red.

### ♿ Accessibility
The button already has a descriptive `aria-label` ("Delete domain example.com") from previous improvements. This visual update reinforces that communication for sighted users.

---
*PR created automatically by Jules for task [11302075497259455818](https://jules.google.com/task/11302075497259455818) started by @schmug*