### PR TITLE
feat(dns): support DNS_SERVERS env var for local-dev resolver override

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,17 @@ npm run dev       # starts local dev server on http://localhost:8790
 npm test          # runs unit tests
 ```
 
+To point the DNS resolver at custom servers during local development (useful
+for testing against `1.1.1.1`, `8.8.8.8`, or an internal resolver), set
+`DNS_SERVERS` to a comma-separated list:
+
+```bash
+DNS_SERVERS=8.8.8.8,1.1.1.1 npm run dev
+```
+
+When unset, the system default resolver (or the Cloudflare Workers DNS
+polyfill in production) is used.
+
 ### Deploy to Your Own Cloudflare Account
 
 1. Authenticate with Cloudflare:

--- a/src/dns/client.ts
+++ b/src/dns/client.ts
@@ -2,8 +2,32 @@ import dns from "node:dns";
 import * as Sentry from "@sentry/cloudflare";
 import type { MxRecord, TxtRecord } from "./types.js";
 
+export function parseDnsServers(raw: string | undefined): string[] | null {
+  if (!raw) return null;
+  const servers = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return servers.length > 0 ? servers : null;
+}
+
 const resolver = new dns.promises.Resolver();
 const DNS_TIMEOUT_MS = 3000;
+
+// Local-dev override: `DNS_SERVERS=8.8.8.8,1.1.1.1 npm run dev` points the
+// resolver at custom servers. In Cloudflare Workers prod the var is absent and
+// the built-in polyfill is used as-is; setServers() may be a no-op there.
+const customDnsServers =
+  typeof process !== "undefined"
+    ? parseDnsServers(process.env?.DNS_SERVERS)
+    : null;
+if (customDnsServers) {
+  try {
+    resolver.setServers(customDnsServers);
+  } catch (err) {
+    console.warn("Failed to apply DNS_SERVERS override:", err);
+  }
+}
 
 function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   let timer: NodeJS.Timeout;

--- a/test/dns-client.test.ts
+++ b/test/dns-client.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { parseDnsServers } from "../src/dns/client.js";
+
+describe("parseDnsServers", () => {
+  it("returns null when raw is undefined", () => {
+    expect(parseDnsServers(undefined)).toBeNull();
+  });
+
+  it("returns null for an empty string", () => {
+    expect(parseDnsServers("")).toBeNull();
+  });
+
+  it("returns null when only whitespace and separators are present", () => {
+    expect(parseDnsServers(" , , ")).toBeNull();
+  });
+
+  it("returns a single server", () => {
+    expect(parseDnsServers("8.8.8.8")).toEqual(["8.8.8.8"]);
+  });
+
+  it("splits a comma-separated list", () => {
+    expect(parseDnsServers("8.8.8.8,1.1.1.1")).toEqual(["8.8.8.8", "1.1.1.1"]);
+  });
+
+  it("trims whitespace around each entry", () => {
+    expect(parseDnsServers(" 8.8.8.8 , 1.1.1.1 ")).toEqual([
+      "8.8.8.8",
+      "1.1.1.1",
+    ]);
+  });
+
+  it("drops empty entries from trailing/leading commas", () => {
+    expect(parseDnsServers(",8.8.8.8,,1.1.1.1,")).toEqual([
+      "8.8.8.8",
+      "1.1.1.1",
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #24.

## Summary
- Adds optional `DNS_SERVERS=8.8.8.8,1.1.1.1` env var that calls `resolver.setServers()` at module load
- Extracts `parseDnsServers()` helper for unit testing (handles whitespace, empty entries, all-empty)
- Documents the option under "Local Development" in README

When unset, behavior is unchanged: system default resolver locally, Cloudflare Workers DNS polyfill in production.

## Test plan
- [x] `npm test` — 7 new tests pass, full suite 810/810
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [ ] Manual: `DNS_SERVERS=1.1.1.1 npm run dev` and confirm resolver picks up the override (smoke test in local dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)