### PR TITLE
🎨 Palette: Add ARIA error association for add-domain wizard

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Accessible Dynamic Wizard Errors
+**Learning:** When adding dynamic error messages inside multi-step wizards or modals (like the add-domain wizard), adding `aria-describedby` on the input linking to an error container with `role="alert"` and `aria-live="polite"` ensures screen readers immediately announce validation errors without losing focus context.
+**Action:** Always pair inputs with dynamic validation to an associated error container using `aria-describedby` and `role="alert"` to guarantee robust accessibility feedback for complex flows.

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -1952,8 +1952,8 @@ function renderAddDomainWizardShell(): string {
     <div class="add-wizard-body">
       <div class="add-wizard-step" data-active="1" data-step="1">
         <label for="wizard-domain">Domain</label>
-        <input type="text" id="wizard-domain" name="domain" placeholder="example.com" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" required>
-        <div class="add-wizard-error" data-wizard-error hidden></div>
+        <input type="text" id="wizard-domain" name="domain" placeholder="example.com" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" required aria-describedby="wizard-domain-error">
+        <div id="wizard-domain-error" class="add-wizard-error" data-wizard-error role="alert" aria-live="polite" hidden></div>
       </div>
       <div class="add-wizard-step" data-step="2">
         <label for="wizard-frequency">Scan frequency</label>


### PR DESCRIPTION
💡 **What:** Added `aria-describedby` to the domain input field in the Add Domain wizard (`src/views/dashboard.ts`), and added a matching `id`, `role="alert"`, and `aria-live="polite"` to the dynamic error message container (`.add-wizard-error`).

🎯 **Why:** Previously, when a user entered an invalid domain in the wizard (e.g., clicking "Next" with an empty or malformed domain), a dynamic error message would appear below the input. However, screen readers would not automatically announce this error, leaving visually impaired users unaware of why they couldn't proceed.

♿ **Accessibility:**
*   Linked the error container directly to the input field using `aria-describedby="wizard-domain-error"`.
*   Added `role="alert"` and `aria-live="polite"` to the error container to ensure screen readers announce the validation failure immediately when it becomes visible without interrupting the user's current focus context.

📸 **Before/After:** No visual changes, structural HTML changes only.

---
*PR created automatically by Jules for task [17587397148569083739](https://jules.google.com/task/17587397148569083739) started by @schmug*