### PR TITLE
🎨 Palette: Add accessible validation to Add Domain wizard

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-03 - Accessible Form Validation in Multi-step Wizards
+**Learning:** For dynamic multi-step form wizards (like the Add Domain wizard in this app), validation errors inserted via JS (using `textContent` and un-hiding) are often missed by screen readers if they lack ARIA roles.
+**Action:** Always link the input to its corresponding error container using `aria-describedby` pointing to the error container's `id`, and apply `role="alert"` and `aria-live="polite"` directly to the error container. This ensures screen readers announce the validation error immediately as it appears, without the user having to lose focus from the input field to find it.

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -1952,8 +1952,8 @@ function renderAddDomainWizardShell(): string {
     <div class="add-wizard-body">
       <div class="add-wizard-step" data-active="1" data-step="1">
         <label for="wizard-domain">Domain</label>
-        <input type="text" id="wizard-domain" name="domain" placeholder="example.com" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" required>
-        <div class="add-wizard-error" data-wizard-error hidden></div>
+        <input type="text" id="wizard-domain" name="domain" placeholder="example.com" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" required aria-describedby="wizard-domain-error">
+        <div id="wizard-domain-error" class="add-wizard-error" data-wizard-error role="alert" aria-live="polite" hidden></div>
       </div>
       <div class="add-wizard-step" data-step="2">
         <label for="wizard-frequency">Scan frequency</label>


### PR DESCRIPTION
### 💡 What
Added robust ARIA attributes (`aria-describedby`, `role="alert"`, `aria-live="polite"`) to the client-side validation error container in the "Add Domain" modal wizard.

### 🎯 Why
When users attempt to add an invalid domain, JavaScript dynamically injects an error message. Previously, this visual text change was completely silent to screen readers, leaving visually impaired users confused as to why the "Next" button was not functioning. 

### ♿ Accessibility
- Linked the `wizard-domain` input to its error container using `aria-describedby="wizard-domain-error"`.
- Added `role="alert"` and `aria-live="polite"` to the error container. 
- Now, when the error appears, screen readers will proactively announce "Enter a valid domain like example.com." without the user needing to manually move focus to discover the error.

---
*PR created automatically by Jules for task [17742741531299988961](https://jules.google.com/task/17742741531299988961) started by @schmug*