### PR TITLE
fix(dashboard): render grandfathered state for over-cap watchlists

### DIFF
--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -611,9 +611,12 @@ dashboardRoutes.post("/domain/add", async (c) => {
   }
 
   if (currentCount >= cap) {
+    const overCap = currentCount > cap;
     const error =
       plan === "pro"
-        ? `You've reached the Pro plan limit of ${cap} domains. Email support@dmarc.mx if you need more.`
+        ? overCap
+          ? `Pro plan includes ${cap} domains and you already have ${currentCount} (grandfathered). Email support@dmarc.mx to add more.`
+          : `You've reached the Pro plan limit of ${cap} domains. Email support@dmarc.mx if you need more.`
         : `Free plan limit reached (${cap} domains). Upgrade to Pro for up to ${PRO_WATCHLIST_CAP}.`;
     return c.html(
       renderAddDomainPage({ email: session.email, error, usage }),

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -2525,10 +2525,21 @@ ${usageBlock}
 
 // Shared "X of N domains used" hint shown above the add-domain form and
 // in the main dashboard's domain panel toolbar. Free plans get an upgrade
-// CTA, Pro plans show a contact pointer when at cap.
+// CTA; Pro plans show a contact pointer when exactly at cap. Accounts that
+// are *over* the cap (grandfathered from before enforcement, or after a
+// future cap reduction) render in a muted tone with no CTA — they already
+// have their slots; the cap only blocks net-new additions.
 export function renderUsageHint(usage: WatchlistUsage): string {
-  const atCap = usage.current >= usage.cap;
   const planLabel = usage.plan === "pro" ? "Pro" : "Free";
+  const overCap = usage.current > usage.cap;
+  const atCap = usage.current === usage.cap;
+
+  if (overCap) {
+    return `<p class="watchlist-usage" style="font-size:0.875rem;margin:0 0 1rem;color:var(--clr-text-muted)">
+  <span>${esc(String(usage.current))} domains tracked (${planLabel} plan includes ${esc(String(usage.cap))} — grandfathered).</span>
+</p>`;
+  }
+
   const cta =
     usage.plan === "free"
       ? `<a href="/dashboard/billing/subscribe" style="color:var(--clr-accent);text-decoration:none">Upgrade →</a>`

--- a/test/dashboard-routes.test.ts
+++ b/test/dashboard-routes.test.ts
@@ -1990,6 +1990,74 @@ describe("dashboard/routes", () => {
       expect(inserted).toBeUndefined();
     });
 
+    it("renders a grandfathered usage hint when a Pro user is over the cap", async () => {
+      const seedDomains = Array.from({ length: 30 }, (_, i) => ({
+        id: i + 1,
+        user_id: "user_1",
+        domain: `seed${i}.example`,
+        is_free: 0,
+        scan_frequency: "weekly",
+        last_scanned_at: null,
+        last_grade: null,
+        created_at: 1_700_000_000,
+      }));
+      const db = createMockDB({
+        domains: seedDomains,
+        subscriptions: [{ user_id: "user_1", status: "active" }],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/domain/add", {
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toMatch(/30 domains tracked/);
+      expect(html).toMatch(/Pro plan includes 25/);
+      expect(html).toMatch(/grandfathered/);
+      // No "X of N used" framing for over-cap accounts.
+      expect(html).not.toMatch(/30 of 25/);
+    });
+
+    it("returns a grandfathered error message when an over-cap Pro user POSTs a net-new domain", async () => {
+      const seedDomains = Array.from({ length: 30 }, (_, i) => ({
+        id: i + 1,
+        user_id: "user_1",
+        domain: `seed${i}.example`,
+        is_free: 0,
+        scan_frequency: "weekly",
+        last_scanned_at: null,
+        last_grade: null,
+        created_at: 1_700_000_000,
+      }));
+      const writes: Array<{ sql: string; bindings: unknown[] }> = [];
+      const db = createMockDB({
+        domains: seedDomains,
+        subscriptions: [{ user_id: "user_1", status: "active" }],
+        writes,
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const body = new URLSearchParams({ domain: "overflow.example" });
+      const res = await app.request("/dashboard/domain/add", {
+        method: "POST",
+        headers: {
+          Cookie: cookie,
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: body.toString(),
+      });
+      expect(res.status).toBe(400);
+      const html = await res.text();
+      expect(html).toMatch(/Pro plan includes 25 domains/);
+      expect(html).toMatch(/already have 30/);
+      expect(html).toMatch(/grandfathered/);
+      const inserted = writes.find((w) =>
+        w.sql.includes("INSERT INTO domains"),
+      );
+      expect(inserted).toBeUndefined();
+    });
+
     it("renders the add-domain form with usage hint for a free user under cap", async () => {
       const db = createMockDB({
         domains: [


### PR DESCRIPTION
## Summary

- Watchlist accounts whose domain count exceeds their plan cap rendered as **"30 of 25 Pro domains used."** in danger-red with a "Contact support" CTA — reading like a billing error instead of a grandfathered slot.
- `renderUsageHint` and the POST `/domain/add` error now split at-cap (`==`) from over-cap (`>`): at-cap keeps the danger tone + CTA, over-cap renders muted **"X domains tracked (Pro plan includes N — grandfathered)"** with no action prompt.
- Cap *enforcement* is unchanged — `currentCount >= cap` still blocks net-new adds, listing routes still return every domain. This is purely a display fix.

## Why

Triggered by an account on Pro that's already past 25 domains. The previous copy implied the user had broken something they couldn't fix; the new copy reflects the actual state (grandfathered, can't add more without support). This path also becomes load-bearing if `PRO_WATCHLIST_CAP` is ever lowered, since every existing pro user above the new line would render through it.

## Test plan

- [x] `npm test` — 860/860 pass, including two new cases at [test/dashboard-routes.test.ts](https://github.com/schmug/dmarcheck/blob/claude/dreamy-shamir-2ebd69/test/dashboard-routes.test.ts) covering the over-cap GET render and the over-cap POST error
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [ ] Reviewer: confirm copy ("X domains tracked (Pro plan includes N — grandfathered)") reads right; tweak if you'd phrase differently

🤖 Generated with [Claude Code](https://claude.com/claude-code)