### PR TITLE
🎨 Palette: [a11y] Link domain wizard input to error container

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - A11y: Dynamic Errors in Multi-step Wizards
+**Learning:** In a dynamic form wizard (like the 'Add Domain' wizard), injecting error text into a hidden `div` and making it visible requires setting `role="alert"` for immediate screen reader announcement. Additionally, the input itself must reference that `div` via `aria-describedby` so its error state is contextually clear when the input is focused.
+**Action:** Always link input fields to their dynamic error containers using `aria-describedby` and ensure the container has `role="alert"`.

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -1952,8 +1952,8 @@ function renderAddDomainWizardShell(): string {
     <div class="add-wizard-body">
       <div class="add-wizard-step" data-active="1" data-step="1">
         <label for="wizard-domain">Domain</label>
-        <input type="text" id="wizard-domain" name="domain" placeholder="example.com" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" required>
-        <div class="add-wizard-error" data-wizard-error hidden></div>
+        <input type="text" id="wizard-domain" name="domain" placeholder="example.com" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" required aria-describedby="wizard-domain-error">
+        <div id="wizard-domain-error" class="add-wizard-error" data-wizard-error role="alert" hidden></div>
       </div>
       <div class="add-wizard-step" data-step="2">
         <label for="wizard-frequency">Scan frequency</label>


### PR DESCRIPTION
💡 **What:** Added `role="alert"` to the dynamic error container in the "Add Domain" wizard, and linked the domain input field to this container using `aria-describedby`.
🎯 **Why:** To ensure that screen readers immediately announce errors when they occur during the validation of the dynamic multi-step wizard, and that the error context is programmatically associated with the relevant input field when it receives focus.
♿ **Accessibility:** This directly addresses an accessibility issue where dynamic validation errors were not being announced correctly or linked contextually to their inputs.

---
*PR created automatically by Jules for task [12985546785722856254](https://jules.google.com/task/12985546785722856254) started by @schmug*