### PR TITLE
🎨 Palette: Add accessible aria-live region to Add Domain Wizard error

### DIFF
--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -1952,8 +1952,8 @@ function renderAddDomainWizardShell(): string {
     <div class="add-wizard-body">
       <div class="add-wizard-step" data-active="1" data-step="1">
         <label for="wizard-domain">Domain</label>
-        <input type="text" id="wizard-domain" name="domain" placeholder="example.com" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" required>
-        <div class="add-wizard-error" data-wizard-error hidden></div>
+        <input type="text" id="wizard-domain" name="domain" placeholder="example.com" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" required aria-describedby="wizard-domain-error">
+        <div id="wizard-domain-error" class="add-wizard-error" data-wizard-error role="alert" aria-live="polite" hidden></div>
       </div>
       <div class="add-wizard-step" data-step="2">
         <label for="wizard-frequency">Scan frequency</label>


### PR DESCRIPTION
🎯 **What**: Added an accessible aria-live region to the "Add Domain" wizard error message.
💡 **Why**: When a validation error occurs (e.g. an invalid domain format) and the error message appears dynamically, screen readers would not automatically announce it.
♿ **Accessibility**:
- Linked the error container to the `wizard-domain` input using `aria-describedby`.
- Added `role="alert"` and `aria-live="polite"` to the error container to ensure immediate announcement to assistive technologies.

---
*PR created automatically by Jules for task [6594199791866104022](https://jules.google.com/task/6594199791866104022) started by @schmug*