### PR TITLE
🎨 Palette: Improve accessibility of Add Domain wizard validation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-08 - Accessible Form Validation
+**Learning:** For accessible dynamic form validation in multi-step wizards, it's crucial to link the input to its corresponding error container using `aria-describedby`. The error container itself needs `role="alert"` and `aria-live="polite"` so screen readers announce errors immediately as they appear, without the user needing to lose focus or manually search for the error text.
+**Action:** Always apply `aria-describedby`, `role="alert"`, and `aria-live="polite"` when building dynamic error containers for forms or inputs.

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -1952,8 +1952,8 @@ function renderAddDomainWizardShell(): string {
     <div class="add-wizard-body">
       <div class="add-wizard-step" data-active="1" data-step="1">
         <label for="wizard-domain">Domain</label>
-        <input type="text" id="wizard-domain" name="domain" placeholder="example.com" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" required>
-        <div class="add-wizard-error" data-wizard-error hidden></div>
+        <input type="text" id="wizard-domain" name="domain" placeholder="example.com" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" required aria-describedby="wizard-domain-error">
+        <div id="wizard-domain-error" class="add-wizard-error" role="alert" aria-live="polite" data-wizard-error hidden></div>
       </div>
       <div class="add-wizard-step" data-step="2">
         <label for="wizard-frequency">Scan frequency</label>


### PR DESCRIPTION
💡 **What:** Added `id`, `role="alert"`, and `aria-live="polite"` attributes to the domain validation error container in the Add Domain wizard, and linked the domain input to it using `aria-describedby`.
🎯 **Why:** To ensure screen readers immediately announce form validation errors (like "Enter a valid domain like example.com") without the user losing focus, making the multi-step form fully accessible.
📸 **Before/After:** The visual UI remains exactly the same, but the underlying markup is now semantically correct for assistive tech. (See attached verification screenshot/video).
♿ **Accessibility:** Fixes a critical a11y gap where dynamically generated error text was previously invisible to screen readers since focus remains on the input field when validation fails.

---
*PR created automatically by Jules for task [3207319276568376123](https://jules.google.com/task/3207319276568376123) started by @schmug*