### PR TITLE
⚡ Bolt: Optimize dashboard render performance by reducing redundant iterations

### DIFF
--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -1873,11 +1873,10 @@ function renderOnFireBanner(failing: number): string {
 }
 
 function renderDashboardHero(
-  domains: DashboardDomain[],
+  stats: PortfolioStats,
+  worst: DashboardDomain | null,
   portfolioTrend: number[],
 ): string {
-  const stats = portfolioStats(domains);
-  const worst = worstDomain(domains);
   // Mood comes from the worst *graded* domain. With nothing scored yet there
   // is no signal to react to, so DMarcus defaults to neutral rather than
   // panicking at a freshly-added entry that just hasn't been scanned.
@@ -1978,8 +1977,7 @@ function renderAddDomainWizardShell(): string {
 </div>`;
 }
 
-function renderDashboardStatStrip(domains: DashboardDomain[]): string {
-  const stats = portfolioStats(domains);
+function renderDashboardStatStrip(stats: PortfolioStats): string {
   const totalCard = statCard(
     "Domains",
     stats.total,
@@ -2040,6 +2038,7 @@ export function renderDashboardPage({
   isFirstRun?: boolean;
 }): string {
   const stats = portfolioStats(domains);
+  const worst = worstDomain(domains);
   const banners: string[] = [];
   if (plan === "free") banners.push(renderFreeTierBanner());
   if (isFirstRun && domains.length === 1) {
@@ -2047,11 +2046,8 @@ export function renderDashboardPage({
   }
   if (stats.failing >= 3) banners.push(renderOnFireBanner(stats.failing));
 
-  const hero =
-    domains.length > 0
-      ? renderDashboardHero(domains, portfolioTrend)
-      : renderDashboardHero([], []);
-  const statStrip = domains.length > 0 ? renderDashboardStatStrip(domains) : "";
+  const hero = renderDashboardHero(stats, worst, portfolioTrend);
+  const statStrip = domains.length > 0 ? renderDashboardStatStrip(stats) : "";
 
   return dashboardPage(
     "Domains — dmarc.mx",


### PR DESCRIPTION
💡 What: Lifted `portfolioStats(domains)` and `worstDomain(domains)` calculations to the top level `renderDashboardPage` and passed the result down to `renderDashboardHero` and `renderDashboardStatStrip`.

🎯 Why: Previously, `renderDashboardPage`, `renderDashboardHero`, and `renderDashboardStatStrip` each independently iterated over the entire `domains` array to compute the same statistics, causing redundant O(N) penalties during every dashboard render.

📊 Impact: Reduces array iteration passes over the `domains` array during dashboard render from up to 5 to exactly 2, significantly reducing CPU cycles and GC pressure for large domain portfolios.

🔬 Measurement: Verified using the full test suite (`pnpm test`); all 860 tests passed.

---
*PR created automatically by Jules for task [16002741095600774332](https://jules.google.com/task/16002741095600774332) started by @schmug*