### PR TITLE
🎨 Palette: Improve add-domain wizard accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-09 - Dynamic Error Announcements in Forms
+**Learning:** For dynamic multi-step wizards or forms, simply having an empty div with `role="alert"` and injecting text is good, but linking it directly to the input via `aria-describedby` and conditionally toggling `aria-invalid="true"` provides a much stronger association and immediate feedback for screen reader users when client-side validation fails.
+**Action:** Always link dynamically populated error containers to their corresponding input fields using `aria-describedby`, and update the input's `aria-invalid` state along with the error message visibility.

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -1952,8 +1952,8 @@ function renderAddDomainWizardShell(): string {
     <div class="add-wizard-body">
       <div class="add-wizard-step" data-active="1" data-step="1">
         <label for="wizard-domain">Domain</label>
-        <input type="text" id="wizard-domain" name="domain" placeholder="example.com" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" required>
-        <div class="add-wizard-error" data-wizard-error hidden></div>
+        <input type="text" id="wizard-domain" name="domain" placeholder="example.com" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" aria-describedby="wizard-domain-error" required>
+        <div id="wizard-domain-error" class="add-wizard-error" role="alert" aria-live="polite" data-wizard-error hidden></div>
       </div>
       <div class="add-wizard-step" data-step="2">
         <label for="wizard-frequency">Scan frequency</label>

--- a/src/views/scripts.ts
+++ b/src/views/scripts.ts
@@ -1319,9 +1319,13 @@ if (typeof navigator !== 'undefined' && navigator.modelContext && typeof navigat
               errorEl.textContent = 'Enter a valid domain like example.com.';
               errorEl.hidden = false;
             }
+            if (domainInput) {
+              domainInput.setAttribute('aria-invalid', 'true');
+            }
             return;
           }
           if (errorEl) errorEl.hidden = true;
+          if (domainInput) domainInput.removeAttribute('aria-invalid');
           if (confirmDom) confirmDom.textContent = raw;
           showStep(2);
         } else if (step === 2) {


### PR DESCRIPTION
### 💡 What
Improved the accessibility of the "Add domain" wizard by providing clearer associations and state announcements for screen reader users during client-side validation.

### 🎯 Why
Previously, when a user entered an invalid domain in the wizard and clicked "Next", the error message became visible visually, but a screen reader user was not necessarily notified and might not understand why they couldn't proceed. By appropriately using `aria-live`, `aria-describedby`, and `aria-invalid`, the application now explicitly announces validation failures and links the error text directly to the input field causing the problem.

### 📸 Before/After
No visual changes were introduced, purely semantic HTML improvements.

### ♿ Accessibility
- `aria-describedby="wizard-domain-error"` associates the domain text input to the error element.
- `role="alert"` and `aria-live="polite"` on the error container ensure screen readers announce validation messages when they are injected.
- The `aria-invalid="true"` attribute is correctly managed via JavaScript to indicate validation state on the input itself.

---
*PR created automatically by Jules for task [3753226809302555415](https://jules.google.com/task/3753226809302555415) started by @schmug*