### PR TITLE
🎨 Palette: [Accessibility] Improve dynamic form validation for Add Domain wizard

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-11 - Dynamic form validation accessible pattern
+**Learning:** When using dynamic JavaScript validation (like in multi-step form wizards), error messages rendered after the initial page load are not read by screen readers unless specifically marked. Furthermore, linking the input field to the error text programmatically ensures context when the field receives focus.
+**Action:** Use `aria-describedby` on the input field to link it to the error container's ID. Add `role="alert"` and `aria-live="polite"` to the error container. Use JavaScript to dynamically set `aria-invalid="true"` on the input when validation fails, and clear it when the field passes validation.

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -1952,8 +1952,8 @@ function renderAddDomainWizardShell(): string {
     <div class="add-wizard-body">
       <div class="add-wizard-step" data-active="1" data-step="1">
         <label for="wizard-domain">Domain</label>
-        <input type="text" id="wizard-domain" name="domain" placeholder="example.com" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" required>
-        <div class="add-wizard-error" data-wizard-error hidden></div>
+        <input type="text" id="wizard-domain" name="domain" placeholder="example.com" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" required aria-describedby="wizard-error-msg">
+        <div id="wizard-error-msg" class="add-wizard-error" data-wizard-error hidden role="alert" aria-live="polite"></div>
       </div>
       <div class="add-wizard-step" data-step="2">
         <label for="wizard-frequency">Scan frequency</label>

--- a/src/views/scripts.ts
+++ b/src/views/scripts.ts
@@ -1291,6 +1291,7 @@ if (typeof navigator !== 'undefined' && navigator.modelContext && typeof navigat
       lastFocusedBeforeOpen = triggerEl || document.activeElement;
       if (form) form.reset();
       if (errorEl) { errorEl.hidden = true; errorEl.textContent = ''; }
+      if (domainInput) domainInput.removeAttribute('aria-invalid');
       showStep(1);
       setOpen(wizard, true);
     }
@@ -1315,12 +1316,14 @@ if (typeof navigator !== 'undefined' && navigator.modelContext && typeof navigat
         if (step === 1) {
           var raw = domainInput && domainInput.value.trim().toLowerCase();
           if (!raw || !/^[a-z0-9.-]+\\.[a-z]{2,}$/.test(raw)) {
+            if (domainInput) domainInput.setAttribute('aria-invalid', 'true');
             if (errorEl) {
               errorEl.textContent = 'Enter a valid domain like example.com.';
               errorEl.hidden = false;
             }
             return;
           }
+          if (domainInput) domainInput.removeAttribute('aria-invalid');
           if (errorEl) errorEl.hidden = true;
           if (confirmDom) confirmDom.textContent = raw;
           showStep(2);


### PR DESCRIPTION
**💡 What:** Added proper ARIA attributes to the "Add Domain" wizard form to improve dynamic validation accessibility. Specifically, linked the input field to the error message container, made the container an ARIA live region, and added logic to toggle the `aria-invalid` state.

**🎯 Why:** In dynamic single-page applications or multi-step wizards, error messages that appear after an interaction are completely missed by screen readers unless explicitly marked. By applying `aria-live` and `role="alert"`, screen readers will now announce validation errors (like "Enter a valid domain") immediately. Furthermore, linking the error to the input with `aria-describedby` provides context to users returning focus to the field, and `aria-invalid` signals that the input requires correction.

**♿ Accessibility:**
* Added `aria-describedby="wizard-error-msg"` to the `#wizard-domain` input.
* Added `id="wizard-error-msg"`, `role="alert"`, and `aria-live="polite"` to the `.add-wizard-error` container.
* Updated validation script in `src/views/scripts.ts` to dynamically apply `aria-invalid="true"` when the regex validation fails, and remove the attribute when validation passes or the form resets.

---
*PR created automatically by Jules for task [15123646532931585360](https://jules.google.com/task/15123646532931585360) started by @schmug*