### PR TITLE
🎨 Palette: Improve accessibility of dynamic form validation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-12 - Dynamic Form Validation Accessibility
+**Learning:** When validating forms dynamically (e.g. in multi-step wizards), it is important to add `aria-describedby` pointing to the error element. In addition, the error element should use `role="alert"` and `aria-live="polite"` so screen readers speak the error correctly. The input itself must toggle `aria-invalid="true"` dynamically when in error.
+**Action:** For accessible dynamic form validation, always link the input to its corresponding error container using `aria-describedby`, apply `role="alert"` and `aria-live="polite"` to the error container, and dynamically toggle `aria-invalid="true"` on the input when validation fails to ensure immediate screen reader announcements.

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -1952,8 +1952,8 @@ function renderAddDomainWizardShell(): string {
     <div class="add-wizard-body">
       <div class="add-wizard-step" data-active="1" data-step="1">
         <label for="wizard-domain">Domain</label>
-        <input type="text" id="wizard-domain" name="domain" placeholder="example.com" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" required>
-        <div class="add-wizard-error" data-wizard-error hidden></div>
+        <input type="text" id="wizard-domain" name="domain" placeholder="example.com" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" required aria-describedby="wizard-domain-error">
+        <div id="wizard-domain-error" class="add-wizard-error" data-wizard-error role="alert" aria-live="polite" hidden></div>
       </div>
       <div class="add-wizard-step" data-step="2">
         <label for="wizard-frequency">Scan frequency</label>

--- a/src/views/scripts.ts
+++ b/src/views/scripts.ts
@@ -1290,6 +1290,7 @@ if (typeof navigator !== 'undefined' && navigator.modelContext && typeof navigat
     function openWizard(triggerEl) {
       lastFocusedBeforeOpen = triggerEl || document.activeElement;
       if (form) form.reset();
+      if (domainInput) domainInput.removeAttribute('aria-invalid');
       if (errorEl) { errorEl.hidden = true; errorEl.textContent = ''; }
       showStep(1);
       setOpen(wizard, true);
@@ -1315,12 +1316,14 @@ if (typeof navigator !== 'undefined' && navigator.modelContext && typeof navigat
         if (step === 1) {
           var raw = domainInput && domainInput.value.trim().toLowerCase();
           if (!raw || !/^[a-z0-9.-]+\\.[a-z]{2,}$/.test(raw)) {
+            if (domainInput) domainInput.setAttribute('aria-invalid', 'true');
             if (errorEl) {
               errorEl.textContent = 'Enter a valid domain like example.com.';
               errorEl.hidden = false;
             }
             return;
           }
+          if (domainInput) domainInput.removeAttribute('aria-invalid');
           if (errorEl) errorEl.hidden = true;
           if (confirmDom) confirmDom.textContent = raw;
           showStep(2);


### PR DESCRIPTION
💡 **What**: Improved the dynamic form validation accessibility for the "Add Domain" wizard by linking the input to its error container and toggling the `aria-invalid` state.
🎯 **Why**: When users with screen readers submit an invalid domain, they previously received no immediate context that an error occurred or what the error was.
📸 **Before/After**: N/A (Non-visual change).
♿ **Accessibility**:
- Linked the domain input to its error text via `aria-describedby="wizard-domain-error"`.
- Applied `role="alert"` and `aria-live="polite"` to the error container for immediate readout.
- Dynamically add/remove `aria-invalid="true"` on the input during validation via JavaScript.

---
*PR created automatically by Jules for task [3751911094722993133](https://jules.google.com/task/3751911094722993133) started by @schmug*