### PR TITLE
feat: strengthen DMARC warnings for rua/ruf auth and pct/sp (#236)

### DIFF
--- a/src/analyzers/dmarc.ts
+++ b/src/analyzers/dmarc.ts
@@ -18,7 +18,8 @@ function uriHost(uri: string): string | null {
     const atIdx = address.lastIndexOf("@");
     if (atIdx === -1) return null;
     const domain = address.slice(atIdx + 1).trim();
-    return domain || null;
+    if (domain && /^[a-zA-Z0-9.-]+$/.test(domain)) return domain;
+    return null;
   }
   try {
     const parsed = new URL(trimmed);

--- a/src/analyzers/dmarc.ts
+++ b/src/analyzers/dmarc.ts
@@ -2,6 +2,58 @@ import { queryTxt } from "../dns/client.js";
 import { parseTags } from "../shared/parse-tags.js";
 import type { DmarcResult, Validation } from "./types.js";
 
+/**
+ * Extract the hostname from a URI in a DMARC rua/ruf tag value.
+ *
+ * RFC 7489 §6.2 allows `mailto:` URIs (most common) and generic URIs.
+ * For `mailto:user@domain`, the host is the part after `@`.
+ * For other URI schemes (e.g. `https://host/path`), use URL.hostname.
+ * Returns null if the URI is malformed or has no discernible host.
+ */
+function uriHost(uri: string): string | null {
+  const trimmed = uri.trim();
+  if (trimmed.toLowerCase().startsWith("mailto:")) {
+    // mailto:localpart@domain  — the domain is after the last '@'
+    const address = trimmed.slice("mailto:".length);
+    const atIdx = address.lastIndexOf("@");
+    if (atIdx === -1) return null;
+    const domain = address.slice(atIdx + 1).trim();
+    return domain || null;
+  }
+  try {
+    const parsed = new URL(trimmed);
+    return parsed.hostname || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse a comma-separated DMARC reporting URI list (rua= or ruf= value).
+ * Returns an array of individual URI strings.
+ */
+function parseUriList(value: string): string[] {
+  return value
+    .split(",")
+    .map((u) => u.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Check whether an external reporting domain has authorized report delivery
+ * per RFC 7489 §7.1. The authorization record is a TXT lookup at
+ * `_report._dmarc.<external-domain>` that contains a DMARC tag `v=DMARC1`.
+ *
+ * Returns true if authorized, false if not authorized (no record / no v=DMARC1).
+ */
+async function isExternalReportAuthorized(
+  externalDomain: string,
+): Promise<boolean> {
+  const record = await queryTxt(`_report._dmarc.${externalDomain}`);
+  if (!record) return false;
+  return record.entries.some((e) => e.trimStart().startsWith("v=DMARC1"));
+}
+
 export async function analyzeDmarc(domain: string): Promise<DmarcResult> {
   const txt = await queryTxt(`_dmarc.${domain}`);
   if (!txt) {
@@ -61,20 +113,48 @@ export async function analyzeDmarc(domain: string): Promise<DmarcResult> {
     });
   }
 
-  // sp= check
-  if (tags.sp) {
-    validations.push({
-      status: "pass",
-      message: "Subdomain policy explicitly set",
-    });
+  // sp= check — warn when sp=none weakens subdomain enforcement
+  const sp = tags.sp?.toLowerCase();
+  if (sp) {
+    if (sp === "none" && (policy === "reject" || policy === "quarantine")) {
+      validations.push({
+        status: "warn",
+        message:
+          "Subdomain policy (sp=none) weakens subdomain enforcement — subdomains are only monitored while the organizational domain policy is stronger",
+      });
+    } else {
+      validations.push({
+        status: "pass",
+        message: "Subdomain policy explicitly set",
+      });
+    }
   }
 
-  // rua= check
+  // rua= check — presence + external authorization
   if (tags.rua) {
     validations.push({
       status: "pass",
       message: "Aggregate reporting (rua) configured",
     });
+
+    const ruaUris = parseUriList(tags.rua);
+    const authChecks = ruaUris.map(async (uri) => {
+      const host = uriHost(uri);
+      if (!host) return;
+      // If the reporting address is on a different domain, verify authorization
+      const normalizedDomain = domain.toLowerCase();
+      const normalizedHost = host.toLowerCase();
+      if (normalizedHost !== normalizedDomain) {
+        const authorized = await isExternalReportAuthorized(normalizedHost);
+        if (!authorized) {
+          validations.push({
+            status: "warn",
+            message: `rua destination ${normalizedHost} has not published a DMARC report authorization record (_report._dmarc.${normalizedHost}); aggregate reports may be rejected`,
+          });
+        }
+      }
+    });
+    await Promise.all(authChecks);
   } else {
     validations.push({
       status: "warn",
@@ -82,20 +162,47 @@ export async function analyzeDmarc(domain: string): Promise<DmarcResult> {
     });
   }
 
-  // ruf= check
+  // ruf= check — presence + external authorization
   if (tags.ruf) {
     validations.push({
       status: "pass",
       message: "Forensic reporting (ruf) configured",
     });
+
+    const rufUris = parseUriList(tags.ruf);
+    const authChecks = rufUris.map(async (uri) => {
+      const host = uriHost(uri);
+      if (!host) return;
+      const normalizedDomain = domain.toLowerCase();
+      const normalizedHost = host.toLowerCase();
+      if (normalizedHost !== normalizedDomain) {
+        const authorized = await isExternalReportAuthorized(normalizedHost);
+        if (!authorized) {
+          validations.push({
+            status: "warn",
+            message: `ruf destination ${normalizedHost} has not published a DMARC report authorization record (_report._dmarc.${normalizedHost}); forensic reports may be rejected`,
+          });
+        }
+      }
+    });
+    await Promise.all(authChecks);
   }
 
-  // pct check
-  if (tags.pct && parseInt(tags.pct, 10) < 100) {
-    validations.push({
-      status: "warn",
-      message: `Only ${tags.pct}% of messages are subject to the policy`,
-    });
+  // pct= check — warn on pct=0 and pct<100
+  if (tags.pct !== undefined) {
+    const pct = parseInt(tags.pct, 10);
+    if (pct === 0) {
+      validations.push({
+        status: "warn",
+        message:
+          "pct=0 means no messages are subject to the policy (policy is effectively disabled)",
+      });
+    } else if (pct < 100) {
+      validations.push({
+        status: "warn",
+        message: `Only ${tags.pct}% of messages are subject to the policy`,
+      });
+    }
   }
 
   const hasFailure = validations.some((v) => v.status === "fail");

--- a/test/dmarc-warnings.test.ts
+++ b/test/dmarc-warnings.test.ts
@@ -1,0 +1,341 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the DNS client before importing analyzers
+vi.mock("../src/dns/client.js", () => ({
+  queryTxt: vi.fn(),
+  queryMx: vi.fn(),
+}));
+
+import { analyzeDmarc } from "../src/analyzers/dmarc.js";
+import { queryTxt } from "../src/dns/client.js";
+
+const mockQueryTxt = vi.mocked(queryTxt);
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// rua= external authorization checks (RFC 7489 §7.1)
+// ---------------------------------------------------------------------------
+
+describe("analyzeDmarc – rua external authorization", () => {
+  it("does not warn when rua mailto is on the same domain", async () => {
+    mockQueryTxt.mockImplementation(async (name: string) => {
+      if (name === "_dmarc.example.com") {
+        return {
+          entries: ["v=DMARC1; p=reject; rua=mailto:dmarc@example.com"],
+          raw: "v=DMARC1; p=reject; rua=mailto:dmarc@example.com",
+        };
+      }
+      return null;
+    });
+
+    const result = await analyzeDmarc("example.com");
+    expect(
+      result.validations.some(
+        (v) =>
+          v.status === "warn" &&
+          v.message.includes("report authorization record"),
+      ),
+    ).toBe(false);
+  });
+
+  it("warns when rua mailto is on a different domain and has no auth record", async () => {
+    mockQueryTxt.mockImplementation(async (name: string) => {
+      if (name === "_dmarc.example.com") {
+        return {
+          entries: ["v=DMARC1; p=reject; rua=mailto:reports@thirdparty.com"],
+          raw: "v=DMARC1; p=reject; rua=mailto:reports@thirdparty.com",
+        };
+      }
+      // _report._dmarc.thirdparty.com → NXDOMAIN (not authorized)
+      if (name === "_report._dmarc.thirdparty.com") {
+        return null;
+      }
+      return null;
+    });
+
+    const result = await analyzeDmarc("example.com");
+    expect(
+      result.validations.some(
+        (v) =>
+          v.status === "warn" &&
+          v.message.includes("thirdparty.com") &&
+          v.message.includes("report authorization record"),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not warn when rua external domain has a valid auth record", async () => {
+    mockQueryTxt.mockImplementation(async (name: string) => {
+      if (name === "_dmarc.example.com") {
+        return {
+          entries: ["v=DMARC1; p=reject; rua=mailto:reports@thirdparty.com"],
+          raw: "v=DMARC1; p=reject; rua=mailto:reports@thirdparty.com",
+        };
+      }
+      if (name === "_report._dmarc.thirdparty.com") {
+        return {
+          entries: ["v=DMARC1"],
+          raw: "v=DMARC1",
+        };
+      }
+      return null;
+    });
+
+    const result = await analyzeDmarc("example.com");
+    expect(
+      result.validations.some(
+        (v) =>
+          v.status === "warn" &&
+          v.message.includes("report authorization record"),
+      ),
+    ).toBe(false);
+  });
+
+  it("warns for each unauthorized rua destination in a multi-URI list", async () => {
+    mockQueryTxt.mockImplementation(async (name: string) => {
+      if (name === "_dmarc.example.com") {
+        return {
+          entries: [
+            "v=DMARC1; p=reject; rua=mailto:a@vendor1.com,mailto:b@vendor2.com",
+          ],
+          raw: "v=DMARC1; p=reject; rua=mailto:a@vendor1.com,mailto:b@vendor2.com",
+        };
+      }
+      // vendor1 is authorized, vendor2 is not
+      if (name === "_report._dmarc.vendor1.com") {
+        return { entries: ["v=DMARC1"], raw: "v=DMARC1" };
+      }
+      if (name === "_report._dmarc.vendor2.com") {
+        return null;
+      }
+      return null;
+    });
+
+    const result = await analyzeDmarc("example.com");
+    const authWarnings = result.validations.filter(
+      (v) =>
+        v.status === "warn" &&
+        v.message.includes("report authorization record"),
+    );
+    expect(authWarnings).toHaveLength(1);
+    expect(authWarnings[0].message).toContain("vendor2.com");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ruf= external authorization checks
+// ---------------------------------------------------------------------------
+
+describe("analyzeDmarc – ruf external authorization", () => {
+  it("warns when ruf mailto is on a different domain without auth record", async () => {
+    mockQueryTxt.mockImplementation(async (name: string) => {
+      if (name === "_dmarc.example.com") {
+        return {
+          entries: [
+            "v=DMARC1; p=reject; rua=mailto:rua@example.com; ruf=mailto:forensic@external.org",
+          ],
+          raw: "v=DMARC1; p=reject; rua=mailto:rua@example.com; ruf=mailto:forensic@external.org",
+        };
+      }
+      if (name === "_report._dmarc.external.org") {
+        return null;
+      }
+      return null;
+    });
+
+    const result = await analyzeDmarc("example.com");
+    expect(
+      result.validations.some(
+        (v) =>
+          v.status === "warn" &&
+          v.message.includes("external.org") &&
+          v.message.includes("report authorization record"),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not warn when ruf external domain has a valid auth record", async () => {
+    mockQueryTxt.mockImplementation(async (name: string) => {
+      if (name === "_dmarc.example.com") {
+        return {
+          entries: [
+            "v=DMARC1; p=reject; rua=mailto:rua@example.com; ruf=mailto:forensic@external.org",
+          ],
+          raw: "v=DMARC1; p=reject; rua=mailto:rua@example.com; ruf=mailto:forensic@external.org",
+        };
+      }
+      if (name === "_report._dmarc.external.org") {
+        return { entries: ["v=DMARC1"], raw: "v=DMARC1" };
+      }
+      return null;
+    });
+
+    const result = await analyzeDmarc("example.com");
+    expect(
+      result.validations.some(
+        (v) =>
+          v.status === "warn" &&
+          v.message.includes("report authorization record"),
+      ),
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pct= warnings
+// ---------------------------------------------------------------------------
+
+describe("analyzeDmarc – pct warnings", () => {
+  it("warns with specific message when pct=0", async () => {
+    mockQueryTxt.mockResolvedValue({
+      entries: ["v=DMARC1; p=reject; rua=mailto:d@example.com; pct=0"],
+      raw: "v=DMARC1; p=reject; rua=mailto:d@example.com; pct=0",
+    });
+
+    const result = await analyzeDmarc("example.com");
+    expect(
+      result.validations.some(
+        (v) =>
+          v.status === "warn" &&
+          v.message.includes("pct=0") &&
+          v.message.includes("policy is effectively disabled"),
+      ),
+    ).toBe(true);
+  });
+
+  it("warns when pct is between 1 and 99", async () => {
+    mockQueryTxt.mockResolvedValue({
+      entries: ["v=DMARC1; p=reject; rua=mailto:d@example.com; pct=75"],
+      raw: "v=DMARC1; p=reject; rua=mailto:d@example.com; pct=75",
+    });
+
+    const result = await analyzeDmarc("example.com");
+    expect(
+      result.validations.some(
+        (v) => v.status === "warn" && v.message.includes("75%"),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not warn when pct=100", async () => {
+    mockQueryTxt.mockResolvedValue({
+      entries: ["v=DMARC1; p=reject; rua=mailto:d@example.com; pct=100"],
+      raw: "v=DMARC1; p=reject; rua=mailto:d@example.com; pct=100",
+    });
+
+    const result = await analyzeDmarc("example.com");
+    expect(
+      result.validations.some(
+        (v) => v.status === "warn" && v.message.match(/pct|%/),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not warn about pct when tag is absent (default is 100)", async () => {
+    mockQueryTxt.mockResolvedValue({
+      entries: ["v=DMARC1; p=reject; rua=mailto:d@example.com"],
+      raw: "v=DMARC1; p=reject; rua=mailto:d@example.com",
+    });
+
+    const result = await analyzeDmarc("example.com");
+    expect(
+      result.validations.some(
+        (v) => v.status === "warn" && v.message.match(/pct|%/),
+      ),
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sp= warnings (sp=none weakens subdomain enforcement)
+// ---------------------------------------------------------------------------
+
+describe("analyzeDmarc – sp=none weakening subdomain enforcement", () => {
+  it("warns when sp=none and p=reject", async () => {
+    mockQueryTxt.mockResolvedValue({
+      entries: ["v=DMARC1; p=reject; sp=none; rua=mailto:d@example.com"],
+      raw: "v=DMARC1; p=reject; sp=none; rua=mailto:d@example.com",
+    });
+
+    const result = await analyzeDmarc("example.com");
+    expect(
+      result.validations.some(
+        (v) =>
+          v.status === "warn" &&
+          v.message.includes("sp=none") &&
+          v.message.includes("subdomain"),
+      ),
+    ).toBe(true);
+  });
+
+  it("warns when sp=none and p=quarantine", async () => {
+    mockQueryTxt.mockResolvedValue({
+      entries: ["v=DMARC1; p=quarantine; sp=none; rua=mailto:d@example.com"],
+      raw: "v=DMARC1; p=quarantine; sp=none; rua=mailto:d@example.com",
+    });
+
+    const result = await analyzeDmarc("example.com");
+    expect(
+      result.validations.some(
+        (v) =>
+          v.status === "warn" &&
+          v.message.includes("sp=none") &&
+          v.message.includes("subdomain"),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not warn when sp=none and p=none (sp matches parent, no weakening)", async () => {
+    mockQueryTxt.mockResolvedValue({
+      entries: ["v=DMARC1; p=none; sp=none; rua=mailto:d@example.com"],
+      raw: "v=DMARC1; p=none; sp=none; rua=mailto:d@example.com",
+    });
+
+    const result = await analyzeDmarc("example.com");
+    // sp=none with p=none is not a weakening (parent is also none)
+    expect(
+      result.validations.some(
+        (v) =>
+          v.status === "warn" &&
+          v.message.includes("sp=none") &&
+          v.message.includes("weakens"),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not warn for sp=reject alongside p=reject", async () => {
+    mockQueryTxt.mockResolvedValue({
+      entries: ["v=DMARC1; p=reject; sp=reject; rua=mailto:d@example.com"],
+      raw: "v=DMARC1; p=reject; sp=reject; rua=mailto:d@example.com",
+    });
+
+    const result = await analyzeDmarc("example.com");
+    expect(
+      result.validations.some(
+        (v) => v.status === "warn" && v.message.includes("sp=none"),
+      ),
+    ).toBe(false);
+    expect(
+      result.validations.some(
+        (v) => v.status === "pass" && v.message.includes("Subdomain policy"),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not warn for sp=quarantine alongside p=reject", async () => {
+    mockQueryTxt.mockResolvedValue({
+      entries: ["v=DMARC1; p=reject; sp=quarantine; rua=mailto:d@example.com"],
+      raw: "v=DMARC1; p=reject; sp=quarantine; rua=mailto:d@example.com",
+    });
+
+    const result = await analyzeDmarc("example.com");
+    expect(
+      result.validations.some(
+        (v) => v.status === "warn" && v.message.includes("sp=none"),
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Extended the DMARC analyzer to check RFC 7489 §7.1 external report authorization: when `rua` or `ruf` destinations point to a different domain, a `_report._dmarc.<external-domain>` TXT lookup is performed and a `warn` is surfaced if the record is absent.
- Added distinct `warn` for `pct=0` (policy effectively disabled) and the existing `pct<100` warning path continues to fire for 1–99.
- Added `warn` when `sp=none` meaningfully weakens subdomain enforcement — only fires when the organizational-domain policy is `reject` or `quarantine`.

Closes #236

## Test plan

- [ ] All 874 existing + 15 new unit tests pass (`npm test`)
- [ ] TypeScript compiles cleanly (`npm run typecheck`)
- [ ] Biome lint passes (`npm run lint`)
- [ ] `rua=mailto:same@example.com` with scanned domain `example.com` → no authorization warning
- [ ] `rua=mailto:reports@thirdparty.com` with no `_report._dmarc.thirdparty.com` record → `warn` with domain name and "report authorization record" in message
- [ ] `rua=mailto:reports@authorized.com` with valid `_report._dmarc.authorized.com` record → no warning
- [ ] Multi-destination `rua=mailto:a@vendor1.com,mailto:b@vendor2.com` with only vendor1 authorized → exactly one warning for vendor2
- [ ] Same checks for `ruf=` destinations
- [ ] `pct=0` → warn includes "pct=0" and "policy is effectively disabled"
- [ ] `pct=75` → warn includes "75%"
- [ ] `pct=100` and absent `pct` → no pct-related warning
- [ ] `p=reject; sp=none` → warn includes "sp=none" and "subdomain"
- [ ] `p=quarantine; sp=none` → warn
- [ ] `p=none; sp=none` → no weakening warning (sp matches parent policy)
- [ ] `p=reject; sp=reject` → no sp=none warning; `pass` "Subdomain policy explicitly set"

https://claude.ai/code/session_01PWjVsDVDNFjWvdMmwVFGdT

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWjVsDVDNFjWvdMmwVFGdT)_