### PR TITLE
feat: Pro dashboard export to CSV/JSON (#194)

### DIFF
--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -9,6 +9,7 @@ import { generateApiKey } from "../auth/api-key.js";
 import { requireAuth } from "../auth/middleware.js";
 import type { SessionPayload } from "../auth/session.js";
 import { dashboardBillingRoutes } from "../billing/routes.js";
+import { escapeCsvField } from "../csv.js";
 import {
   acknowledgeAlert,
   countUnacknowledgedByDomain,
@@ -30,6 +31,7 @@ import {
   listDomainsForUserPaged,
 } from "../db/domains.js";
 import {
+  getDashboardExportRows,
   getPortfolioTrendForUser,
   getScanHistory,
   getScanHistoryWithProtocols,
@@ -54,6 +56,7 @@ import {
   renderDomainDetailPage,
   renderDomainHistoryPage,
   renderDomainPanel,
+  renderExportUpsellPage,
   renderSettingsPage,
   toApiKeyListEntry,
 } from "../views/dashboard.js";
@@ -541,6 +544,147 @@ dashboardRoutes.get("/domains", async (c) => {
   // no-store keeps a CDN from caching one user's domain list and serving it
   // to another. The route is auth-required, but belt-and-suspenders.
   return c.html(html, 200, { "Cache-Control": "no-store" });
+});
+
+// Dashboard export — Pro only. Serves the user's full watchlist + most-recent
+// scan result for every domain as either CSV or JSON, depending on ?format=.
+// Strictly reads from the existing scan_history table — no fresh DNS lookups,
+// so this is fast and never hits the rate limiter.
+//
+// Future work (out of scope): historical bulk-export (all scans over time),
+// scheduled/emailed exports, PDF reports. See issue #194 for context.
+dashboardRoutes.get("/export", async (c) => {
+  const session = c.get("user" as never) as SessionPayload;
+  const db = (c.env as { DB: D1Database }).DB;
+  const plan = await getPlanForUser(db, session.sub);
+
+  // Gate on Pro — but return a 402 upsell page, not 404, so the URL is stable
+  // and can appear in docs/pricing without breaking for non-Pro visitors.
+  if (plan !== "pro") {
+    return c.html(renderExportUpsellPage({ email: session.email }), 402);
+  }
+
+  const rows = await getDashboardExportRows(db, session.sub);
+  const formatParam = new URL(c.req.url).searchParams.get("format");
+  const format = formatParam === "json" ? "json" : "csv";
+
+  const dateStr = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+
+  if (format === "json") {
+    const payload = rows.map((row) => {
+      let protocols: Record<string, unknown> | null = null;
+      if (row.protocol_results) {
+        try {
+          protocols = JSON.parse(row.protocol_results) as Record<
+            string,
+            unknown
+          >;
+        } catch {
+          protocols = null;
+        }
+      }
+      return {
+        domain: row.domain,
+        last_scanned_at: row.last_scanned_at,
+        grade: row.last_grade,
+        protocols,
+      };
+    });
+
+    return new Response(JSON.stringify(payload, null, 2), {
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Disposition": `attachment; filename="dmarcheck-dashboard-${dateStr}.json"`,
+        "Cache-Control": "no-store",
+      },
+    });
+  }
+
+  // CSV: one row per domain with flat protocol-status columns
+  const CSV_HEADERS = [
+    "domain",
+    "last_scanned_at",
+    "grade",
+    "score",
+    "dmarc_status",
+    "spf_status",
+    "dkim_status",
+    "bimi_status",
+    "mta_sts_status",
+    "mx_status",
+  ];
+
+  // Grade → numeric score (0–12), mirroring the GRADE_SCORE table in scans.ts
+  const GRADE_SCORE: Record<string, number> = {
+    S: 12,
+    "A+": 11,
+    A: 10,
+    "A-": 9,
+    "B+": 8,
+    B: 7,
+    "B-": 6,
+    "C+": 5,
+    C: 4,
+    "C-": 3,
+    "D+": 2,
+    D: 1,
+    "D-": 1,
+    F: 0,
+  };
+
+  function extractStatus(
+    protocols: Record<string, unknown> | null,
+    key: string,
+  ): string {
+    const proto = protocols?.[key] as { status?: unknown } | undefined | null;
+    const s = proto?.status;
+    return typeof s === "string" ? s : "";
+  }
+
+  const csvRows: string[] = [];
+  // BOM so Excel auto-detects UTF-8
+  csvRows.push(`﻿${CSV_HEADERS.map(escapeCsvField).join(",")}`);
+
+  for (const row of rows) {
+    let protocols: Record<string, unknown> | null = null;
+    if (row.protocol_results) {
+      try {
+        protocols = JSON.parse(row.protocol_results) as Record<string, unknown>;
+      } catch {
+        protocols = null;
+      }
+    }
+
+    const lastScannedIso = row.last_scanned_at
+      ? new Date(row.last_scanned_at * 1000).toISOString()
+      : "";
+    const grade = row.last_grade ?? "";
+    const score = grade ? String(GRADE_SCORE[grade] ?? "") : "";
+
+    const fields = [
+      row.domain,
+      lastScannedIso,
+      grade,
+      score,
+      extractStatus(protocols, "dmarc"),
+      extractStatus(protocols, "spf"),
+      extractStatus(protocols, "dkim"),
+      extractStatus(protocols, "bimi"),
+      extractStatus(protocols, "mta_sts"),
+      extractStatus(protocols, "mx"),
+    ];
+    csvRows.push(fields.map(escapeCsvField).join(","));
+  }
+
+  const csv = `${csvRows.join("\r\n")}\r\n`;
+
+  return new Response(csv, {
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": `attachment; filename="dmarcheck-dashboard-${dateStr}.csv"`,
+      "Cache-Control": "no-store",
+    },
+  });
 });
 
 dashboardRoutes.post("/alerts/:id/acknowledge", async (c) => {

--- a/src/db/scans.ts
+++ b/src/db/scans.ts
@@ -154,6 +154,47 @@ export async function getPortfolioTrendForUser(
   });
 }
 
+// One row per domain the user monitors: the domain name, grade, last_scanned_at
+// (from the domains table), and the protocol_results blob from the most-recent
+// scan_history row. Used exclusively by GET /dashboard/export — no fresh DNS
+// lookups are performed.
+//
+// Future work: a historical bulk-export (all scans over time) would need a
+// different query shape; that is intentionally out of scope for this route.
+export interface DashboardExportRow {
+  domain: string;
+  last_scanned_at: number | null;
+  last_grade: string | null;
+  protocol_results: string | null;
+}
+
+export async function getDashboardExportRows(
+  db: D1Database,
+  userId: string,
+): Promise<DashboardExportRow[]> {
+  // Correlated subquery picks the single most-recent protocol_results blob per
+  // domain without a second round-trip. domains.last_grade / last_scanned_at
+  // are the authoritative "current posture" fields maintained by recordScan.
+  const result = await db
+    .prepare(
+      `SELECT
+         d.domain,
+         d.last_scanned_at,
+         d.last_grade,
+         (SELECT sh.protocol_results
+            FROM scan_history sh
+           WHERE sh.domain_id = d.id
+           ORDER BY sh.scanned_at DESC
+           LIMIT 1) AS protocol_results
+       FROM domains d
+       WHERE d.user_id = ?
+       ORDER BY d.domain ASC`,
+    )
+    .bind(userId)
+    .all<DashboardExportRow>();
+  return result.results;
+}
+
 export async function getScanHistoryWithProtocols(
   db: D1Database,
   domainId: number,

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -2061,6 +2061,11 @@ ${statStrip}
 ${renderAlertsSection(alerts)}
 <div class="dashboard-domains-header" style="display:flex;align-items:center;gap:1rem;margin-bottom:0.75rem;">
   <h2 class="dashboard-title" style="margin:0;flex:1;">Your Domains</h2>
+  ${
+    plan === "pro"
+      ? `<a href="/dashboard/export" class="btn btn-secondary" style="font-size:0.8125rem">Export</a>`
+      : `<a href="/dashboard/export" class="btn btn-secondary" style="font-size:0.8125rem;opacity:0.6" title="Pro feature">Export</a>`
+  }
   <button type="button" class="dashboard-add-btn" data-wizard-open>Add domain</button>
 </div>
 ${renderDomainPanel({ domains, controls, usage })}
@@ -2068,6 +2073,19 @@ ${renderDomainDrawerShell()}
 ${renderAddDomainWizardShell()}`,
     email,
   );
+}
+
+// 402 upsell page shown to free-plan users who hit GET /dashboard/export.
+// The route is not hidden (same pattern as /domain/:domain/history) so the URL
+// is stable and can appear in docs without breaking links for non-Pro visitors.
+export function renderExportUpsellPage({ email }: { email: string }): string {
+  const body = `<h1 class="dashboard-title">Export Watchlist</h1>
+<div class="upgrade-prompt">
+  <h2>Pro feature</h2>
+  <p>Export your full watchlist and the most recent scan result for every domain to CSV or JSON. Available on the Pro plan.</p>
+  <a href="/dashboard/billing/subscribe" class="btn">Upgrade to Pro</a>
+</div>`;
+  return dashboardPage("Export — dmarc.mx", body, email);
 }
 
 // === Local-only fixture preview ============================================

--- a/test/dashboard-routes.test.ts
+++ b/test/dashboard-routes.test.ts
@@ -181,6 +181,30 @@ function createMockDB(data: {
       return null as T | null;
     },
     all: async <T>() => {
+      // Dashboard export query — correlated subquery form emitted by
+      // getDashboardExportRows. Matches before the generic domains handler.
+      if (sql.includes("FROM domains d") && sql.includes("d.user_id = ?")) {
+        const userId = bindings[0] as string;
+        const userDomains = [...domains]
+          .filter((d) => d.user_id === userId)
+          .sort((a, b) => a.domain.localeCompare(b.domain));
+        // Build a lookup from domain_id → most-recent protocol_results
+        const latestProtocol = new Map<number, string | null>();
+        for (const d of userDomains) {
+          const latest = [...scanHistory]
+            .filter((sh) => (sh.domain_id ?? 1) === d.id)
+            .sort((a, b) => b.scanned_at - a.scanned_at)[0];
+          latestProtocol.set(d.id, latest?.protocol_results ?? null);
+        }
+        return {
+          results: userDomains.map((d) => ({
+            domain: d.domain,
+            last_scanned_at: d.last_scanned_at,
+            last_grade: d.last_grade,
+            protocol_results: latestProtocol.get(d.id) ?? null,
+          })) as T[],
+        };
+      }
       if (sql.includes("SELECT * FROM domains WHERE user_id")) {
         // Paged listing path (used by Pro dashboard) — applies search / grade
         // / frequency filters + LIMIT/OFFSET. The simpler unpaged select used
@@ -2443,6 +2467,234 @@ describe("dashboard/routes", () => {
       expect(res.status).toBe(400);
       const html = await res.text();
       expect(html).toContain("Too many domains");
+    });
+  });
+
+  describe("GET /dashboard/export", () => {
+    it("redirects to /auth/login without a session cookie", async () => {
+      const db = createMockDB({});
+      const app = createTestApp(db);
+      const res = await app.request("/dashboard/export");
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/auth/login");
+    });
+
+    it("returns 402 with upsell page for free users", async () => {
+      const db = createMockDB({
+        domains: [
+          {
+            id: 1,
+            user_id: "user_1",
+            domain: "example.com",
+            is_free: 1,
+            scan_frequency: "monthly",
+            last_scanned_at: null,
+            last_grade: null,
+            created_at: 1700000000,
+          },
+        ],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+      const res = await app.request("/dashboard/export", {
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(402);
+      const body = await res.text();
+      expect(body).toContain("Pro feature");
+      expect(body).toContain("Upgrade to Pro");
+    });
+
+    it("returns CSV with expected columns for a Pro user", async () => {
+      const protocolResults = JSON.stringify({
+        dmarc: { status: "pass" },
+        spf: { status: "warn" },
+        dkim: { status: "pass" },
+        bimi: { status: "fail" },
+        mta_sts: { status: "pass" },
+        mx: { status: "info" },
+      });
+      const db = createMockDB({
+        subscriptions: [{ user_id: "user_pro", status: "active" }],
+        domains: [
+          {
+            id: 1,
+            user_id: "user_pro",
+            domain: "example.com",
+            is_free: 0,
+            scan_frequency: "weekly",
+            last_scanned_at: 1700000000,
+            last_grade: "B",
+            created_at: 1700000000,
+          },
+        ],
+        scanHistory: [
+          {
+            id: 1,
+            domain_id: 1,
+            grade: "B",
+            scanned_at: 1700000000,
+            protocol_results: protocolResults,
+            score_factors: null,
+          },
+        ],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_pro", "pro@example.com");
+      const res = await app.request("/dashboard/export", {
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toContain("text/csv");
+      expect(res.headers.get("Content-Disposition")).toMatch(
+        /filename="dmarcheck-dashboard-\d{4}-\d{2}-\d{2}\.csv"/,
+      );
+      const text = await res.text();
+      // Header row must contain all required columns
+      const lines = text.trim().split(/\r?\n/);
+      // First line is BOM + headers; strip BOM for comparison
+      const headerLine = lines[0].replace(/^﻿/, "");
+      expect(headerLine).toBe(
+        "domain,last_scanned_at,grade,score,dmarc_status,spf_status,dkim_status,bimi_status,mta_sts_status,mx_status",
+      );
+      // Data row
+      expect(lines.length).toBe(2); // header + 1 domain
+      const dataLine = lines[1];
+      expect(dataLine).toContain("example.com");
+      expect(dataLine).toContain("pass"); // dmarc_status
+      expect(dataLine).toContain("warn"); // spf_status
+      expect(dataLine).toContain("fail"); // bimi_status
+    });
+
+    it("returns header-only CSV for a Pro user with an empty watchlist", async () => {
+      const db = createMockDB({
+        subscriptions: [{ user_id: "user_pro", status: "active" }],
+        domains: [],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_pro", "pro@example.com");
+      const res = await app.request("/dashboard/export", {
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toContain("text/csv");
+      const text = await res.text();
+      const lines = text.trim().split(/\r?\n/);
+      expect(lines.length).toBe(1); // header only
+      const headerLine = lines[0].replace(/^﻿/, "");
+      expect(headerLine).toBe(
+        "domain,last_scanned_at,grade,score,dmarc_status,spf_status,dkim_status,bimi_status,mta_sts_status,mx_status",
+      );
+    });
+
+    it("returns JSON array with domain and protocols for ?format=json", async () => {
+      const protocolResults = JSON.stringify({
+        dmarc: { status: "pass" },
+        spf: { status: "pass" },
+        dkim: { status: "pass" },
+        bimi: { status: "fail" },
+        mta_sts: { status: "pass" },
+        mx: { status: "info" },
+      });
+      const db = createMockDB({
+        subscriptions: [{ user_id: "user_pro", status: "active" }],
+        domains: [
+          {
+            id: 1,
+            user_id: "user_pro",
+            domain: "alpha.com",
+            is_free: 0,
+            scan_frequency: "weekly",
+            last_scanned_at: 1700000000,
+            last_grade: "A",
+            created_at: 1700000000,
+          },
+          {
+            id: 2,
+            user_id: "user_pro",
+            domain: "beta.com",
+            is_free: 0,
+            scan_frequency: "weekly",
+            last_scanned_at: null,
+            last_grade: null,
+            created_at: 1700000001,
+          },
+        ],
+        scanHistory: [
+          {
+            id: 1,
+            domain_id: 1,
+            grade: "A",
+            scanned_at: 1700000000,
+            protocol_results: protocolResults,
+            score_factors: null,
+          },
+        ],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_pro", "pro@example.com");
+      const res = await app.request("/dashboard/export?format=json", {
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toContain("application/json");
+      expect(res.headers.get("Content-Disposition")).toMatch(
+        /filename="dmarcheck-dashboard-\d{4}-\d{2}-\d{2}\.json"/,
+      );
+      const payload = (await res.json()) as Array<{
+        domain: string;
+        last_scanned_at: number | null;
+        grade: string | null;
+        protocols: Record<string, unknown> | null;
+      }>;
+      expect(Array.isArray(payload)).toBe(true);
+      expect(payload).toHaveLength(2);
+      // Sorted by domain alphabetically
+      expect(payload[0].domain).toBe("alpha.com");
+      expect(payload[0].grade).toBe("A");
+      expect(payload[0].protocols).not.toBeNull();
+      // beta.com has no scan yet
+      expect(payload[1].domain).toBe("beta.com");
+      expect(payload[1].grade).toBeNull();
+      expect(payload[1].protocols).toBeNull();
+    });
+
+    it("renders an Export button in the dashboard toolbar for Pro users", async () => {
+      const db = createMockDB({
+        subscriptions: [{ user_id: "user_pro", status: "active" }],
+        users: [
+          {
+            id: "user_pro",
+            email: "pro@example.com",
+            email_domain: "example.com",
+            stripe_customer_id: "cus_x",
+            email_alerts_enabled: 1,
+            api_key_retirement_acknowledged_at: 1700000000,
+            created_at: 1700000000,
+          },
+        ],
+        domains: [
+          {
+            id: 1,
+            user_id: "user_pro",
+            domain: "example.com",
+            is_free: 0,
+            scan_frequency: "weekly",
+            last_scanned_at: null,
+            last_grade: "A",
+            created_at: 1700000000,
+          },
+        ],
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_pro", "pro@example.com");
+      const res = await app.request("/dashboard", {
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body).toContain('href="/dashboard/export"');
+      expect(body).toContain("Export");
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds `GET /dashboard/export` (Pro-gated) that exports all watchlist domains + most-recent scan result per domain as CSV or JSON
- CSV has columns: `domain, last_scanned_at, grade, score, dmarc_status, spf_status, dkim_status, bimi_status, mta_sts_status, mx_status`; JSON is an array of `{domain, last_scanned_at, grade, protocols}` objects; both use `Content-Disposition: attachment` with a date-stamped filename
- Free users see a 402 upsell page (not 404); an Export link appears in the dashboard header for all users (muted appearance for free plan, fully styled for Pro)

Closes #194

## Test plan

- [x] `npm test` — 865 pass / 866 total (1 pre-existing integration test requires live network to dmarc.mx; unrelated to this change)
- [x] `npm run typecheck` — no errors
- [x] `npm run lint` — clean
- [x] New tests in `test/dashboard-routes.test.ts`:
  - Unauthenticated → 302 to `/auth/login`
  - Free user → 402 upsell page with "Pro feature" + "Upgrade to Pro" copy
  - Pro user with data → 200 CSV; header row contains all 10 required columns; data row includes domain and protocol statuses
  - Pro user with empty watchlist → header-only CSV (one line)
  - `?format=json` → JSON array with `{domain, last_scanned_at, grade, protocols}` shape, sorted alphabetically, null protocols for unscanned domains
  - Dashboard page for Pro user contains `href="/dashboard/export"` Export link

https://claude.ai/code/session_01PWjVsDVDNFjWvdMmwVFGdT

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWjVsDVDNFjWvdMmwVFGdT)_