### PR TITLE
feat: SMTP TLS Reporting (TLS-RPT) analyzer (#235)

### DIFF
--- a/src/analyzers/tls-rpt.ts
+++ b/src/analyzers/tls-rpt.ts
@@ -1,0 +1,105 @@
+import { queryTxt } from "../dns/client.js";
+import { parseTags } from "../shared/parse-tags.js";
+import type { TlsRptResult, Validation } from "./types.js";
+
+// RFC 8460 — SMTP TLS Reporting. Informational analyzer; does not affect
+// the letter grade. TLS-RPT is a companion to MTA-STS: it tells receiving
+// MTAs where to send TLS failure reports, but its presence or absence does
+// not change the enforcement posture.
+
+export async function analyzeTlsRpt(domain: string): Promise<TlsRptResult> {
+  const txt = await queryTxt(`_smtp._tls.${domain}`);
+
+  if (!txt || txt.entries.length === 0) {
+    return {
+      status: "info",
+      record: null,
+      tags: null,
+      validations: [
+        {
+          status: "info",
+          message: "No TLS-RPT record found at _smtp._tls TXT",
+        },
+      ],
+    };
+  }
+
+  const validations: Validation[] = [];
+
+  const tlsRptEntries = txt.entries.filter((e) =>
+    e.toLowerCase().startsWith("v=tlsrptv1"),
+  );
+  const otherEntries = txt.entries.filter(
+    (e) => !e.toLowerCase().startsWith("v=tlsrptv1"),
+  );
+
+  if (otherEntries.length > 0) {
+    validations.push({
+      status: "warn",
+      message: `${otherEntries.length} unrelated TXT record${otherEntries.length > 1 ? "s" : ""} at _smtp._tls — may cause confusion`,
+    });
+  }
+
+  if (tlsRptEntries.length === 0) {
+    validations.push({
+      status: "warn",
+      message:
+        "TXT record(s) found at _smtp._tls but none begin with v=TLSRPTv1",
+    });
+    return { status: "warn", record: null, tags: null, validations };
+  }
+
+  if (tlsRptEntries.length > 1) {
+    validations.push({
+      status: "warn",
+      message: `${tlsRptEntries.length} TLS-RPT records found; exactly one is required (RFC 8460 §3)`,
+    });
+  }
+
+  const record = tlsRptEntries[0];
+  const tags = parseTags(record);
+
+  validations.push({
+    status: "info",
+    message: "TLS-RPT record found (v=TLSRPTv1)",
+  });
+
+  if (!tags.rua) {
+    validations.push({
+      status: "warn",
+      message: "Missing required rua= tag (RFC 8460 §3.1)",
+    });
+  } else {
+    const ruas = tags.rua
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+    if (ruas.length === 0) {
+      validations.push({ status: "warn", message: "rua= tag is empty" });
+    } else {
+      const invalid = ruas.filter(
+        (r) => !r.startsWith("mailto:") && !r.startsWith("https://"),
+      );
+      if (invalid.length > 0) {
+        validations.push({
+          status: "warn",
+          message: `rua= destination${invalid.length > 1 ? "s" : ""} not in mailto:/https:// format: ${invalid.slice(0, 3).join(", ")}`,
+        });
+      } else {
+        validations.push({
+          status: "info",
+          message: `Report destination${ruas.length > 1 ? "s" : ""}: ${ruas.join(", ")}`,
+        });
+      }
+    }
+  }
+
+  const hasWarn = validations.some((v) => v.status === "warn");
+  return {
+    status: hasWarn ? "warn" : "pass",
+    record,
+    tags,
+    validations,
+  };
+}

--- a/src/analyzers/types.ts
+++ b/src/analyzers/types.ts
@@ -102,6 +102,13 @@ export interface SecurityTxtResult {
   validations: Validation[];
 }
 
+export interface TlsRptResult {
+  status: Status;
+  record: string | null;
+  tags: Record<string, string> | null;
+  validations: Validation[];
+}
+
 export interface ScanSummary {
   mx_records: number;
   mx_providers: string[];
@@ -127,5 +134,6 @@ export interface ScanResult {
     bimi: BimiResult;
     mta_sts: MtaStsResult;
     security_txt: SecurityTxtResult;
+    tls_rpt?: TlsRptResult;
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import type {
   ScanResult,
   SecurityTxtResult,
   SpfResult,
+  TlsRptResult,
 } from "./analyzers/types.js";
 import {
   getAgentSkillsIndexJson,
@@ -80,6 +81,7 @@ import {
   renderSecurityTxtCard,
   renderSpfCard,
   renderStreamingLoading,
+  renderTlsRptCard,
 } from "./views/html.js";
 import {
   renderLearnBimi,
@@ -513,6 +515,7 @@ const protocolRenderers: Record<
   bimi: (r) => renderBimiCard(r as BimiResult),
   mta_sts: (r) => renderMtaStsCard(r as MtaStsResult),
   security_txt: (r) => renderSecurityTxtCard(r as SecurityTxtResult),
+  tls_rpt: (r) => renderTlsRptCard(r as TlsRptResult),
 };
 
 function tagScanResult(result: ScanResult): void {

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -6,6 +6,7 @@ import { analyzeMtaSts } from "./analyzers/mta-sts.js";
 import { analyzeMx } from "./analyzers/mx.js";
 import { analyzeSecurityTxt } from "./analyzers/security-txt.js";
 import { analyzeSpf } from "./analyzers/spf.js";
+import { analyzeTlsRpt } from "./analyzers/tls-rpt.js";
 import type {
   BimiResult,
   DkimResult,
@@ -15,6 +16,7 @@ import type {
   ScanResult,
   SecurityTxtResult,
   SpfResult,
+  TlsRptResult,
 } from "./analyzers/types.js";
 import { queryTxt } from "./dns/client.js";
 import { computeGradeBreakdown } from "./shared/scoring.js";
@@ -26,7 +28,8 @@ export type ProtocolId =
   | "dkim"
   | "bimi"
   | "mta_sts"
-  | "security_txt";
+  | "security_txt"
+  | "tls_rpt";
 export type ProtocolResult =
   | MxResult
   | DmarcResult
@@ -34,7 +37,8 @@ export type ProtocolResult =
   | DkimResult
   | BimiResult
   | MtaStsResult
-  | SecurityTxtResult;
+  | SecurityTxtResult
+  | TlsRptResult;
 
 async function buildScanResult(
   domain: string,
@@ -89,6 +93,7 @@ export async function scan(
   const bimiDnsPromise = prefetchBimiDns(domain);
   const mxPromise = analyzeMx(domain);
   const securityTxtPromise = analyzeSecurityTxt(domain);
+  const tlsRptPromise = analyzeTlsRpt(domain);
 
   // Chain DKIM off MX so it starts as soon as MX resolves
   // without blocking on unrelated queries
@@ -118,6 +123,7 @@ export async function scan(
     bimiResult,
     mxResult,
     securityTxtResult,
+    tlsRptResult,
   ] = await Promise.all([
     dmarcPromise,
     spfPromise,
@@ -126,6 +132,7 @@ export async function scan(
     bimiPromise,
     mxPromise,
     securityTxtPromise,
+    tlsRptPromise,
   ]);
 
   Sentry.addBreadcrumb({
@@ -164,6 +171,12 @@ export async function scan(
     data: { protocol: "security_txt", status: securityTxtResult.status },
     level: "info",
   });
+  Sentry.addBreadcrumb({
+    category: "analyzer.complete",
+    message: `tls_rpt: ${tlsRptResult.status}`,
+    data: { protocol: "tls_rpt", status: tlsRptResult.status },
+    level: "info",
+  });
 
   return await buildScanResult(domain, {
     mx: mxResult,
@@ -173,6 +186,7 @@ export async function scan(
     bimi: bimiResult,
     mta_sts: mtaStsResult,
     security_txt: securityTxtResult,
+    tls_rpt: tlsRptResult,
   });
 }
 
@@ -192,6 +206,7 @@ export async function scanStreaming(
   const bimiDnsPromise = prefetchBimiDns(domain);
   const mxPromise = analyzeMx(domain);
   const securityTxtPromise = analyzeSecurityTxt(domain);
+  const tlsRptPromise = analyzeTlsRpt(domain);
 
   // Chain DKIM off MX so it starts as soon as MX resolves
   const dkimPromise = mxPromise.then((mxResult) => {
@@ -278,6 +293,16 @@ export async function scanStreaming(
     onResult("security_txt", r);
   });
 
+  tlsRptPromise.then((r) => {
+    Sentry.addBreadcrumb({
+      category: "analyzer.complete",
+      message: `tls_rpt: ${r.status}`,
+      data: { protocol: "tls_rpt", status: r.status },
+      level: "info",
+    });
+    onResult("tls_rpt", r);
+  });
+
   const [
     dmarcResult,
     spfResult,
@@ -286,6 +311,7 @@ export async function scanStreaming(
     bimiResult,
     mxResult,
     securityTxtResult,
+    tlsRptResult,
   ] = await Promise.all([
     dmarcPromise,
     spfPromise,
@@ -294,6 +320,7 @@ export async function scanStreaming(
     bimiPromise,
     mxPromise,
     securityTxtPromise,
+    tlsRptPromise,
   ]);
 
   return await buildScanResult(domain, {
@@ -304,5 +331,6 @@ export async function scanStreaming(
     bimi: bimiResult,
     mta_sts: mtaStsResult,
     security_txt: securityTxtResult,
+    tls_rpt: tlsRptResult,
   });
 }

--- a/src/shared/scoring.ts
+++ b/src/shared/scoring.ts
@@ -6,6 +6,7 @@ import type {
   SecurityTxtResult,
   SpfResult,
   Status,
+  TlsRptResult,
 } from "../analyzers/types.js";
 
 interface Protocols {
@@ -19,6 +20,8 @@ interface Protocols {
   // The orchestrator always populates it; informational only — does not
   // affect grade resolution.
   security_txt?: SecurityTxtResult;
+  // Optional for same reason — older fixtures don't include tls_rpt.
+  tls_rpt?: TlsRptResult;
   [key: string]: unknown;
 }
 
@@ -47,7 +50,7 @@ export interface GradeBreakdown {
   protocolSummaries: Record<string, { status: Status; summary: string }>;
 }
 
-// ── Single decision engine ────────────────────────────────────
+// ── Single decision engine ─────────────────────────────────
 
 interface ScoringResult {
   grade: string;
@@ -227,7 +230,7 @@ function resolveScoring(protocols: Protocols): ScoringResult {
   };
 }
 
-// ── Public API (thin wrappers) ────────────────────────────────
+// ── Public API (thin wrappers) ────────────────────────
 
 export function computeGrade(protocols: Protocols): string {
   return resolveScoring(protocols).grade;
@@ -245,7 +248,7 @@ export function computeGradeBreakdown(protocols: Protocols): GradeBreakdown {
   };
 }
 
-// ── Modifier helpers ──────────────────────────────────────────
+// ── Modifier helpers ────────────────────────────────
 
 function applyModifier(base: "A" | "B" | "C" | "D", modifier: number): string {
   if (modifier >= 1) return `${base}+`;
@@ -261,7 +264,7 @@ function modifierToLabel(modifier: number): string {
   return "";
 }
 
-// ── Factor helpers ────────────────────────────────────────────
+// ── Factor helpers ────────────────────────────────
 
 function spfFactors(spf: SpfResult): ScoringFactor[] {
   const factors: ScoringFactor[] = [];
@@ -348,12 +351,12 @@ function dkimFactors(dkim: DkimResult): ScoringFactor[] {
   return factors;
 }
 
-// ── Protocol summaries ────────────────────────────────────────
+// ── Protocol summaries ────────────────────────────
 
 function buildProtocolSummaries(
   protocols: Protocols,
 ): GradeBreakdown["protocolSummaries"] {
-  const { dmarc, spf, dkim, bimi, mta_sts, security_txt } = protocols;
+  const { dmarc, spf, dkim, bimi, mta_sts, security_txt, tls_rpt } = protocols;
   const dmarcPolicy = dmarc.tags?.p ?? null;
   const dkimFound = Object.values(dkim.selectors).filter((s) => s.found);
 
@@ -400,10 +403,20 @@ function buildProtocolSummaries(
         : "Not published",
     };
   }
+  if (tls_rpt) {
+    summaries.tls_rpt = {
+      status: tls_rpt.status,
+      summary: tls_rpt.record
+        ? tls_rpt.tags?.rua
+          ? tls_rpt.tags.rua.split(",")[0].trim()
+          : "Record found (no rua)"
+        : "Not configured",
+    };
+  }
   return summaries;
 }
 
-// ── Recommendations ───────────────────────────────────────────
+// ── Recommendations ───────────────────────────────
 
 function generateRecommendations(
   tier: string,

--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -7,6 +7,7 @@ import type {
   ScanResult,
   SecurityTxtResult,
   SpfResult,
+  TlsRptResult,
 } from "../analyzers/types.js";
 import { isIndexableScanDomain } from "../shared/indexable-domains.js";
 import { CSS_PATH, JS_PATH } from "./assets.js";
@@ -328,17 +329,38 @@ export function renderSecurityTxtCard(s: SecurityTxtResult): string {
   );
 }
 
+export function renderTlsRptCard(t: TlsRptResult): string {
+  const subtitle = t.record
+    ? t.tags?.rua
+      ? t.tags.rua.split(",")[0].trim()
+      : "Record found (no rua)"
+    : "Not configured";
+  let body = "";
+  if (t.tags?.rua) {
+    const ruas = t.tags.rua
+      .split(",")
+      .map((v) => v.trim())
+      .filter(Boolean);
+    body += `<div class="tag-grid"><div><strong>rua</strong></div><div>${ruas.map((v) => `<code>${esc(v)}</code>`).join("<br>")}</div></div>`;
+  }
+  body += validationList(t.validations);
+  if (t.record) {
+    body += rawRecord(t.record);
+  }
+  return protocolCard("TLS-RPT", t.status, subtitle, body, false, "tls-rpt");
+}
+
 export function renderMxCard(mx: MxResult): string {
   const subtitle =
     mx.records.length > 0
-      ? `${mx.records.length} record${mx.records.length !== 1 ? "s" : ""}${mx.providers.length > 0 ? ` \u00b7 ${mx.providers.map((p) => p.name).join(", ")}` : ""}`
+      ? `${mx.records.length} record${mx.records.length !== 1 ? "s" : ""}${mx.providers.length > 0 ? ` · ${mx.providers.map((p) => p.name).join(", ")}` : ""}`
       : "No MX records";
   const body = mxTable(mx.records) + validationList(mx.validations);
   return protocolCard("MX", mx.status, subtitle, body);
 }
 
 function reportBody(result: ScanResult): string {
-  const { mx, dmarc, spf, dkim, bimi, mta_sts, security_txt } =
+  const { mx, dmarc, spf, dkim, bimi, mta_sts, security_txt, tls_rpt } =
     result.protocols;
 
   return `<main class="report">
@@ -367,6 +389,7 @@ function reportBody(result: ScanResult): string {
   ${renderBimiCard(bimi)}
   ${renderMtaStsCard(mta_sts)}
   ${security_txt ? renderSecurityTxtCard(security_txt) : ""}
+  ${tls_rpt ? renderTlsRptCard(tls_rpt) : ""}
   ${monitorSnapshotCard(result)}
   <div class="learn-link" style="margin-top:2.5rem">Analyze message headers: <a href="https://toolbox.googleapps.com/apps/messageheader/" target="_blank" rel="noopener">Google &#8599;</a> &middot; <a href="https://mha.azurewebsites.net/" target="_blank" rel="noopener">Microsoft &#8599;</a></div>
   <div class="learn-link" style="margin-top:0.4rem;margin-bottom:1rem"><a href="/scoring">How is my score calculated?</a> &middot; <a href="https://www.cloudflare.com/learning/email-security/dmarc-dkim-spf/" target="_blank" rel="noopener">What is email security? &#8599;</a></div>
@@ -805,9 +828,9 @@ export function renderApiDocs(): string {
       <p>Content-negotiated human endpoint.</p>
       <ul>
         <li>Default: HTML</li>
-        <li><code>Accept: application/json</code> → JSON (same shape as <code>/api/check</code>)</li>
-        <li><code>Accept: text/markdown</code> → markdown for agents</li>
-        <li><code>format=csv</code> → CSV download</li>
+        <li><code>Accept: application/json</code> &rarr; JSON (same shape as <code>/api/check</code>)</li>
+        <li><code>Accept: text/markdown</code> &rarr; markdown for agents</li>
+        <li><code>format=csv</code> &rarr; CSV download</li>
       </ul>
     </div>
   </div>

--- a/src/views/markdown.ts
+++ b/src/views/markdown.ts
@@ -1,6 +1,7 @@
 import type {
   ScanResult,
   SecurityTxtResult,
+  TlsRptResult,
   Validation,
 } from "../analyzers/types.js";
 
@@ -44,6 +45,26 @@ Source: <${s.source_url}>${s.signed ? " (PGP-signed)" : ""}
 ${fieldLines.join("\n")}
 
 ${validationLines(s.validations)}`;
+}
+
+function renderTlsRptMarkdown(t: TlsRptResult): string {
+  if (!t.record) {
+    return `## TLS-RPT — ${t.status}
+
+_No TLS-RPT record found at _smtp._tls TXT._
+
+${validationLines(t.validations)}`;
+  }
+  const ruaLine = t.tags?.rua ? `rua: ${t.tags.rua}` : "rua: _(missing)_";
+  return `## TLS-RPT — ${t.status}
+
+\`\`\`
+${t.record}
+\`\`\`
+
+${ruaLine}
+
+${validationLines(t.validations)}`;
 }
 
 export function renderLandingMarkdown(): string {
@@ -159,6 +180,8 @@ ${bullet(protocols.mx.records.map((r) => `${r.priority} ${r.exchange}${r.provide
 ${validationLines(protocols.mx.validations)}
 
 ${protocols.security_txt ? renderSecurityTxtMarkdown(protocols.security_txt) : ""}
+
+${protocols.tls_rpt ? renderTlsRptMarkdown(protocols.tls_rpt) : ""}
 
 ---
 

--- a/test/tls-rpt.test.ts
+++ b/test/tls-rpt.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { analyzeTlsRpt } from "../src/analyzers/tls-rpt.js";
+
+// Mock the DNS client — imported by the analyzer
+vi.mock("../src/dns/client.js", () => ({
+  queryTxt: vi.fn(),
+  queryMx: vi.fn(),
+}));
+
+import { queryTxt } from "../src/dns/client.js";
+
+const mockQueryTxt = vi.mocked(queryTxt);
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("analyzeTlsRpt", () => {
+  it("returns info when no TXT record exists", async () => {
+    mockQueryTxt.mockResolvedValue(null);
+    const result = await analyzeTlsRpt("example.com");
+    expect(result.status).toBe("info");
+    expect(result.record).toBeNull();
+    expect(result.tags).toBeNull();
+    expect(
+      result.validations.some(
+        (v) => v.status === "info" && v.message.includes("No TLS-RPT record"),
+      ),
+    ).toBe(true);
+  });
+
+  it("queries the correct DNS name (_smtp._tls.<domain>)", async () => {
+    mockQueryTxt.mockResolvedValue(null);
+    await analyzeTlsRpt("example.com");
+    expect(mockQueryTxt).toHaveBeenCalledWith("_smtp._tls.example.com");
+  });
+
+  it("returns pass for a valid record with mailto rua", async () => {
+    mockQueryTxt.mockResolvedValue({
+      entries: ["v=TLSRPTv1; rua=mailto:tlsrpt@example.com"],
+      raw: "v=TLSRPTv1; rua=mailto:tlsrpt@example.com",
+    });
+    const result = await analyzeTlsRpt("example.com");
+    expect(result.status).toBe("pass");
+    expect(result.record).toBe("v=TLSRPTv1; rua=mailto:tlsrpt@example.com");
+    expect(result.tags?.rua).toBe("mailto:tlsrpt@example.com");
+    expect(
+      result.validations.some(
+        (v) => v.status === "info" && v.message.includes("v=TLSRPTv1"),
+      ),
+    ).toBe(true);
+    expect(
+      result.validations.some(
+        (v) => v.status === "info" && v.message.includes("tlsrpt@example.com"),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns pass for a valid record with https rua", async () => {
+    mockQueryTxt.mockResolvedValue({
+      entries: ["v=TLSRPTv1; rua=https://example.com/tlsrpt"],
+      raw: "v=TLSRPTv1; rua=https://example.com/tlsrpt",
+    });
+    const result = await analyzeTlsRpt("example.com");
+    expect(result.status).toBe("pass");
+  });
+
+  it("warns when rua= tag is missing", async () => {
+    mockQueryTxt.mockResolvedValue({
+      entries: ["v=TLSRPTv1"],
+      raw: "v=TLSRPTv1",
+    });
+    const result = await analyzeTlsRpt("example.com");
+    expect(result.status).toBe("warn");
+    expect(
+      result.validations.some(
+        (v) => v.status === "warn" && v.message.includes("rua="),
+      ),
+    ).toBe(true);
+  });
+
+  it("warns for multiple TLS-RPT records", async () => {
+    mockQueryTxt.mockResolvedValue({
+      entries: [
+        "v=TLSRPTv1; rua=mailto:a@example.com",
+        "v=TLSRPTv1; rua=mailto:b@example.com",
+      ],
+      raw: "v=TLSRPTv1; rua=mailto:a@example.com v=TLSRPTv1; rua=mailto:b@example.com",
+    });
+    const result = await analyzeTlsRpt("example.com");
+    expect(result.status).toBe("warn");
+    expect(
+      result.validations.some(
+        (v) =>
+          v.status === "warn" &&
+          v.message.includes("2 TLS-RPT records") &&
+          v.message.includes("exactly one"),
+      ),
+    ).toBe(true);
+  });
+
+  it("warns for unrelated TXT records alongside TLSRPTv1", async () => {
+    mockQueryTxt.mockResolvedValue({
+      entries: [
+        "v=TLSRPTv1; rua=mailto:r@example.com",
+        "some-unrelated-record",
+      ],
+      raw: "v=TLSRPTv1; rua=mailto:r@example.com some-unrelated-record",
+    });
+    const result = await analyzeTlsRpt("example.com");
+    expect(
+      result.validations.some(
+        (v) => v.status === "warn" && v.message.includes("unrelated TXT"),
+      ),
+    ).toBe(true);
+  });
+
+  it("warns when TXT records exist but none start with v=TLSRPTv1", async () => {
+    mockQueryTxt.mockResolvedValue({
+      entries: ["v=spf1 include:example.com ~all"],
+      raw: "v=spf1 include:example.com ~all",
+    });
+    const result = await analyzeTlsRpt("example.com");
+    expect(result.status).toBe("warn");
+    expect(
+      result.validations.some(
+        (v) => v.status === "warn" && v.message.includes("v=TLSRPTv1"),
+      ),
+    ).toBe(true);
+  });
+
+  it("warns for rua= destinations not in mailto:/https:// format", async () => {
+    mockQueryTxt.mockResolvedValue({
+      entries: ["v=TLSRPTv1; rua=ftp://invalid.example.com"],
+      raw: "v=TLSRPTv1; rua=ftp://invalid.example.com",
+    });
+    const result = await analyzeTlsRpt("example.com");
+    expect(result.status).toBe("warn");
+    expect(
+      result.validations.some(
+        (v) =>
+          v.status === "warn" && v.message.includes("mailto:/https:// format"),
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts multiple comma-separated rua destinations", async () => {
+    mockQueryTxt.mockResolvedValue({
+      entries: [
+        "v=TLSRPTv1; rua=mailto:a@example.com,https://example.com/report",
+      ],
+      raw: "v=TLSRPTv1; rua=mailto:a@example.com,https://example.com/report",
+    });
+    const result = await analyzeTlsRpt("example.com");
+    expect(result.status).toBe("pass");
+    expect(
+      result.validations.some(
+        (v) =>
+          v.status === "info" &&
+          v.message.includes("Report destinations") &&
+          v.message.includes("a@example.com"),
+      ),
+    ).toBe(true);
+  });
+
+  it("is case-insensitive for v=TLSRPTv1", async () => {
+    mockQueryTxt.mockResolvedValue({
+      entries: ["V=TLSRPTV1; rua=mailto:r@example.com"],
+      raw: "V=TLSRPTV1; rua=mailto:r@example.com",
+    });
+    const result = await analyzeTlsRpt("example.com");
+    expect(result.status).toBe("pass");
+  });
+});


### PR DESCRIPTION
## Summary

- Implements RFC 8460 SMTP TLS Reporting as a new informational analyzer (`src/analyzers/tls-rpt.ts`)
- Queries `_smtp._tls.<domain>` for `v=TLSRPTv1` records; validates `rua=` tag format (mailto:/https:// only), warns on missing rua, multiple records, and unrelated TXT entries
- TLS-RPT is **informational only** — does not affect the letter grade
- Wired into orchestrator, scoring summaries, HTML card (`renderTlsRptCard`), markdown report, and SSE streaming
- 10 Vitest unit tests covering all validation paths

## Test plan

- [ ] `npm test` passes (10 new TLS-RPT tests)
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] HTML report shows TLS-RPT card for domains with a record (e.g. `_smtp._tls.google.com`)
- [ ] HTML report shows "Not configured" card for domains without a record
- [ ] Markdown report (`Accept: text/markdown`) includes TLS-RPT section
- [ ] JSON API includes `protocols.tls_rpt` field

Closes #235

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWjVsDVDNFjWvdMmwVFGdT)_