### PR TITLE
feat: MX/MTA-STS consistency check (RFC 8461 §3.4)

### DIFF
--- a/src/analyzers/mx-mta-sts-consistency.ts
+++ b/src/analyzers/mx-mta-sts-consistency.ts
@@ -1,17 +1,8 @@
 import type { MtaStsResult, MxResult, Validation } from "./types.js";
 
-/**
- * Returns true when the MX hostname is covered by the given MTA-STS pattern.
- *
- * RFC 8461 §3.4 defines the wildcard rule:
- *   - `*.example.com` matches `mail.example.com` but NOT `mail.sub.example.com`
- *     (only one label may be wildcarded).
- *   - Exact hostname matches work without a wildcard.
- * Trailing dots (FQDN notation) are stripped before comparison.
- */
 export function mxMatchesPattern(mx: string, pattern: string): boolean {
-  const hParts = mx.toLowerCase().replace(/\.$/,  "").split(".");
-  const pParts = pattern.toLowerCase().replace(/\.$/,  "").split(".");
+  const hParts = mx.toLowerCase().replace(/\.$/, "").split(".");
+  const pParts = pattern.toLowerCase().replace(/\.$/, "").split(".");
   if (pParts[0] === "*") {
     // RFC 8461 §3.4: wildcard covers exactly one label (*.example.com matches
     // mail.example.com but not mail.sub.example.com).
@@ -22,16 +13,6 @@ export function mxMatchesPattern(mx: string, pattern: string): boolean {
   return hParts.join(".") === pParts.join(".");
 }
 
-/**
- * Cross-checks MX hostnames against the MTA-STS policy `mx` patterns.
- *
- * Only runs when:
- *   - At least one MX record exists
- *   - An MTA-STS policy is present (not null)
- *   - The policy has at least one `mx` pattern
- *
- * Returns Validation[] entries to be appended to the MTA-STS result.
- */
 export function checkMxMtaStsConsistency(
   mx: MxResult,
   mtaSts: MtaStsResult,

--- a/src/analyzers/mx-mta-sts-consistency.ts
+++ b/src/analyzers/mx-mta-sts-consistency.ts
@@ -1,0 +1,73 @@
+import type { MtaStsResult, MxResult, Validation } from "./types.js";
+
+/**
+ * Returns true when the MX hostname is covered by the given MTA-STS pattern.
+ *
+ * RFC 8461 §3.4 defines the wildcard rule:
+ *   - `*.example.com` matches `mail.example.com` but NOT `mail.sub.example.com`
+ *     (only one label may be wildcarded).
+ *   - Exact hostname matches work without a wildcard.
+ * Trailing dots (FQDN notation) are stripped before comparison.
+ */
+export function mxMatchesPattern(mx: string, pattern: string): boolean {
+  const h = mx.toLowerCase().replace(/\.$/, "");
+  const p = pattern.toLowerCase().replace(/\.$/, "");
+  if (p.startsWith("*.")) {
+    const suffix = p.slice(1); // ".example.com"
+    // h must end with the suffix AND the part before the suffix must not
+    // contain a dot (i.e. exactly one label is wildcarded).
+    return (
+      h.endsWith(suffix) &&
+      h.slice(0, h.length - suffix.length).indexOf(".") === -1
+    );
+  }
+  return h === p;
+}
+
+/**
+ * Cross-checks MX hostnames against the MTA-STS policy `mx` patterns.
+ *
+ * Only runs when:
+ *   - At least one MX record exists
+ *   - An MTA-STS policy is present (not null)
+ *   - The policy has at least one `mx` pattern
+ *
+ * Returns Validation[] entries to be appended to the MTA-STS result.
+ */
+export function checkMxMtaStsConsistency(
+  mx: MxResult,
+  mtaSts: MtaStsResult,
+): Validation[] {
+  if (mx.records.length === 0) return [];
+  if (!mtaSts.policy) return [];
+  if (mtaSts.policy.mx.length === 0) return [];
+
+  const validations: Validation[] = [];
+  const patterns = mtaSts.policy.mx;
+  const uncovered: string[] = [];
+
+  for (const record of mx.records) {
+    const covered = patterns.some((pattern) =>
+      mxMatchesPattern(record.exchange, pattern),
+    );
+    if (!covered) {
+      uncovered.push(record.exchange);
+    }
+  }
+
+  if (uncovered.length > 0) {
+    for (const host of uncovered) {
+      validations.push({
+        status: "warn",
+        message: `MX host ${host} is not covered by any MTA-STS policy mx pattern`,
+      });
+    }
+  } else {
+    validations.push({
+      status: "pass",
+      message: "All MX hosts are covered by MTA-STS policy mx patterns",
+    });
+  }
+
+  return validations;
+}

--- a/src/analyzers/mx-mta-sts-consistency.ts
+++ b/src/analyzers/mx-mta-sts-consistency.ts
@@ -10,18 +10,16 @@ import type { MtaStsResult, MxResult, Validation } from "./types.js";
  * Trailing dots (FQDN notation) are stripped before comparison.
  */
 export function mxMatchesPattern(mx: string, pattern: string): boolean {
-  const h = mx.toLowerCase().replace(/\.$/, "");
-  const p = pattern.toLowerCase().replace(/\.$/, "");
-  if (p.startsWith("*.")) {
-    const suffix = p.slice(1); // ".example.com"
-    // h must end with the suffix AND the part before the suffix must not
-    // contain a dot (i.e. exactly one label is wildcarded).
-    return (
-      h.endsWith(suffix) &&
-      h.slice(0, h.length - suffix.length).indexOf(".") === -1
-    );
+  const hParts = mx.toLowerCase().replace(/\.$/,  "").split(".");
+  const pParts = pattern.toLowerCase().replace(/\.$/,  "").split(".");
+  if (pParts[0] === "*") {
+    // RFC 8461 §3.4: wildcard covers exactly one label (*.example.com matches
+    // mail.example.com but not mail.sub.example.com).
+    const pTail = pParts.slice(1);
+    if (hParts.length !== pTail.length + 1) return false;
+    return hParts.slice(1).join(".") === pTail.join(".");
   }
-  return h === p;
+  return hParts.join(".") === pParts.join(".");
 }
 
 /**

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -4,6 +4,7 @@ import { analyzeDkim } from "./analyzers/dkim.js";
 import { analyzeDmarc } from "./analyzers/dmarc.js";
 import { analyzeMtaSts } from "./analyzers/mta-sts.js";
 import { analyzeMx } from "./analyzers/mx.js";
+import { checkMxMtaStsConsistency } from "./analyzers/mx-mta-sts-consistency.js";
 import { analyzeSecurityTxt } from "./analyzers/security-txt.js";
 import { analyzeSpf } from "./analyzers/spf.js";
 import { analyzeTlsRpt } from "./analyzers/tls-rpt.js";
@@ -44,6 +45,23 @@ async function buildScanResult(
   domain: string,
   protocols: ScanResult["protocols"],
 ): Promise<ScanResult> {
+  // Cross-check MX hosts against MTA-STS policy patterns (RFC 8461 §3.4)
+  const consistencyValidations = checkMxMtaStsConsistency(
+    protocols.mx,
+    protocols.mta_sts,
+  );
+  if (consistencyValidations.length > 0) {
+    protocols.mta_sts.validations.push(...consistencyValidations);
+    // Re-derive status in case new warn validations were added
+    const hasFailure = protocols.mta_sts.validations.some(
+      (v) => v.status === "fail",
+    );
+    const hasWarn = protocols.mta_sts.validations.some(
+      (v) => v.status === "warn",
+    );
+    protocols.mta_sts.status = hasFailure ? "fail" : hasWarn ? "warn" : "pass";
+  }
+
   const breakdown = computeGradeBreakdown(protocols);
 
   // Easter egg: S grade for A+ domains advertising dmarc.mx

--- a/test/mx-mta-sts-consistency.test.ts
+++ b/test/mx-mta-sts-consistency.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import {
+  checkMxMtaStsConsistency,
+  mxMatchesPattern,
+} from "../src/analyzers/mx-mta-sts-consistency.js";
+import type { MtaStsResult, MxResult } from "../src/analyzers/types.js";
+
+// ─── mxMatchesPattern unit tests ────────────────────────────────────────────
+
+describe("mxMatchesPattern", () => {
+  it("matches exact hostname (case-insensitive)", () => {
+    expect(mxMatchesPattern("mail.example.com", "mail.example.com")).toBe(true);
+    expect(mxMatchesPattern("MAIL.example.com", "mail.example.com")).toBe(true);
+  });
+
+  it("does not match a different exact hostname", () => {
+    expect(mxMatchesPattern("smtp.example.com", "mail.example.com")).toBe(
+      false,
+    );
+  });
+
+  it("wildcard *.example.com covers mail.example.com", () => {
+    expect(mxMatchesPattern("mail.example.com", "*.example.com")).toBe(true);
+  });
+
+  it("wildcard *.example.com does NOT cover mail.sub.example.com (RFC 8461 §3.4)", () => {
+    expect(mxMatchesPattern("mail.sub.example.com", "*.example.com")).toBe(
+      false,
+    );
+  });
+
+  it("wildcard *.example.com does NOT cover example.com itself", () => {
+    expect(mxMatchesPattern("example.com", "*.example.com")).toBe(false);
+  });
+
+  it("strips trailing dots (FQDN notation) before comparing", () => {
+    expect(mxMatchesPattern("mail.example.com.", "*.example.com")).toBe(true);
+    expect(mxMatchesPattern("mail.example.com", "*.example.com.")).toBe(true);
+    expect(mxMatchesPattern("mail.example.com.", "mail.example.com.")).toBe(
+      true,
+    );
+  });
+
+  it("wildcard pattern is case-insensitive", () => {
+    expect(mxMatchesPattern("MAIL.EXAMPLE.COM", "*.example.com")).toBe(true);
+  });
+});
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeMx(exchanges: string[]): MxResult {
+  return {
+    status: "info",
+    records: exchanges.map((e, i) => ({ priority: (i + 1) * 10, exchange: e })),
+    providers: [],
+    validations: [],
+  };
+}
+
+function makeMtaSts(policyMx: string[] | null, mode = "enforce"): MtaStsResult {
+  return {
+    status: "pass",
+    dns_record: "v=STSv1; id=20240101",
+    policy:
+      policyMx !== null
+        ? { version: "STSv1", mode, mx: policyMx, max_age: 86400 }
+        : null,
+    validations: [],
+  };
+}
+
+// ─── checkMxMtaStsConsistency ────────────────────────────────────────────────
+
+describe("checkMxMtaStsConsistency", () => {
+  it("returns pass validation when all MX hosts are covered", () => {
+    const mx = makeMx(["mail.example.com", "smtp.example.com"]);
+    const mtaSts = makeMtaSts(["*.example.com"]);
+
+    const result = checkMxMtaStsConsistency(mx, mtaSts);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe("pass");
+    expect(result[0].message).toMatch(/all mx hosts are covered/i);
+  });
+
+  it("returns warn for each uncovered MX host", () => {
+    const mx = makeMx(["mail.example.com", "smtp.other.com"]);
+    const mtaSts = makeMtaSts(["*.example.com"]);
+
+    const result = checkMxMtaStsConsistency(mx, mtaSts);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe("warn");
+    expect(result[0].message).toContain("smtp.other.com");
+  });
+
+  it("returns a warn per uncovered host when multiple are missing", () => {
+    const mx = makeMx(["a.other.com", "b.other.com"]);
+    const mtaSts = makeMtaSts(["*.example.com"]);
+
+    const result = checkMxMtaStsConsistency(mx, mtaSts);
+
+    expect(result).toHaveLength(2);
+    expect(result.every((v) => v.status === "warn")).toBe(true);
+    const messages = result.map((v) => v.message);
+    expect(messages.some((m) => m.includes("a.other.com"))).toBe(true);
+    expect(messages.some((m) => m.includes("b.other.com"))).toBe(true);
+  });
+
+  it("wildcard *.example.com covers mail.example.com but not mail.sub.example.com", () => {
+    const mx = makeMx(["mail.example.com", "mail.sub.example.com"]);
+    const mtaSts = makeMtaSts(["*.example.com"]);
+
+    const result = checkMxMtaStsConsistency(mx, mtaSts);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe("warn");
+    expect(result[0].message).toContain("mail.sub.example.com");
+  });
+
+  it("returns empty array when no MTA-STS policy is present", () => {
+    const mx = makeMx(["mail.example.com"]);
+    const mtaSts = makeMtaSts(null);
+
+    const result = checkMxMtaStsConsistency(mx, mtaSts);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns empty array when no MX records exist", () => {
+    const mx = makeMx([]);
+    const mtaSts = makeMtaSts(["*.example.com"]);
+
+    const result = checkMxMtaStsConsistency(mx, mtaSts);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns empty array when policy has no mx patterns", () => {
+    const mx = makeMx(["mail.example.com"]);
+    const mtaSts = makeMtaSts([]);
+
+    const result = checkMxMtaStsConsistency(mx, mtaSts);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("MX host covered by exact pattern in policy passes", () => {
+    const mx = makeMx(["mail.example.com"]);
+    const mtaSts = makeMtaSts(["mail.example.com"]);
+
+    const result = checkMxMtaStsConsistency(mx, mtaSts);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe("pass");
+  });
+
+  it("mix of exact and wildcard patterns can cover multiple MX hosts", () => {
+    const mx = makeMx(["mail.example.com", "smtp.other.org"]);
+    const mtaSts = makeMtaSts(["*.example.com", "smtp.other.org"]);
+
+    const result = checkMxMtaStsConsistency(mx, mtaSts);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe("pass");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/analyzers/mx-mta-sts-consistency.ts` with `mxMatchesPattern()` (RFC 8461 §3.4 wildcard semantics) and `checkMxMtaStsConsistency()` that compares each MX hostname against the MTA-STS policy `mx` patterns
- Wires the cross-check into `buildScanResult()` in `src/orchestrator.ts` — runs after all analyzers resolve, appends validations to `result.protocols.mta_sts.validations`, and re-derives the MTA-STS status if new `warn` entries are added
- Guard conditions: only runs when MX records exist AND an MTA-STS policy is present AND the policy has at least one `mx` pattern

**Wildcard rule (RFC 8461 §3.4):** `*.example.com` covers `mail.example.com` but not `mail.sub.example.com` (exactly one label wildcarded). Trailing FQDN dots are stripped before comparison.

**Validation messages added:**
- `warn`: `MX host <host> is not covered by any MTA-STS policy mx pattern` — one per uncovered host
- `pass`: `All MX hosts are covered by MTA-STS policy mx patterns` — when all are covered

## Test plan

- [x] `npm test` — 16 new tests in `test/mx-mta-sts-consistency.test.ts`, all pass; pre-existing failure is an unrelated live-network integration test (failing before this PR too)
- [x] `npm run typecheck` — clean
- [x] `npm run lint:fix` — no fixes needed

New test cases cover:
- All MX covered → single `pass` validation
- One MX uncovered → `warn` with that hostname
- Multiple MX uncovered → one `warn` per host
- Wildcard `*.example.com` covers `mail.example.com` but not `mail.sub.example.com`
- No MTA-STS policy → no check run (empty array)
- No MX records → no check run (empty array)
- Policy with no `mx` patterns → no check run (empty array)
- Exact pattern match → `pass`
- Mix of exact + wildcard patterns covering multiple MX hosts → `pass`

Closes #237

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWjVsDVDNFjWvdMmwVFGdT)_