### PR TITLE
fix: throttle Google Chat webhooks to 1 msg/s, retry on 429

### DIFF
--- a/src/webhooks/dispatcher.ts
+++ b/src/webhooks/dispatcher.ts
@@ -33,11 +33,16 @@ export interface DispatchResult {
   event_id: string;
 }
 
+const RETRY_DELAY_MS = 2000;
+
 export interface DispatchOptions {
   // Override for tests so signatures and event timestamps are deterministic.
   now?: number;
   // Override for tests so generated event ids are deterministic.
   eventId?: string;
+  // Override the 429-retry backoff delay (ms). Pass 0 in tests to skip the
+  // real 2-second wait without needing fake timers.
+  retryDelayMs?: number;
 }
 
 export async function dispatchWebhook(
@@ -103,13 +108,35 @@ export async function dispatchWebhook(
       body,
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
-    result = {
-      ok: response.ok,
-      status: response.status,
-      error: response.ok ? null : `HTTP ${response.status}`,
-      attempted_at: now,
-      event_id: eventId,
-    };
+
+    if (response.status === 429) {
+      // One retry after a fixed backoff — Google Chat (and other platforms)
+      // return 429 when the per-space rate limit is exceeded. A single retry
+      // with a short pause clears the leaky-bucket window without looping.
+      const delay = options.retryDelayMs ?? RETRY_DELAY_MS;
+      await new Promise<void>((r) => setTimeout(r, delay));
+      const retry = await fetch(webhook.url, {
+        method: "POST",
+        headers,
+        body,
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+      result = {
+        ok: retry.ok,
+        status: retry.status,
+        error: retry.ok ? null : `HTTP ${retry.status}`,
+        attempted_at: now,
+        event_id: eventId,
+      };
+    } else {
+      result = {
+        ok: response.ok,
+        status: response.status,
+        error: response.ok ? null : `HTTP ${response.status}`,
+        attempted_at: now,
+        event_id: eventId,
+      };
+    }
   } catch (err) {
     result = {
       ok: false,

--- a/src/webhooks/formats/index.ts
+++ b/src/webhooks/formats/index.ts
@@ -50,6 +50,20 @@ export function getFormatAdapter(format: WebhookFormat): FormatAdapter {
   return ADAPTERS[format];
 }
 
+// Per-format rate limit for outbound dispatches. Google Chat incoming webhooks
+// are capped at ~1 msg/second per space; the 10% buffer avoids hitting the
+// edge. `null` means "no enforced delay between sends" — the receiver (or a
+// future per-format config) handles backpressure itself.
+export const FORMAT_RATE_LIMIT_MS: Record<WebhookFormat, number | null> = {
+  raw: null, // enterprise receivers handle their own rate limits
+  slack: null, // Slack is more generous; throttle separately if needed
+  google_chat: 1100, // 1 msg/s cap + 10% buffer
+};
+
+export function getFormatRateLimitMs(format: WebhookFormat): number | null {
+  return FORMAT_RATE_LIMIT_MS[format];
+}
+
 export function isWebhookFormat(value: unknown): value is WebhookFormat {
   return (
     typeof value === "string" &&

--- a/src/webhooks/triggers.ts
+++ b/src/webhooks/triggers.ts
@@ -1,6 +1,8 @@
 import type { BulkResultEntry } from "../api/bulk-scan.js";
 import { CANONICAL_ORIGIN } from "../api/catalog.js";
+import { getWebhookForUser } from "../db/webhooks.js";
 import { dispatchWebhook, type ScanCompletedData } from "./dispatcher.js";
+import { getFormatRateLimitMs } from "./formats/index.js";
 
 // Convenience wrapper used by every scan trigger (dashboard / cron / bulk).
 // Centralizes the `scan.completed` payload shape so adding a field later
@@ -38,16 +40,16 @@ export async function fireScanCompletedWebhook(
 const WEBHOOK_BATCH_SIZE = 10;
 
 // Fires one `scan.completed` event per successfully-scanned entry in a bulk
-// outcome. Best-effort and bounded-parallel — callers should hand this to
-// `waitUntil` so it never blocks the response. Queued/invalid/error entries
-// are skipped (no scan happened, nothing to report).
+// outcome. Best-effort — callers should hand this to `waitUntil` so it never
+// blocks the response. Queued/invalid/error entries are skipped (no scan
+// happened, nothing to report).
 //
-// Parallel matters: a serial loop over N webhooks accumulates wall-clock
-// time inside the waitUntil budget. Once the runtime decides to recycle the
-// isolate, every pending fetch is aborted with the literal "operation
-// aborted due to timeout" message — including ones whose request bytes
-// already left and were acked by the chat platform. Batching keeps total
-// wall-clock under budget while still capping the burst per receiver.
+// Dispatch strategy is format-aware:
+//   - Rate-limited formats (google_chat: 1 msg/s): serial loop with a
+//     per-send delay so we never exceed the platform cap.
+//   - Unlimited formats (raw, slack): bounded-parallel batches of
+//     WEBHOOK_BATCH_SIZE keep total wall-clock under the waitUntil budget
+//     while capping burst per receiver.
 export async function fireBulkScanWebhooks(
   db: D1Database,
   userId: string,
@@ -58,19 +60,44 @@ export async function fireBulkScanWebhooks(
     (entry): entry is BulkResultEntry & { grade: string } =>
       entry.status === "scanned" && !!entry.grade,
   );
-  for (let i = 0; i < toFire.length; i += WEBHOOK_BATCH_SIZE) {
-    const batch = toFire.slice(i, i + WEBHOOK_BATCH_SIZE);
-    await Promise.allSettled(
-      batch.map((entry) =>
-        fireScanCompletedWebhook(db, userId, {
-          domain: entry.domain,
-          grade: entry.grade,
-          // Bulk scans don't surface a stable scan_history.id; receivers can
-          // re-fetch by domain via /api/domain/:name/history.
-          scanId: entry.domain,
-          trigger,
-        }),
-      ),
-    );
+
+  // Look up the user's webhook format once to decide the dispatch strategy.
+  const webhook = await getWebhookForUser(db, userId);
+  const rateLimitMs = webhook ? getFormatRateLimitMs(webhook.format) : null;
+
+  if (rateLimitMs !== null) {
+    // Serial path: rate-limited formats (e.g. google_chat at ~1 msg/s).
+    // Insert a delay BETWEEN sends (not before the first one) so we respect
+    // the platform cap without adding unnecessary latency to the first event.
+    for (let i = 0; i < toFire.length; i++) {
+      if (i > 0) await new Promise<void>((r) => setTimeout(r, rateLimitMs));
+      await fireScanCompletedWebhook(db, userId, {
+        domain: toFire[i].domain,
+        grade: toFire[i].grade,
+        // Bulk scans don't surface a stable scan_history.id; receivers can
+        // re-fetch by domain via /api/domain/:name/history.
+        scanId: toFire[i].domain,
+        trigger,
+      });
+    }
+  } else {
+    // Parallel path: unbounded-rate formats use bounded concurrency batches.
+    // Parallel matters: a serial loop over N webhooks accumulates wall-clock
+    // time inside the waitUntil budget. Once the runtime decides to recycle
+    // the isolate, every pending fetch is aborted. Batching keeps total
+    // wall-clock under budget while still capping the burst per receiver.
+    for (let i = 0; i < toFire.length; i += WEBHOOK_BATCH_SIZE) {
+      const batch = toFire.slice(i, i + WEBHOOK_BATCH_SIZE);
+      await Promise.allSettled(
+        batch.map((entry) =>
+          fireScanCompletedWebhook(db, userId, {
+            domain: entry.domain,
+            grade: entry.grade,
+            scanId: entry.domain,
+            trigger,
+          }),
+        ),
+      );
+    }
   }
 }

--- a/test/webhook-throttle.test.ts
+++ b/test/webhook-throttle.test.ts
@@ -1,0 +1,195 @@
+// Tests for Google Chat webhook rate-limit throttling (issue #242).
+//
+// Google Chat incoming webhooks cap at ~1 msg/second per space. Without
+// throttling, fireBulkScanWebhooks batches 10 concurrent POSTs and causes an
+// 87.5% 429 failure rate during cron rescans.
+//
+// Strategy: mock dispatchWebhook entirely so tests only exercise the
+// scheduling logic in fireBulkScanWebhooks. Fake timers make the 1100ms
+// inter-send delays free in CI.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { BulkResultEntry } from "../src/api/bulk-scan.js";
+
+// ---------------------------------------------------------------------------
+// Module-level mocks — declared before any dynamic import so Vitest can hoist
+// them before module evaluation.
+// ---------------------------------------------------------------------------
+
+const getWebhookForUserMock = vi.fn();
+vi.mock("../src/db/webhooks.js", () => ({
+  getWebhookForUser: getWebhookForUserMock,
+}));
+
+// Mock dispatchWebhook so scheduling tests don't touch HTTP machinery.
+const dispatchWebhookMock = vi.fn();
+vi.mock("../src/webhooks/dispatcher.js", () => ({
+  dispatchWebhook: dispatchWebhookMock,
+}));
+
+// Import after mocks are declared.
+const { fireBulkScanWebhooks } = await import("../src/webhooks/triggers.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const GOOGLE_CHAT_URL =
+  "https://chat.googleapis.com/v1/spaces/X/messages?key=k&token=t";
+
+function makeGoogleChatWebhook() {
+  return {
+    id: 1,
+    user_id: "u1",
+    url: GOOGLE_CHAT_URL,
+    secret: null,
+    format: "google_chat" as const,
+    created_at: 0,
+  };
+}
+
+function makeResults(n: number): BulkResultEntry[] {
+  return Array.from({ length: n }, (_, i) => ({
+    domain: `domain${i}.com`,
+    status: "scanned" as const,
+    grade: "A",
+  }));
+}
+
+const fakeDb = {} as D1Database;
+
+function okDispatch() {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    error: null,
+    attempted_at: 0,
+    event_id: "evt_x",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Google Chat — serial throttled dispatch
+// ---------------------------------------------------------------------------
+
+describe("fireBulkScanWebhooks — Google Chat serial dispatch", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    getWebhookForUserMock.mockResolvedValue(makeGoogleChatWebhook());
+    dispatchWebhookMock.mockImplementation(okDispatch);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    getWebhookForUserMock.mockReset();
+    dispatchWebhookMock.mockReset();
+  });
+
+  it("dispatches all N entries for a google_chat webhook", async () => {
+    const N = 10;
+    const promise = fireBulkScanWebhooks(fakeDb, "u1", makeResults(N), "cron");
+    // Advance time past all inter-send delays: (N-1) × 1100ms.
+    await vi.advanceTimersByTimeAsync(15_000);
+    await promise;
+
+    expect(dispatchWebhookMock).toHaveBeenCalledTimes(N);
+  });
+
+  it("inserts a delay of at least 1100ms between consecutive sends", async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    const N = 4;
+    const promise = fireBulkScanWebhooks(fakeDb, "u1", makeResults(N), "cron");
+    await vi.advanceTimersByTimeAsync(10_000);
+    await promise;
+
+    expect(dispatchWebhookMock).toHaveBeenCalledTimes(N);
+
+    // Exactly N-1 inter-send timeouts, each ≥ 1100ms.
+    const delays = setTimeoutSpy.mock.calls
+      .map(([, ms]) => ms as number)
+      .filter((ms) => ms >= 1000);
+
+    expect(delays.length).toBe(N - 1);
+    for (const ms of delays) {
+      expect(ms).toBeGreaterThanOrEqual(1100);
+    }
+  });
+
+  it("does not dispatch non-scanned entries", async () => {
+    const results: BulkResultEntry[] = [
+      { domain: "ok.com", status: "scanned", grade: "A" },
+      { domain: "q.com", status: "queued" },
+      { domain: "bad.com", status: "invalid", error: "Not valid" },
+    ];
+    const promise = fireBulkScanWebhooks(fakeDb, "u1", results, "cron");
+    await vi.advanceTimersByTimeAsync(5_000);
+    await promise;
+
+    expect(dispatchWebhookMock).toHaveBeenCalledTimes(1);
+    expect(dispatchWebhookMock.mock.calls[0][2].data.domain).toBe("ok.com");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Raw format — parallel batch dispatch (no throttle)
+// ---------------------------------------------------------------------------
+
+describe("fireBulkScanWebhooks — raw format uses parallel dispatch", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    getWebhookForUserMock.mockReset();
+    dispatchWebhookMock.mockReset();
+  });
+
+  beforeEach(() => {
+    getWebhookForUserMock.mockResolvedValue({
+      id: 2,
+      user_id: "u1",
+      url: "https://hooks.example.com/recv",
+      secret: "shhh",
+      format: "raw" as const,
+      created_at: 0,
+    });
+  });
+
+  it("dispatches raw webhooks concurrently (maxActive > 1 within a batch)", async () => {
+    let active = 0;
+    let maxActive = 0;
+    dispatchWebhookMock.mockImplementation(async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      for (let i = 0; i < 5; i++) await Promise.resolve();
+      active--;
+      return {
+        ok: true,
+        status: 200,
+        error: null,
+        attempted_at: 0,
+        event_id: "e",
+      };
+    });
+
+    const N = 8;
+    await fireBulkScanWebhooks(fakeDb, "u1", makeResults(N), "cron");
+
+    expect(dispatchWebhookMock).toHaveBeenCalledTimes(N);
+    expect(maxActive).toBeGreaterThan(1);
+  });
+
+  it("does not insert any rate-limit delays for raw format", async () => {
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    dispatchWebhookMock.mockImplementation(okDispatch);
+
+    await fireBulkScanWebhooks(fakeDb, "u1", makeResults(5), "cron");
+
+    vi.useRealTimers();
+
+    const throttleDelays = setTimeoutSpy.mock.calls
+      .map(([, ms]) => ms as number)
+      .filter((ms) => ms >= 1000);
+    expect(throttleDelays.length).toBe(0);
+  });
+});

--- a/test/webhooks-dispatcher.test.ts
+++ b/test/webhooks-dispatcher.test.ts
@@ -320,4 +320,117 @@ describe("webhooks/dispatcher.dispatchWebhook", () => {
     expect(deliveries[0].ok).toBe(1);
     expect(deliveries[0].event_type).toBe("scan.completed");
   });
+
+  it("retries once after a 429 and records the retry result as ok=true", async () => {
+    webhooksByUser.set("u1", {
+      id: 30,
+      user_id: "u1",
+      url: "https://chat.googleapis.com/v1/spaces/X/messages?key=k",
+      secret: null,
+      format: "google_chat",
+      created_at: 0,
+    });
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("rate limited", { status: 429 }))
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    const db = makeDb();
+
+    // retryDelayMs: 0 skips the real 2s backoff so the test is instant.
+    const result = await dispatchWebhook(
+      db,
+      "u1",
+      {
+        type: "scan.completed",
+        data: {
+          domain: "example.com",
+          grade: "A",
+          scan_id: "scn_1",
+          trigger: "cron",
+          report_url: "https://dmarc.mx/check?domain=example.com",
+        },
+      },
+      { retryDelayMs: 0 },
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(result?.ok).toBe(true);
+    expect(result?.status).toBe(200);
+    // Only one delivery row recorded — the final (post-retry) outcome.
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0].ok).toBe(1);
+    expect(deliveries[0].status_code).toBe(200);
+  });
+
+  it("records ok=false when the retry after 429 also fails", async () => {
+    webhooksByUser.set("u1", {
+      id: 31,
+      user_id: "u1",
+      url: "https://chat.googleapis.com/v1/spaces/X/messages?key=k",
+      secret: null,
+      format: "google_chat",
+      created_at: 0,
+    });
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("still limited", { status: 429 }));
+    const db = makeDb();
+
+    // retryDelayMs: 0 skips the real 2s backoff so the test is instant.
+    const result = await dispatchWebhook(
+      db,
+      "u1",
+      {
+        type: "scan.completed",
+        data: {
+          domain: "example.com",
+          grade: "B",
+          scan_id: "scn_2",
+          trigger: "cron",
+          report_url: "https://dmarc.mx/check?domain=example.com",
+        },
+      },
+      { retryDelayMs: 0 },
+    );
+
+    // Exactly 2 fetch calls — initial + one retry, no further recursion.
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(result?.ok).toBe(false);
+    expect(result?.status).toBe(429);
+    expect(result?.error).toBe("HTTP 429");
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0].ok).toBe(0);
+  });
+
+  it("does NOT retry on non-429 errors (e.g. 500)", async () => {
+    webhooksByUser.set("u1", {
+      id: 32,
+      user_id: "u1",
+      url: "https://chat.googleapis.com/v1/spaces/X/messages?key=k",
+      secret: null,
+      format: "google_chat",
+      created_at: 0,
+    });
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("server error", { status: 500 }));
+    const db = makeDb();
+
+    const result = await dispatchWebhook(db, "u1", {
+      type: "scan.completed",
+      data: {
+        domain: "example.com",
+        grade: "F",
+        scan_id: "scn_3",
+        trigger: "cron",
+        report_url: "https://dmarc.mx/check?domain=example.com",
+      },
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(result?.ok).toBe(false);
+    expect(result?.status).toBe(500);
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0].ok).toBe(0);
+  });
 });

--- a/test/webhooks-triggers.test.ts
+++ b/test/webhooks-triggers.test.ts
@@ -6,13 +6,25 @@ vi.mock("../src/webhooks/dispatcher.js", () => ({
   dispatchWebhook: dispatchWebhookMock,
 }));
 
-// Imported after the mock so the trigger module sees the mocked dispatcher.
+// fireBulkScanWebhooks now calls getWebhookForUser to decide the dispatch
+// strategy (serial for rate-limited formats, parallel otherwise). Return null
+// here so the existing concurrency tests exercise the parallel path, which
+// matches the pre-throttle behaviour these tests were written to assert.
+const getWebhookForUserMock = vi.fn().mockResolvedValue(null);
+vi.mock("../src/db/webhooks.js", () => ({
+  getWebhookForUser: getWebhookForUserMock,
+}));
+
+// Imported after the mocks so the trigger module sees both mocked modules.
 const { fireBulkScanWebhooks, fireScanCompletedWebhook } = await import(
   "../src/webhooks/triggers.js"
 );
 
 beforeEach(() => {
   dispatchWebhookMock.mockReset();
+  getWebhookForUserMock.mockReset();
+  // Default: no webhook configured → parallel path (null format → no throttle).
+  getWebhookForUserMock.mockResolvedValue(null);
 });
 
 afterEach(() => {


### PR DESCRIPTION
## Summary

Fixes #242 — Google Chat incoming webhooks cap at ~1 msg/second per space, causing 87.5% 429 failure rate when `fireBulkScanWebhooks` fires 10 concurrent POSTs per batch during cron rescans.

- **`src/webhooks/formats/index.ts`**: Add `FORMAT_RATE_LIMIT_MS` record (`google_chat: 1100`, `raw/slack: null`) and `getFormatRateLimitMs()` helper. The 10% buffer over the 1 msg/s cap absorbs clock skew.

- **`src/webhooks/triggers.ts`**: `fireBulkScanWebhooks` now looks up the user's webhook format once and branches on rate limit:
  - **google_chat** (and any future rate-limited format): serial loop with `await new Promise(r => setTimeout(r, 1100))` *between* sends — no delay before the first, no change to non-bulk paths.
  - **raw / slack** (null limit): existing `Promise.allSettled` batch logic unchanged — no regression.

- **`src/webhooks/dispatcher.ts`**: On a 429 response, do one retry after a 2-second backoff (`RETRY_DELAY_MS`). Records only the final outcome to `webhook_deliveries` — no recursive retries. Added `retryDelayMs` to `DispatchOptions` so tests can pass `0` and skip the real wait without fake timers.

- **`test/webhook-throttle.test.ts`** (new): Covers Google Chat serial dispatch (N=10 entries, delay ≥ 1100ms, non-scanned entries skipped), raw parallel path (maxActive > 1, zero throttle delays).

- **`test/webhooks-dispatcher.test.ts`**: Three new cases — 429→200 retry records ok=true with one delivery row; 429→429 records ok=false; 500 is not retried.

- **`test/webhooks-triggers.test.ts`**: Add `vi.mock` for `../src/db/webhooks.js` returning `null` so the existing concurrency assertions (`maxActive === 8`) continue to exercise the parallel path.

## Test plan

- [ ] `npm test -- test/webhook-throttle.test.ts test/webhooks-dispatcher.test.ts test/webhooks-triggers.test.ts` — all 20 tests pass
- [ ] `npm run typecheck` — clean
- [ ] `npm run lint` — no fixes needed
- [ ] Full `npm test` — 927/928 pass (one pre-existing `mta-sts-runtime` network test fails in CI sandbox; unrelated to this change)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWjVsDVDNFjWvdMmwVFGdT)_