### PR TITLE
feat: surface DNS lookup errors (SERVFAIL/timeout) — closes #241

### DIFF
--- a/src/analyzers/bimi.ts
+++ b/src/analyzers/bimi.ts
@@ -1,10 +1,13 @@
-import { queryTxt } from "../dns/client.js";
+import { DnsLookupError, queryTxt } from "../dns/client.js";
 import type { TxtRecord } from "../dns/types.js";
 import { parseTags } from "../shared/parse-tags.js";
 import type { BimiResult, Validation } from "./types.js";
 
 export function prefetchBimiDns(domain: string): Promise<TxtRecord | null> {
-  return queryTxt(`default._bimi.${domain}`);
+  return queryTxt(`default._bimi.${domain}`).catch((err) => {
+    if (err instanceof DnsLookupError) return null;
+    throw err;
+  });
 }
 
 export async function analyzeBimi(
@@ -41,13 +44,12 @@ export async function analyzeBimi(
   if (!bimiRecord) {
     return {
       status: "warn",
-      record: txt.raw,
+      record: null,
       tags: null,
       validations: [
         {
           status: "warn",
-          message:
-            "TXT record exists but is not a valid BIMI record (possibly a wildcard DNS entry)",
+          message: `TXT record at default._bimi.${domain} is not a valid BIMI record`,
         },
       ],
     };
@@ -58,62 +60,51 @@ export async function analyzeBimi(
 
   validations.push({ status: "pass", message: "BIMI record found" });
 
-  // v= check
-  if (tags.v !== "BIMI1") {
-    validations.push({ status: "fail", message: "Invalid BIMI version tag" });
-  }
-
-  // l= check (logo URL)
-  if (tags.l) {
-    if (tags.l.startsWith("https://")) {
-      validations.push({
-        status: "pass",
-        message: "Logo URL (l=) is present and uses HTTPS",
-      });
-    } else {
-      validations.push({
-        status: "warn",
-        message: "Logo URL (l=) should use HTTPS",
-      });
-    }
+  if (dmarcPolicy === "reject") {
+    validations.push({
+      status: "pass",
+      message: "DMARC policy is reject — meets BIMI requirement",
+    });
+  } else if (dmarcPolicy === "quarantine") {
+    validations.push({
+      status: "warn",
+      message:
+        "DMARC quarantine policy meets minimum BIMI requirement, but reject is preferred",
+    });
   } else {
     validations.push({
       status: "warn",
-      message: "No logo URL (l=) specified",
+      message: "BIMI requires a DMARC policy of quarantine or reject",
     });
   }
 
-  // a= check (authority / VMC/CMC)
+  if (tags.l) {
+    validations.push({
+      status: "pass",
+      message: `Logo URL configured: ${tags.l}`,
+    });
+  } else {
+    validations.push({
+      status: "warn",
+      message: "No logo URL (l=) in BIMI record",
+    });
+  }
+
   if (tags.a) {
     validations.push({
       status: "pass",
-      message: "Authority evidence (a=) VMC/CMC certificate URL present",
+      message: `Authority certificate (VMC/CMC) configured: ${tags.a}`,
     });
   } else {
     validations.push({
       status: "warn",
       message:
-        "No authority certificate (a=) — add a VMC or CMC to display your logo in Gmail and Apple Mail",
+        "No authority certificate (a=) — logo may not appear in Gmail/Apple Mail",
     });
   }
 
-  // DMARC cross-check
-  if (dmarcPolicy && ["quarantine", "reject"].includes(dmarcPolicy)) {
-    validations.push({
-      status: "pass",
-      message: "DMARC policy meets BIMI requirement",
-    });
-  } else {
-    validations.push({
-      status: "fail",
-      message:
-        "DMARC policy must be quarantine or reject for BIMI to be honored",
-    });
-  }
-
-  const hasFailure = validations.some((v) => v.status === "fail");
   const hasWarn = validations.some((v) => v.status === "warn");
-  const status = hasFailure ? "fail" : hasWarn ? "warn" : "pass";
+  const status = hasWarn ? "warn" : "pass";
 
   return { status, record: bimiRecord, tags, validations };
 }

--- a/src/analyzers/bimi.ts
+++ b/src/analyzers/bimi.ts
@@ -44,12 +44,13 @@ export async function analyzeBimi(
   if (!bimiRecord) {
     return {
       status: "warn",
-      record: null,
+      record: txt.raw,
       tags: null,
       validations: [
         {
           status: "warn",
-          message: `TXT record at default._bimi.${domain} is not a valid BIMI record`,
+          message:
+            "TXT record exists but is not a valid BIMI record (possibly a wildcard DNS entry)",
         },
       ],
     };
@@ -60,51 +61,62 @@ export async function analyzeBimi(
 
   validations.push({ status: "pass", message: "BIMI record found" });
 
-  if (dmarcPolicy === "reject") {
-    validations.push({
-      status: "pass",
-      message: "DMARC policy is reject — meets BIMI requirement",
-    });
-  } else if (dmarcPolicy === "quarantine") {
-    validations.push({
-      status: "warn",
-      message:
-        "DMARC quarantine policy meets minimum BIMI requirement, but reject is preferred",
-    });
-  } else {
-    validations.push({
-      status: "warn",
-      message: "BIMI requires a DMARC policy of quarantine or reject",
-    });
+  // v= check
+  if (tags.v !== "BIMI1") {
+    validations.push({ status: "fail", message: "Invalid BIMI version tag" });
   }
 
+  // l= check (logo URL)
   if (tags.l) {
-    validations.push({
-      status: "pass",
-      message: `Logo URL configured: ${tags.l}`,
-    });
+    if (tags.l.startsWith("https://")) {
+      validations.push({
+        status: "pass",
+        message: "Logo URL (l=) is present and uses HTTPS",
+      });
+    } else {
+      validations.push({
+        status: "warn",
+        message: "Logo URL (l=) should use HTTPS",
+      });
+    }
   } else {
     validations.push({
       status: "warn",
-      message: "No logo URL (l=) in BIMI record",
+      message: "No logo URL (l=) specified",
     });
   }
 
+  // a= check (authority / VMC/CMC)
   if (tags.a) {
     validations.push({
       status: "pass",
-      message: `Authority certificate (VMC/CMC) configured: ${tags.a}`,
+      message: "Authority evidence (a=) VMC/CMC certificate URL present",
     });
   } else {
     validations.push({
       status: "warn",
       message:
-        "No authority certificate (a=) — logo may not appear in Gmail/Apple Mail",
+        "No authority certificate (a=) — add a VMC or CMC to display your logo in Gmail and Apple Mail",
     });
   }
 
+  // DMARC cross-check
+  if (dmarcPolicy && ["quarantine", "reject"].includes(dmarcPolicy)) {
+    validations.push({
+      status: "pass",
+      message: "DMARC policy meets BIMI requirement",
+    });
+  } else {
+    validations.push({
+      status: "fail",
+      message:
+        "DMARC policy must be quarantine or reject for BIMI to be honored",
+    });
+  }
+
+  const hasFailure = validations.some((v) => v.status === "fail");
   const hasWarn = validations.some((v) => v.status === "warn");
-  const status = hasWarn ? "warn" : "pass";
+  const status = hasFailure ? "fail" : hasWarn ? "warn" : "pass";
 
   return { status, record: bimiRecord, tags, validations };
 }

--- a/src/analyzers/dmarc.ts
+++ b/src/analyzers/dmarc.ts
@@ -1,9 +1,28 @@
-import { queryTxt } from "../dns/client.js";
+import { DnsLookupError, queryTxt } from "../dns/client.js";
 import { parseTags } from "../shared/parse-tags.js";
 import type { DmarcResult, Validation } from "./types.js";
 
 export async function analyzeDmarc(domain: string): Promise<DmarcResult> {
-  const txt = await queryTxt(`_dmarc.${domain}`);
+  let txt: Awaited<ReturnType<typeof queryTxt>>;
+  try {
+    txt = await queryTxt(`_dmarc.${domain}`);
+  } catch (err) {
+    if (err instanceof DnsLookupError) {
+      return {
+        status: "warn",
+        record: null,
+        tags: null,
+        lookup_error: { code: err.code, message: err.message },
+        validations: [
+          {
+            status: "warn",
+            message: `DMARC lookup failed (${err.code}) — result may be incomplete`,
+          },
+        ],
+      };
+    }
+    throw err;
+  }
   if (!txt) {
     return {
       status: "fail",

--- a/src/analyzers/mx.ts
+++ b/src/analyzers/mx.ts
@@ -1,4 +1,4 @@
-import { queryMx } from "../dns/client.js";
+import { DnsLookupError, queryMx } from "../dns/client.js";
 import type { EmailProvider, MxRecord, MxResult, Validation } from "./types.js";
 
 interface ProviderSignature {
@@ -113,7 +113,26 @@ export function detectProviders(
 }
 
 export async function analyzeMx(domain: string): Promise<MxResult> {
-  const rawRecords = await queryMx(domain);
+  let rawRecords: Awaited<ReturnType<typeof queryMx>>;
+  try {
+    rawRecords = await queryMx(domain);
+  } catch (err) {
+    if (err instanceof DnsLookupError) {
+      return {
+        status: "warn",
+        records: [],
+        providers: [],
+        lookup_error: { code: err.code, message: err.message },
+        validations: [
+          {
+            status: "warn",
+            message: `MX lookup failed (${err.code}) — result may be incomplete`,
+          },
+        ],
+      };
+    }
+    throw err;
+  }
 
   if (!rawRecords || rawRecords.length === 0) {
     return {

--- a/src/analyzers/spf.ts
+++ b/src/analyzers/spf.ts
@@ -1,4 +1,4 @@
-import { queryTxt } from "../dns/client.js";
+import { DnsLookupError, queryTxt } from "../dns/client.js";
 import type { SpfIncludeNode, SpfResult, Validation } from "./types.js";
 
 const MAX_LOOKUPS = 10;
@@ -9,7 +9,29 @@ export async function analyzeSpf(domain: string): Promise<SpfResult> {
     visited: new Set(),
     hasCycle: false,
   };
-  const tree = await resolveSpfTree(domain, ctx, 0);
+
+  let tree: SpfIncludeNode | null;
+  try {
+    tree = await resolveSpfTree(domain, ctx, 0);
+  } catch (err) {
+    if (err instanceof DnsLookupError) {
+      return {
+        status: "warn",
+        record: null,
+        lookups_used: 0,
+        lookup_limit: MAX_LOOKUPS,
+        include_tree: null,
+        lookup_error: { code: err.code, message: err.message },
+        validations: [
+          {
+            status: "warn",
+            message: `SPF lookup failed (${err.code}) — result may be incomplete`,
+          },
+        ],
+      };
+    }
+    throw err;
+  }
 
   if (!tree?.record) {
     return {

--- a/src/analyzers/types.ts
+++ b/src/analyzers/types.ts
@@ -10,6 +10,7 @@ export interface DmarcResult {
   record: string | null;
   tags: Record<string, string> | null;
   validations: Validation[];
+  lookup_error?: { code: string; message: string };
 }
 
 export interface SpfIncludeNode {
@@ -26,6 +27,7 @@ export interface SpfResult {
   lookup_limit: number;
   include_tree: SpfIncludeNode | null;
   validations: Validation[];
+  lookup_error?: { code: string; message: string };
 }
 
 export interface DkimSelectorResult {
@@ -79,6 +81,7 @@ export interface MxResult {
   records: MxRecord[];
   providers: EmailProvider[];
   validations: Validation[];
+  lookup_error?: { code: string; message: string };
 }
 
 export interface SecurityTxtFields {

--- a/src/dns/client.ts
+++ b/src/dns/client.ts
@@ -11,6 +11,16 @@ export function parseDnsServers(raw: string | undefined): string[] | null {
   return servers.length > 0 ? servers : null;
 }
 
+export class DnsLookupError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "DnsLookupError";
+  }
+}
+
 const resolver = new dns.promises.Resolver();
 const DNS_TIMEOUT_MS = 3000;
 
@@ -40,6 +50,31 @@ function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   });
 }
 
+// ENOTFOUND/ENODATA = record genuinely absent (NXDOMAIN / NODATA).
+// ESERVFAIL and timeouts are resolver errors — the record may exist but
+// the query failed. These are re-thrown as DnsLookupError so callers can
+// surface them to the user rather than treating them as "not configured".
+function isDnsAbsent(err: unknown): boolean {
+  if (typeof err === "object" && err !== null && "code" in err) {
+    const code = (err as { code: string }).code;
+    return code === "ENOTFOUND" || code === "ENODATA";
+  }
+  return false;
+}
+
+function toDnsLookupError(err: unknown): DnsLookupError | null {
+  if (err instanceof Error && err.message === "DNS timeout") {
+    return new DnsLookupError("DNS_TIMEOUT", "DNS query timed out");
+  }
+  if (typeof err === "object" && err !== null && "code" in err) {
+    const code = (err as { code: string }).code;
+    if (code === "ESERVFAIL") {
+      return new DnsLookupError(code, "DNS server failure (SERVFAIL)");
+    }
+  }
+  return null;
+}
+
 export async function queryTxt(name: string): Promise<TxtRecord | null> {
   Sentry.addBreadcrumb({
     category: "dns.query",
@@ -60,7 +95,9 @@ export async function queryTxt(name: string): Promise<TxtRecord | null> {
     );
     return { entries, raw: entries.join(" ") };
   } catch (err: unknown) {
-    if (isDnsNotFound(err)) return null;
+    if (isDnsAbsent(err)) return null;
+    const lookupErr = toDnsLookupError(err);
+    if (lookupErr) throw lookupErr;
     throw err;
   }
 }
@@ -76,16 +113,9 @@ export async function queryMx(name: string): Promise<MxRecord[] | null> {
     const records = await withTimeout(resolver.resolveMx(name), DNS_TIMEOUT_MS);
     return records.map((r) => ({ priority: r.priority, exchange: r.exchange }));
   } catch (err: unknown) {
-    if (isDnsNotFound(err)) return null;
+    if (isDnsAbsent(err)) return null;
+    const lookupErr = toDnsLookupError(err);
+    if (lookupErr) throw lookupErr;
     throw err;
   }
-}
-
-function isDnsNotFound(err: unknown): boolean {
-  if (err instanceof Error && err.message === "DNS timeout") return true;
-  if (typeof err === "object" && err !== null && "code" in err) {
-    const code = (err as { code: string }).code;
-    return code === "ENOTFOUND" || code === "ENODATA" || code === "ESERVFAIL";
-  }
-  return false;
 }

--- a/src/shared/scoring.ts
+++ b/src/shared/scoring.ts
@@ -62,6 +62,20 @@ function resolveScoring(protocols: Protocols): ScoringResult {
   const { dmarc, spf, dkim, bimi, mta_sts } = protocols;
   const dmarcPolicy = dmarc.tags?.p?.toLowerCase() ?? null;
 
+  // DNS lookup failure ≠ "no record" — avoid a false F when the resolver
+  // returned SERVFAIL or timed out. Report D so the user knows something
+  // went wrong but doesn't think they have no DMARC policy.
+  if (dmarc.lookup_error) {
+    return {
+      grade: "D",
+      tier: "D",
+      tierReason: `DMARC lookup failed (${dmarc.lookup_error.code}) — policy could not be verified`,
+      modifier: 0,
+      modifierLabel: "",
+      factors: [],
+    };
+  }
+
   // Gatekeeper: no DMARC or p=none is automatic F
   if (dmarc.status === "fail" || !dmarcPolicy || dmarcPolicy === "none") {
     const tierReason = !dmarcPolicy

--- a/test/dns-error-surfacing.test.ts
+++ b/test/dns-error-surfacing.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/dns/client.js", () => ({
+  queryTxt: vi.fn(),
+  queryMx: vi.fn(),
+  DnsLookupError: class DnsLookupError extends Error {
+    code: string;
+    constructor(code: string, message: string) {
+      super(message);
+      this.name = "DnsLookupError";
+      this.code = code;
+    }
+  },
+}));
+
+import { analyzeDmarc } from "../src/analyzers/dmarc.js";
+import { analyzeMx } from "../src/analyzers/mx.js";
+import { analyzeSpf } from "../src/analyzers/spf.js";
+import { DnsLookupError, queryMx, queryTxt } from "../src/dns/client.js";
+import { computeGradeBreakdown } from "../src/shared/scoring.js";
+
+const mockQueryTxt = vi.mocked(queryTxt);
+const mockQueryMx = vi.mocked(queryMx);
+
+function makeServfailError(): DnsLookupError {
+  return new DnsLookupError("ESERVFAIL", "DNS server failure (SERVFAIL)");
+}
+
+function makeTimeoutError(): DnsLookupError {
+  return new DnsLookupError("DNS_TIMEOUT", "DNS query timed out");
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("analyzeDmarc with DNS lookup errors", () => {
+  it("returns warn + lookup_error on SERVFAIL", async () => {
+    mockQueryTxt.mockRejectedValue(makeServfailError());
+    const result = await analyzeDmarc("example.com");
+    expect(result.status).toBe("warn");
+    expect(result.record).toBeNull();
+    expect(result.tags).toBeNull();
+    expect(result.lookup_error).toEqual({
+      code: "ESERVFAIL",
+      message: "DNS server failure (SERVFAIL)",
+    });
+    expect(
+      result.validations.some(
+        (v) => v.status === "warn" && v.message.includes("ESERVFAIL"),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns warn + lookup_error on DNS timeout", async () => {
+    mockQueryTxt.mockRejectedValue(makeTimeoutError());
+    const result = await analyzeDmarc("example.com");
+    expect(result.status).toBe("warn");
+    expect(result.lookup_error?.code).toBe("DNS_TIMEOUT");
+  });
+
+  it("re-throws non-DnsLookupError errors", async () => {
+    mockQueryTxt.mockRejectedValue(new Error("unexpected error"));
+    await expect(analyzeDmarc("example.com")).rejects.toThrow(
+      "unexpected error",
+    );
+  });
+
+  it("still returns fail when record is absent (NXDOMAIN)", async () => {
+    mockQueryTxt.mockResolvedValue(null);
+    const result = await analyzeDmarc("example.com");
+    expect(result.status).toBe("fail");
+    expect(result.lookup_error).toBeUndefined();
+  });
+});
+
+describe("analyzeSpf with DNS lookup errors", () => {
+  it("returns warn + lookup_error on SERVFAIL", async () => {
+    mockQueryTxt.mockRejectedValue(makeServfailError());
+    const result = await analyzeSpf("example.com");
+    expect(result.status).toBe("warn");
+    expect(result.record).toBeNull();
+    expect(result.lookup_error).toEqual({
+      code: "ESERVFAIL",
+      message: "DNS server failure (SERVFAIL)",
+    });
+    expect(
+      result.validations.some(
+        (v) => v.status === "warn" && v.message.includes("ESERVFAIL"),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns warn + lookup_error on DNS timeout", async () => {
+    mockQueryTxt.mockRejectedValue(makeTimeoutError());
+    const result = await analyzeSpf("example.com");
+    expect(result.status).toBe("warn");
+    expect(result.lookup_error?.code).toBe("DNS_TIMEOUT");
+  });
+
+  it("still returns fail when no SPF record exists", async () => {
+    mockQueryTxt.mockResolvedValue(null);
+    const result = await analyzeSpf("example.com");
+    expect(result.status).toBe("fail");
+    expect(result.lookup_error).toBeUndefined();
+  });
+});
+
+describe("analyzeMx with DNS lookup errors", () => {
+  it("returns warn + lookup_error on SERVFAIL", async () => {
+    mockQueryMx.mockRejectedValue(makeServfailError());
+    const result = await analyzeMx("example.com");
+    expect(result.status).toBe("warn");
+    expect(result.records).toEqual([]);
+    expect(result.lookup_error).toEqual({
+      code: "ESERVFAIL",
+      message: "DNS server failure (SERVFAIL)",
+    });
+  });
+
+  it("still returns info with empty records when no MX exists", async () => {
+    mockQueryMx.mockResolvedValue(null);
+    const result = await analyzeMx("example.com");
+    expect(result.status).toBe("info");
+    expect(result.lookup_error).toBeUndefined();
+  });
+});
+
+describe("scoring with DMARC lookup_error", () => {
+  const baseProtocols = {
+    spf: {
+      status: "pass" as const,
+      record: "v=spf1 -all",
+      lookups_used: 1,
+      lookup_limit: 10,
+      include_tree: null,
+      validations: [],
+    },
+    dkim: {
+      status: "pass" as const,
+      selectors: { google: { found: true } },
+      validations: [],
+    },
+    bimi: {
+      status: "warn" as const,
+      record: null,
+      tags: null,
+      validations: [],
+    },
+    mta_sts: {
+      status: "warn" as const,
+      dns_record: null,
+      policy: null,
+      validations: [],
+    },
+  };
+
+  it("returns D grade when DMARC has lookup_error (not false F)", () => {
+    const protocols = {
+      ...baseProtocols,
+      dmarc: {
+        status: "warn" as const,
+        record: null,
+        tags: null,
+        lookup_error: {
+          code: "ESERVFAIL",
+          message: "DNS server failure (SERVFAIL)",
+        },
+        validations: [
+          {
+            status: "warn" as const,
+            message: "DMARC lookup failed (ESERVFAIL)",
+          },
+        ],
+      },
+    };
+    const breakdown = computeGradeBreakdown(protocols);
+    expect(breakdown.grade).toBe("D");
+    expect(breakdown.tierReason).toContain("ESERVFAIL");
+  });
+
+  it("returns F when DMARC has no record and no lookup_error", () => {
+    const protocols = {
+      ...baseProtocols,
+      dmarc: {
+        status: "fail" as const,
+        record: null,
+        tags: null,
+        validations: [
+          { status: "fail" as const, message: "No DMARC record found" },
+        ],
+      },
+    };
+    const breakdown = computeGradeBreakdown(protocols);
+    expect(breakdown.grade).toBe("F");
+  });
+});


### PR DESCRIPTION
## Summary

- **Distinguishes SERVFAIL/timeout from NXDOMAIN** in `dns/client.ts`: exports a new `DnsLookupError` class; `isDnsAbsent` now only catches `ENOTFOUND`/`ENODATA` (genuine record absence); ESERVFAIL and DNS timeouts are re-thrown as `DnsLookupError` so callers can report them to the user
- **DMARC, SPF, MX analyzers** catch `DnsLookupError` and return `status: "warn"` with a populated `lookup_error: { code, message }` field instead of silently treating the failure as "record not found"
- **BIMI** (`prefetchBimiDns`) guards against `DnsLookupError` propagating into the orchestrator's `Promise.all` chain
- **Scoring** checks `dmarc.lookup_error` before the F-gatekeeper: a DMARC SERVFAIL now yields grade **D** ("policy could not be verified") instead of a false **F** ("no DMARC record")
- **11 new tests** in `test/dns-error-surfacing.test.ts` covering SERVFAIL and timeout paths for each analyzer, plus the D-not-F scoring invariant

## Test plan
- [ ] `npx vitest run test/dns-error-surfacing.test.ts` — 11 tests pass
- [ ] `npm run typecheck` — no errors
- [ ] `npx vitest run test/analyzers.test.ts test/scoring.test.ts` — existing tests unaffected
- [ ] CI green on this PR

Closes #241

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWjVsDVDNFjWvdMmwVFGdT)_