### PR TITLE
🎨 Palette: Add accessible dynamic form validation to Add Domain wizard

### DIFF
--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -1952,8 +1952,8 @@ function renderAddDomainWizardShell(): string {
     <div class="add-wizard-body">
       <div class="add-wizard-step" data-active="1" data-step="1">
         <label for="wizard-domain">Domain</label>
-        <input type="text" id="wizard-domain" name="domain" placeholder="example.com" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" required>
-        <div class="add-wizard-error" data-wizard-error hidden></div>
+        <input type="text" id="wizard-domain" name="domain" placeholder="example.com" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" required aria-describedby="wizard-domain-error">
+        <div id="wizard-domain-error" class="add-wizard-error" data-wizard-error role="alert" aria-live="polite" hidden></div>
       </div>
       <div class="add-wizard-step" data-step="2">
         <label for="wizard-frequency">Scan frequency</label>

--- a/src/views/scripts.ts
+++ b/src/views/scripts.ts
@@ -1291,6 +1291,7 @@ if (typeof navigator !== 'undefined' && navigator.modelContext && typeof navigat
       lastFocusedBeforeOpen = triggerEl || document.activeElement;
       if (form) form.reset();
       if (errorEl) { errorEl.hidden = true; errorEl.textContent = ''; }
+      if (domainInput) domainInput.removeAttribute('aria-invalid');
       showStep(1);
       setOpen(wizard, true);
     }
@@ -1319,9 +1320,11 @@ if (typeof navigator !== 'undefined' && navigator.modelContext && typeof navigat
               errorEl.textContent = 'Enter a valid domain like example.com.';
               errorEl.hidden = false;
             }
+            if (domainInput) domainInput.setAttribute('aria-invalid', 'true');
             return;
           }
           if (errorEl) errorEl.hidden = true;
+          if (domainInput) domainInput.removeAttribute('aria-invalid');
           if (confirmDom) confirmDom.textContent = raw;
           showStep(2);
         } else if (step === 2) {


### PR DESCRIPTION
💡 What: Added accessible dynamic form validation to the "Add Domain" wizard. 
🎯 Why: Without these attributes, screen reader users would not be dynamically informed when their domain input triggered a validation error.
📸 Before/After: Visuals remain unchanged, but the DOM now includes `aria-describedby` on the input, `role="alert"` and `aria-live="polite"` on the error container, and dynamically toggles `aria-invalid="true"` when the user enters an invalid domain.
♿ Accessibility: Ensures that dynamic form validation errors are immediately and accurately announced to assistive technology users, maintaining correct input validation state visibility programmatically.

---
*PR created automatically by Jules for task [9967053214816098946](https://jules.google.com/task/9967053214816098946) started by @schmug*