### PR TITLE
security: replace unsafe-inline with per-request CSP nonce (#83)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -206,9 +206,14 @@ app.use("*", async (c, next) => {
   const isHtml = contentType.includes("text/html");
   if (isHtml) {
     const frameAncestors = ["'self'", ...EMBED_ALLOWED_ORIGINS].join(" ");
+    // Per-request nonce eliminates 'unsafe-inline' from script-src. Scripts
+    // with a matching nonce attribute execute; all others are blocked.
+    const nonce = btoa(
+      String.fromCharCode(...crypto.getRandomValues(new Uint8Array(16))),
+    );
     c.res.headers.set(
       "Content-Security-Policy",
-      `default-src 'none'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; manifest-src 'self'; form-action 'self'; base-uri 'none'; frame-ancestors ${frameAncestors}`,
+      `default-src 'none'; script-src 'nonce-${nonce}' 'strict-dynamic'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; manifest-src 'self'; form-action 'self'; base-uri 'none'; frame-ancestors ${frameAncestors}`,
     );
     if (!c.res.headers.has("Link")) {
       c.res.headers.set("Link", AGENT_DISCOVERY_LINK_HEADER);
@@ -222,28 +227,29 @@ app.use("*", async (c, next) => {
       );
     }
 
-    // Inject the Cloudflare Web Analytics beacon on public HTML pages.
-    // Skipped when the token isn't configured (self-host default) and on
-    // auth/dashboard/webhook paths whose URLs can carry user-specific detail.
-    // Our HTML responses are already buffered strings (never streamed), so a
-    // simple `</body>` replace is both correct and keeps tests in the Node
-    // pool runnable without HTMLRewriter.
+    // Inject nonce into all <script> tags (excluding JSON-LD data blocks which
+    // are not executable JS and don't fall under script-src).  Combine with the
+    // optional Cloudflare Analytics beacon injection to avoid reading the body
+    // twice — HTML responses are buffered strings, never true streams.
     const token = (c.env as Env | undefined)?.CF_ANALYTICS_TOKEN;
     const path = c.req.path;
     const isAnalyticsEligible =
       token &&
       CF_ANALYTICS_TOKEN_RE.test(token) &&
       !ANALYTICS_SKIP_PATH_PREFIXES.some((p) => path.startsWith(p));
+    let body = (await c.res.text()).replace(
+      /<script(?!\s+type=["']application\/ld\+json)/g,
+      `<script nonce="${nonce}"`,
+    );
     if (isAnalyticsEligible) {
-      const beacon = `<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token":"${token}"}'></script>`;
-      const body = await c.res.text();
-      const injected = body.replace("</body>", `${beacon}</body>`);
-      c.res = new Response(injected, {
-        status: c.res.status,
-        statusText: c.res.statusText,
-        headers: c.res.headers,
-      });
+      const beacon = `<script defer nonce="${nonce}" src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token":"${token}"}'></script>`;
+      body = body.replace("</body>", `${beacon}</body>`);
     }
+    c.res = new Response(body, {
+      status: c.res.status,
+      statusText: c.res.statusText,
+      headers: c.res.headers,
+    });
   } else {
     // `frame-ancestors` does not inherit from `default-src`, so it must be
     // declared explicitly to keep JSON/CSV/SSE responses unframable.

--- a/test/cf-analytics.test.ts
+++ b/test/cf-analytics.test.ts
@@ -117,11 +117,17 @@ describe("Cloudflare Web Analytics beacon injection", () => {
     }
   });
 
-  describe("CSP already permits the beacon origin", () => {
-    it("script-src allows static.cloudflareinsights.com on HTML responses", async () => {
+  describe("CSP nonce covers the beacon script", () => {
+    it("beacon script tag carries the per-request nonce", async () => {
       const res = await app.request("/", {}, envWithToken);
       const csp = res.headers.get("content-security-policy") ?? "";
-      expect(csp).toContain("https://static.cloudflareinsights.com");
+      // With 'strict-dynamic' + nonce, external URLs need not be listed in script-src
+      expect(csp).toMatch(/script-src 'nonce-[A-Za-z0-9+/]+=*' 'strict-dynamic'/);
+      const nonceMatch = csp.match(/'nonce-([A-Za-z0-9+/]+=*)'/);
+      expect(nonceMatch).not.toBeNull();
+      const nonce = nonceMatch![1];
+      const body = await res.text();
+      expect(body).toContain(`nonce="${nonce}" src="https://${BEACON_SRC}"`);
     });
   });
 });

--- a/test/cf-analytics.test.ts
+++ b/test/cf-analytics.test.ts
@@ -122,10 +122,12 @@ describe("Cloudflare Web Analytics beacon injection", () => {
       const res = await app.request("/", {}, envWithToken);
       const csp = res.headers.get("content-security-policy") ?? "";
       // With 'strict-dynamic' + nonce, external URLs need not be listed in script-src
-      expect(csp).toMatch(/script-src 'nonce-[A-Za-z0-9+/]+=*' 'strict-dynamic'/);
+      expect(csp).toMatch(
+        /script-src 'nonce-[A-Za-z0-9+/]+=*' 'strict-dynamic'/,
+      );
       const nonceMatch = csp.match(/'nonce-([A-Za-z0-9+/]+=*)'/);
       expect(nonceMatch).not.toBeNull();
-      const nonce = nonceMatch![1];
+      const nonce = nonceMatch?.[1];
       const body = await res.text();
       expect(body).toContain(`nonce="${nonce}" src="https://${BEACON_SRC}"`);
     });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -380,14 +380,37 @@ describe("security headers", () => {
     expect(res.headers.get("X-Frame-Options")).toBeNull();
   });
 
-  it("sets CSP with inline scripts allowed on HTML responses", async () => {
+  it("sets nonce-based CSP without unsafe-inline on HTML responses", async () => {
     const res = await app.request("/");
-    const csp = res.headers.get("Content-Security-Policy");
-    expect(csp).toContain(
-      "script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com",
-    );
+    const csp = res.headers.get("Content-Security-Policy") ?? "";
+    expect(csp).toMatch(/script-src 'nonce-[A-Za-z0-9+/]+=*'/);
+    expect(csp).toContain("'strict-dynamic'");
+    // script-src must not have unsafe-inline; style-src keeps it (CSS has no nonce equiv here)
+    const scriptSrc = csp.match(/script-src[^;]*/)?.[0] ?? "";
+    expect(scriptSrc).not.toContain("'unsafe-inline'");
     expect(csp).toContain("style-src 'self' 'unsafe-inline'");
     expect(csp).toContain("frame-ancestors 'self' https://cortech.online");
+  });
+
+  it("injects nonce attribute into script tags in the HTML body", async () => {
+    const res = await app.request("/");
+    const csp = res.headers.get("Content-Security-Policy") ?? "";
+    const nonceMatch = csp.match(/'nonce-([A-Za-z0-9+/]+=*)'/);
+    expect(nonceMatch).not.toBeNull();
+    const nonce = nonceMatch?.[1];
+    const body = await res.text();
+    expect(body).toContain(`<script nonce="${nonce}"`);
+  });
+
+  it("does not add nonce to JSON-LD script blocks", async () => {
+    const res = await app.request("/check?domain=dmarc.mx");
+    const body = await res.text();
+    const jsonLdMatch = body.match(/<script type="application\/ld\+json"/g);
+    if (jsonLdMatch) {
+      for (const tag of jsonLdMatch) {
+        expect(tag).not.toContain("nonce=");
+      }
+    }
   });
 
   it("allows only cortech.online to embed (no wildcards, exact origin)", async () => {
@@ -524,7 +547,7 @@ describe("HTML head tags", () => {
     const res = await app.request("/");
     const html = await res.text();
     expect(html).toContain('rel="stylesheet" href="/assets/styles-');
-    expect(html).toContain('<script src="/assets/scripts-');
+    expect(html).toContain('src="/assets/scripts-');
     expect(html).not.toMatch(/<style>[^<]{500,}<\/style>/);
     expect(html).not.toMatch(/<script>[^<]{500,}<\/script>/);
   });


### PR DESCRIPTION
## Summary

- Generates a cryptographically-random 128-bit nonce per HTML response via `crypto.getRandomValues`
- Replaces `'unsafe-inline'` in `script-src` with `'nonce-{nonce}' 'strict-dynamic'`
- Injects the nonce attribute into every executable `<script>` tag at response-time (JSON-LD `<script type="application/ld+json">` blocks are excluded — they're data, not JS)
- Cloudflare Analytics beacon is injected directly with the same nonce; the external URL no longer needs to appear in `script-src` because `'strict-dynamic'` covers it

`style-src` keeps `'unsafe-inline'` — CSS doesn't have an equivalent nonce mechanism in this architecture and isn't an XSS vector in the same way.

## Test plan

- [x] `npm test` — 861/862 pass (1 failure is pre-existing `mta-sts-runtime.test.ts` network test, excluded from CI `check` job)
- [x] `npm run typecheck` — clean
- [x] Updated `test/index.test.ts`: replaced old `'unsafe-inline'` CSP assertion with nonce-pattern assertions; added nonce injection and JSON-LD exemption tests
- [x] Updated `test/cf-analytics.test.ts`: replaced URL-in-CSP assertion with nonce-on-beacon-tag assertion

Closes #83

---
_Generated by [Claude Code](https://claude.ai/code/session_01BeyfuTUrVZdJBASAzEyQTa)_