### PR TITLE
⚡ Bolt: Prevent redundant array iterations in dashboard

### DIFF
--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -1873,11 +1873,10 @@ function renderOnFireBanner(failing: number): string {
 }
 
 function renderDashboardHero(
-  domains: DashboardDomain[],
+  stats: PortfolioStats,
+  worst: DashboardDomain | null,
   portfolioTrend: number[],
 ): string {
-  const stats = portfolioStats(domains);
-  const worst = worstDomain(domains);
   // Mood comes from the worst *graded* domain. With nothing scored yet there
   // is no signal to react to, so DMarcus defaults to neutral rather than
   // panicking at a freshly-added entry that just hasn't been scanned.
@@ -1978,8 +1977,7 @@ function renderAddDomainWizardShell(): string {
 </div>`;
 }
 
-function renderDashboardStatStrip(domains: DashboardDomain[]): string {
-  const stats = portfolioStats(domains);
+function renderDashboardStatStrip(stats: PortfolioStats): string {
   const totalCard = statCard(
     "Domains",
     stats.total,
@@ -2040,6 +2038,7 @@ export function renderDashboardPage({
   isFirstRun?: boolean;
 }): string {
   const stats = portfolioStats(domains);
+  const worst = worstDomain(domains);
   const banners: string[] = [];
   if (plan === "free") banners.push(renderFreeTierBanner());
   if (isFirstRun && domains.length === 1) {
@@ -2049,9 +2048,13 @@ export function renderDashboardPage({
 
   const hero =
     domains.length > 0
-      ? renderDashboardHero(domains, portfolioTrend)
-      : renderDashboardHero([], []);
-  const statStrip = domains.length > 0 ? renderDashboardStatStrip(domains) : "";
+      ? renderDashboardHero(stats, worst, portfolioTrend)
+      : renderDashboardHero(
+          { total: 0, healthy: 0, drifting: 0, failing: 0, ungraded: 0 },
+          null,
+          [],
+        );
+  const statStrip = domains.length > 0 ? renderDashboardStatStrip(stats) : "";
 
   return dashboardPage(
     "Domains — dmarc.mx",


### PR DESCRIPTION
## 💡 What

Extracted the calculation of `portfolioStats` and `worstDomain` to the top level in `renderDashboardPage` and passed the computed results down to child components (`renderDashboardHero` and `renderDashboardStatStrip`).

## 🎯 Why

`portfolioStats(domains)` iterates over the `domains` array. Previously, it was called redundantly inside `renderDashboardPage`, `renderDashboardHero`, and `renderDashboardStatStrip`, leading to multiple passes over the same array. By calculating derived metrics once and passing them down (prop drilling), we avoid redundant iterations and reduce CPU overhead on the view rendering path.

## 📊 Impact

Reduces iterations over the `domains` array from 3+ times to just 2 times (once for stats, once for worst domain) per render, directly improving the execution time of the dashboard view for users with larger domain portfolios.

## 🔬 Measurement

Run `pnpm test` to ensure all functionality remains correct. The tests verify that the UI components correctly render the stats regardless of where the calculations take place.

---
*PR created automatically by Jules for task [14262332325239767165](https://jules.google.com/task/14262332325239767165) started by @schmug*