### PR TITLE
🎨 Palette: Improve accessibility of add-domain wizard validation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-16 - Add ARIA live region for dynamic form validation
+**Learning:** For multi-step wizard forms or dynamic client-side validation, screen readers need explicit context when errors appear. Using a hidden error div without `role="alert"` and `aria-live="polite"` prevents the error from being announced.
+**Action:** Always link the input field to its error container using `aria-describedby` and dynamically toggle `aria-invalid="true"` on the input when it fails validation.

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -1952,8 +1952,8 @@ function renderAddDomainWizardShell(): string {
     <div class="add-wizard-body">
       <div class="add-wizard-step" data-active="1" data-step="1">
         <label for="wizard-domain">Domain</label>
-        <input type="text" id="wizard-domain" name="domain" placeholder="example.com" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" required>
-        <div class="add-wizard-error" data-wizard-error hidden></div>
+        <input type="text" id="wizard-domain" name="domain" placeholder="example.com" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" required aria-describedby="wizard-domain-error">
+        <div id="wizard-domain-error" class="add-wizard-error" data-wizard-error role="alert" aria-live="polite" hidden></div>
       </div>
       <div class="add-wizard-step" data-step="2">
         <label for="wizard-frequency">Scan frequency</label>

--- a/src/views/scripts.ts
+++ b/src/views/scripts.ts
@@ -1291,6 +1291,7 @@ if (typeof navigator !== 'undefined' && navigator.modelContext && typeof navigat
       lastFocusedBeforeOpen = triggerEl || document.activeElement;
       if (form) form.reset();
       if (errorEl) { errorEl.hidden = true; errorEl.textContent = ''; }
+      if (domainInput) domainInput.removeAttribute('aria-invalid');
       showStep(1);
       setOpen(wizard, true);
     }
@@ -1319,9 +1320,11 @@ if (typeof navigator !== 'undefined' && navigator.modelContext && typeof navigat
               errorEl.textContent = 'Enter a valid domain like example.com.';
               errorEl.hidden = false;
             }
+            if (domainInput) domainInput.setAttribute('aria-invalid', 'true');
             return;
           }
           if (errorEl) errorEl.hidden = true;
+          if (domainInput) domainInput.removeAttribute('aria-invalid');
           if (confirmDom) confirmDom.textContent = raw;
           showStep(2);
         } else if (step === 2) {


### PR DESCRIPTION
💡 **What:** 
Added proper ARIA attributes to the add-domain wizard's inline validation error. The input is now linked to its error container using `aria-describedby`, and the `aria-invalid` state is dynamically toggled.

🎯 **Why:** 
When users enter an invalid domain (like "invalid" instead of "example.com"), the client-side validation prevents form submission and shows an error text. However, without ARIA linkages, screen reader users are not immediately notified of the error and may not realize why the form won't progress to the next step.

📸 **Before/After:**
- Before: `<input id="wizard-domain" required>` and `<div class="add-wizard-error">`
- After: `<input id="wizard-domain" aria-describedby="wizard-domain-error" aria-invalid="true" required>` and `<div id="wizard-domain-error" role="alert" aria-live="polite">`

♿ **Accessibility:** 
- The error container now has `role="alert"` and `aria-live="polite"` to ensure the error is announced when it appears.
- The input properly announces its invalid state (`aria-invalid="true"`) when validation fails.
- The input is explicitly linked to the error description (`aria-describedby`) for contextual reading.

---
*PR created automatically by Jules for task [7535750204159313389](https://jules.google.com/task/7535750204159313389) started by @schmug*