### PR TITLE
docs: move database migration rules to src/db/CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,11 +90,7 @@ Live at dmarc.mx | Repo: github.com/schmug/dmarcheck
 
 ## Database migrations
 
-- Migrations live in `src/db/migrations/`, named `NNNN_description.sql` with a monotonically-increasing 4-digit prefix. Pick the next prefix by listing the directory — never reuse one (PR #154 collided on `0003_` and had to be renamed).
-- Every schema change updates **both** `src/db/schema.sql` (fresh-DB shape) and a new migration file (delta against prod). The migration is what runs against the live D1; `schema.sql` is what self-hosters apply on first install.
-- **Additive-only**: new tables, new nullable or defaulted columns, new indexes. Column drops, renames, and type changes go through a two-PR expand/contract because `.github/workflows/migrate.yml` and the Cloudflare Git auto-deploy run in parallel — there is no ordering guarantee between schema change and code change.
-- Migrations apply automatically: `.github/workflows/migrate.yml` runs `wrangler d1 migrations apply dmarcheck-db --remote` after CI passes on `main`. **Do not** run `npx wrangler d1 execute --file=...` by hand anymore.
-- Wrangler tracks applied migrations in the `d1_migrations` table. If a migration is added, applied manually, and then automation tries to replay it, `ALTER TABLE ADD COLUMN` will fail. If you ever apply one out of band, also `INSERT INTO d1_migrations (name) VALUES ('NNNN_description.sql')` so the workflow skips it.
+Database migration rules: see [src/db/CLAUDE.md](src/db/CLAUDE.md)
 
 ## Testing
 

--- a/src/db/CLAUDE.md
+++ b/src/db/CLAUDE.md
@@ -1,0 +1,7 @@
+# Database Migrations
+
+- Migrations live in `src/db/migrations/`, named `NNNN_description.sql` with a monotonically-increasing 4-digit prefix. Pick the next prefix by listing the directory — never reuse one (PR #154 collided on `0003_` and had to be renamed).
+- Every schema change updates **both** `src/db/schema.sql` (fresh-DB shape) and a new migration file (delta against prod). The migration is what runs against the live D1; `schema.sql` is what self-hosters apply on first install.
+- **Additive-only**: new tables, new nullable or defaulted columns, new indexes. Column drops, renames, and type changes go through a two-PR expand/contract because `.github/workflows/migrate.yml` and the Cloudflare Git auto-deploy run in parallel — there is no ordering guarantee between schema change and code change.
+- Migrations apply automatically: `.github/workflows/migrate.yml` runs `wrangler d1 migrations apply dmarcheck-db --remote` after CI passes on `main`. **Do not** run `npx wrangler d1 execute --file=...` by hand anymore.
+- Wrangler tracks applied migrations in the `d1_migrations` table. If a migration is added, applied manually, and then automation tries to replay it, `ALTER TABLE ADD COLUMN` will fail. If you ever apply one out of band, also `INSERT INTO d1_migrations (name) VALUES ('NNNN_description.sql')` so the workflow skips it.


### PR DESCRIPTION
## Summary

- Extracts the full "## Database migrations" block from the root `CLAUDE.md` into a new `src/db/CLAUDE.md` file so that migration rules only load into an agent's context when it is working under `src/db/` (context efficiency).
- Root `CLAUDE.md` retains the section heading with a one-line pointer: `Database migration rules: see [src/db/CLAUDE.md](src/db/CLAUDE.md)`.

Closes #283

## Test plan

- [ ] `git grep "expand.contract" src/db/` finds a result in `src/db/CLAUDE.md`
- [ ] `git grep "d1_migrations" src/db/` finds results in `src/db/CLAUDE.md`
- [ ] Root `CLAUDE.md` no longer contains the full migration bullet list
- [ ] `src/db/CLAUDE.md` contains all five original migration rules verbatim, including the PR #154 reference
- [ ] No code files were modified

https://claude.ai/code/session_013KLcbwzgnEaQy2KjWpaKbk

---
_Generated by [Claude Code](https://claude.ai/code/session_013KLcbwzgnEaQy2KjWpaKbk)_