### PR TITLE
feat: add MX/MTA-STS consistency coverage checks

### DIFF
--- a/src/analyzers/mta-sts.ts
+++ b/src/analyzers/mta-sts.ts
@@ -1,6 +1,67 @@
 import { queryTxt } from "../dns/client.js";
 import type { MtaStsPolicy, MtaStsResult, Validation } from "./types.js";
 
+/**
+ * Check whether each MX hostname is covered by at least one MTA-STS mx pattern.
+ *
+ * Pattern matching follows RFC 8461 §3.1:
+ * - A pattern that begins with "*." is a wildcard covering exactly one
+ *   subdomain level (e.g. "*.example.com" matches "mail.example.com" but NOT
+ *   "deep.mail.example.com" and NOT "example.com" itself).
+ * - All other patterns are compared as literal hostnames (case-insensitive).
+ *
+ * Returns the subset of mxHosts that are NOT covered by any pattern.
+ */
+export function checkMxCoverage(
+  mxHosts: string[],
+  stsMxPatterns: string[],
+): string[] {
+  const uncovered: string[] = [];
+
+  for (const host of mxHosts) {
+    const normalizedHost = host.toLowerCase();
+    let covered = false;
+
+    for (const pattern of stsMxPatterns) {
+      const normalizedPattern = pattern.toLowerCase();
+
+      if (normalizedPattern.slice(0, 2) === "*.") {
+        // Wildcard pattern: "*.suffix" — host must be exactly one label deeper
+        // than the suffix, i.e. host === "<single-label>.<suffix>"
+        const suffix = normalizedPattern.slice(2); // e.g. "example.com"
+        // The host must end with ".<suffix>" and the part before that must
+        // contain no dots (single label only).
+        if (normalizedHost.length > suffix.length + 1) {
+          const dotSuffix = `.${suffix}`;
+          if (normalizedHost.slice(-dotSuffix.length) === dotSuffix) {
+            const prefix = normalizedHost.slice(
+              0,
+              normalizedHost.length - dotSuffix.length,
+            );
+            // prefix must be a single label (no dots)
+            if (prefix.indexOf(".") === -1 && prefix.length > 0) {
+              covered = true;
+              break;
+            }
+          }
+        }
+      } else {
+        // Literal match (case-insensitive)
+        if (normalizedHost === normalizedPattern) {
+          covered = true;
+          break;
+        }
+      }
+    }
+
+    if (!covered) {
+      uncovered.push(host);
+    }
+  }
+
+  return uncovered;
+}
+
 export async function analyzeMtaSts(domain: string): Promise<MtaStsResult> {
   const [dnsResult, policyResult] = await Promise.allSettled([
     queryTxt(`_mta-sts.${domain}`),

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -2,7 +2,7 @@ import * as Sentry from "@sentry/cloudflare";
 import { analyzeBimi, prefetchBimiDns } from "./analyzers/bimi.js";
 import { analyzeDkim } from "./analyzers/dkim.js";
 import { analyzeDmarc } from "./analyzers/dmarc.js";
-import { analyzeMtaSts } from "./analyzers/mta-sts.js";
+import { analyzeMtaSts, checkMxCoverage } from "./analyzers/mta-sts.js";
 import { analyzeMx } from "./analyzers/mx.js";
 import { analyzeSecurityTxt } from "./analyzers/security-txt.js";
 import { analyzeSpf } from "./analyzers/spf.js";
@@ -36,10 +36,41 @@ export type ProtocolResult =
   | MtaStsResult
   | SecurityTxtResult;
 
+function applyMxCoverageCheck(protocols: ScanResult["protocols"]): void {
+  const { mx, mta_sts } = protocols;
+
+  // Only run when MX records exist and MTA-STS policy is present and enforced
+  // (mode "none" means the policy is intentionally disabled, so no check needed)
+  if (
+    mx.records.length === 0 ||
+    mta_sts.policy === null ||
+    mta_sts.policy.mode === "none"
+  ) {
+    return;
+  }
+
+  const mxHosts = mx.records.map((r) => r.exchange);
+  const uncovered = checkMxCoverage(mxHosts, mta_sts.policy.mx);
+
+  for (const host of uncovered) {
+    mta_sts.validations.push({
+      status: "warn",
+      message: `MX host "${host}" is not covered by any MTA-STS mx pattern`,
+    });
+  }
+
+  // Recalculate status if we added new warnings and the result was previously "pass"
+  if (uncovered.length > 0 && mta_sts.status === "pass") {
+    mta_sts.status = "warn";
+  }
+}
+
 async function buildScanResult(
   domain: string,
   protocols: ScanResult["protocols"],
 ): Promise<ScanResult> {
+  applyMxCoverageCheck(protocols);
+
   const breakdown = computeGradeBreakdown(protocols);
 
   // Easter egg: S grade for A+ domains advertising dmarc.mx

--- a/test/mta-sts.test.ts
+++ b/test/mta-sts.test.ts
@@ -5,7 +5,7 @@ vi.mock("../src/dns/client.js", () => ({
   queryMx: vi.fn(),
 }));
 
-import { analyzeMtaSts } from "../src/analyzers/mta-sts.js";
+import { analyzeMtaSts, checkMxCoverage } from "../src/analyzers/mta-sts.js";
 import { queryTxt } from "../src/dns/client.js";
 
 const mockQueryTxt = vi.mocked(queryTxt);
@@ -272,5 +272,75 @@ describe("analyzeMtaSts", () => {
           v.message.includes("Policy file not accessible"),
       ),
     ).toBe(true);
+  });
+});
+
+describe("checkMxCoverage", () => {
+  it("returns empty array when all MX hosts are covered by literal patterns", () => {
+    const uncovered = checkMxCoverage(
+      ["mail.example.com", "backup.example.com"],
+      ["mail.example.com", "backup.example.com"],
+    );
+    expect(uncovered).toEqual([]);
+  });
+
+  it("returns uncovered host when one MX host is missing from policy", () => {
+    const uncovered = checkMxCoverage(
+      ["mail.example.com", "unlisted.example.com"],
+      ["mail.example.com"],
+    );
+    expect(uncovered).toEqual(["unlisted.example.com"]);
+  });
+
+  it("wildcard pattern *.example.com matches mail.example.com (one subdomain level)", () => {
+    const uncovered = checkMxCoverage(["mail.example.com"], ["*.example.com"]);
+    expect(uncovered).toEqual([]);
+  });
+
+  it("wildcard pattern *.example.com does NOT match sub.mail.example.com (two subdomain levels)", () => {
+    const uncovered = checkMxCoverage(
+      ["sub.mail.example.com"],
+      ["*.example.com"],
+    );
+    expect(uncovered).toEqual(["sub.mail.example.com"]);
+  });
+
+  it("wildcard pattern *.example.com does NOT match example.com itself", () => {
+    const uncovered = checkMxCoverage(["example.com"], ["*.example.com"]);
+    expect(uncovered).toEqual(["example.com"]);
+  });
+
+  it("matching is case-insensitive for both host and pattern", () => {
+    const uncovered = checkMxCoverage(
+      ["MAIL.Example.COM"],
+      ["mail.example.com"],
+    );
+    expect(uncovered).toEqual([]);
+  });
+
+  it("wildcard matching is case-insensitive", () => {
+    const uncovered = checkMxCoverage(["MAIL.EXAMPLE.COM"], ["*.example.com"]);
+    expect(uncovered).toEqual([]);
+  });
+
+  it("returns empty array when mxHosts is empty", () => {
+    const uncovered = checkMxCoverage([], ["*.example.com"]);
+    expect(uncovered).toEqual([]);
+  });
+
+  it("returns all hosts as uncovered when stsMxPatterns is empty", () => {
+    const uncovered = checkMxCoverage(
+      ["mail.example.com", "backup.example.com"],
+      [],
+    );
+    expect(uncovered).toEqual(["mail.example.com", "backup.example.com"]);
+  });
+
+  it("multiple patterns: host covered by any one pattern is not flagged", () => {
+    const uncovered = checkMxCoverage(
+      ["mail.example.com", "mx.other.com"],
+      ["*.example.com", "mx.other.com"],
+    );
+    expect(uncovered).toEqual([]);
   });
 });


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `checkMxCoverage(mxHosts, stsMxPatterns)` to `src/analyzers/mta-sts.ts`, implementing RFC 8461 §3.1 wildcard and literal hostname pattern matching
- Wires the check into `buildScanResult` in `src/orchestrator.ts` — runs after both MX and MTA-STS results are available, appends `warn` validations for any uncovered MX hosts, and upgrades the MTA-STS status from `pass` → `warn` when violations are found
- Guard conditions: skips the check when MX records are absent, when no MTA-STS policy is present, or when policy mode is `"none"` (enforcement intentionally disabled)
- Adds 10 new unit tests in `test/mta-sts.test.ts` covering all specified RFC matching rules and edge cases

Closes #237

## Test plan

- [ ] All 24 tests in `test/mta-sts.test.ts` pass (14 pre-existing + 10 new `checkMxCoverage` tests)
- [ ] `npm run typecheck` — clean (no errors)
- [ ] `npm run lint` — clean (no errors)
- [ ] `checkMxCoverage(["mail.example.com"], ["*.example.com"])` → `[]` (covered)
- [ ] `checkMxCoverage(["sub.mail.example.com"], ["*.example.com"])` → `["sub.mail.example.com"]` (not covered — two subdomain levels)
- [ ] `checkMxCoverage(["example.com"], ["*.example.com"])` → `["example.com"]` (not covered — wildcard doesn't match apex)
- [ ] MTA-STS mode=none → no check runs
- [ ] No MX records → no check runs
- [ ] No MTA-STS policy → no check runs

https://claude.ai/code/session_013KLcbwzgnEaQy2KjWpaKbk
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_013KLcbwzgnEaQy2KjWpaKbk)_