### PR TITLE
feat: add SMTP TLS Reporting (TLS-RPT) analyzer

### DIFF
--- a/src/analyzers/tls-rpt.ts
+++ b/src/analyzers/tls-rpt.ts
@@ -1,0 +1,130 @@
+import { DnsLookupError, queryTxt } from "../dns/client.js";
+import { parseTags } from "../shared/parse-tags.js";
+import type { TlsRptResult, Validation } from "./types.js";
+
+// RFC 8460 — SMTP TLS Reporting. DNS-only; no SMTP socket probing.
+// Looks up `_smtp._tls.<domain>` TXT for a v=TLSRPTv1 record.
+
+export async function analyzeTlsRpt(domain: string): Promise<TlsRptResult> {
+  let txt: Awaited<ReturnType<typeof queryTxt>>;
+  try {
+    txt = await queryTxt(`_smtp._tls.${domain}`);
+  } catch (err) {
+    if (err instanceof DnsLookupError) {
+      return {
+        status: "warn",
+        record: null,
+        tags: null,
+        validations: [
+          {
+            status: "warn",
+            message: `TLS-RPT lookup failed (${err.code}) — result may be incomplete`,
+          },
+        ],
+      };
+    }
+    throw err;
+  }
+
+  if (!txt) {
+    return {
+      status: "fail",
+      record: null,
+      tags: null,
+      validations: [{ status: "fail", message: "No TLS-RPT record found" }],
+    };
+  }
+
+  const tlsRptRecords = txt.entries.filter((e) =>
+    e.trimStart().startsWith("v=TLSRPTv1"),
+  );
+  const unrelated = txt.entries.filter(
+    (e) => !e.trimStart().startsWith("v=TLSRPTv1"),
+  );
+
+  const validations: Validation[] = [];
+
+  if (unrelated.length > 0) {
+    validations.push({
+      status: "warn",
+      message: `${unrelated.length} unrelated TXT record${unrelated.length > 1 ? "s" : ""} found at _smtp._tls.${domain}`,
+    });
+  }
+
+  if (tlsRptRecords.length === 0) {
+    return {
+      status: "fail",
+      record: txt.raw,
+      tags: null,
+      validations: [
+        ...validations,
+        {
+          status: "fail",
+          message: "No valid TLS-RPT record found (missing v=TLSRPTv1)",
+        },
+      ],
+    };
+  }
+
+  if (tlsRptRecords.length > 1) {
+    validations.push({
+      status: "warn",
+      message: `Multiple TLS-RPT records found at _smtp._tls.${domain} — only one is allowed`,
+    });
+  }
+
+  // Use the first TLS-RPT record
+  const record = tlsRptRecords[0];
+  const tags = parseTags(record);
+
+  validations.push({ status: "pass", message: "TLS-RPT record found" });
+
+  // rua= is required (RFC 8460 §3)
+  if (!tags.rua) {
+    validations.push({
+      status: "warn",
+      message:
+        "Missing required rua= tag — no reporting destination configured",
+    });
+    return {
+      status: "warn",
+      record,
+      tags,
+      validations,
+    };
+  }
+
+  // Validate rua destinations
+  const ruaEntries = tags.rua
+    .split(",")
+    .map((u) => u.trim())
+    .filter(Boolean);
+  if (ruaEntries.length === 0) {
+    validations.push({
+      status: "warn",
+      message: "rua= tag is empty — no reporting destination configured",
+    });
+  } else {
+    const validUriPrefixes = ["mailto:", "https://"];
+    const invalid = ruaEntries.filter(
+      (u) => !validUriPrefixes.some((prefix) => u.startsWith(prefix)),
+    );
+    if (invalid.length > 0) {
+      validations.push({
+        status: "warn",
+        message: `rua= contains malformed destination${invalid.length > 1 ? "s" : ""}: ${invalid.map((u) => `"${u}"`).join(", ")} — expected mailto: or https:// URI`,
+      });
+    } else {
+      validations.push({
+        status: "pass",
+        message: `${ruaEntries.length} reporting destination${ruaEntries.length > 1 ? "s" : ""} configured`,
+      });
+    }
+  }
+
+  const hasFailure = validations.some((v) => v.status === "fail");
+  const hasWarn = validations.some((v) => v.status === "warn");
+  const status = hasFailure ? "fail" : hasWarn ? "warn" : "pass";
+
+  return { status, record, tags, validations };
+}

--- a/src/analyzers/types.ts
+++ b/src/analyzers/types.ts
@@ -105,6 +105,13 @@ export interface SecurityTxtResult {
   validations: Validation[];
 }
 
+export interface TlsRptResult {
+  status: Status;
+  record: string | null;
+  tags: Record<string, string> | null;
+  validations: Validation[];
+}
+
 export interface ScanSummary {
   mx_records: number;
   mx_providers: string[];
@@ -130,5 +137,6 @@ export interface ScanResult {
     bimi: BimiResult;
     mta_sts: MtaStsResult;
     security_txt: SecurityTxtResult;
+    tls_rpt: TlsRptResult;
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import type {
   ScanResult,
   SecurityTxtResult,
   SpfResult,
+  TlsRptResult,
 } from "./analyzers/types.js";
 import {
   getAgentSkillsIndexJson,
@@ -80,6 +81,7 @@ import {
   renderSecurityTxtCard,
   renderSpfCard,
   renderStreamingLoading,
+  renderTlsRptCard,
 } from "./views/html.js";
 import {
   renderLearnBimi,
@@ -513,6 +515,7 @@ const protocolRenderers: Record<
   bimi: (r) => renderBimiCard(r as BimiResult),
   mta_sts: (r) => renderMtaStsCard(r as MtaStsResult),
   security_txt: (r) => renderSecurityTxtCard(r as SecurityTxtResult),
+  tls_rpt: (r) => renderTlsRptCard(r as TlsRptResult),
 };
 
 function tagScanResult(result: ScanResult): void {

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -6,6 +6,7 @@ import { analyzeMtaSts } from "./analyzers/mta-sts.js";
 import { analyzeMx } from "./analyzers/mx.js";
 import { analyzeSecurityTxt } from "./analyzers/security-txt.js";
 import { analyzeSpf } from "./analyzers/spf.js";
+import { analyzeTlsRpt } from "./analyzers/tls-rpt.js";
 import type {
   BimiResult,
   DkimResult,
@@ -15,6 +16,7 @@ import type {
   ScanResult,
   SecurityTxtResult,
   SpfResult,
+  TlsRptResult,
 } from "./analyzers/types.js";
 import { queryTxt } from "./dns/client.js";
 import { computeGradeBreakdown } from "./shared/scoring.js";
@@ -26,7 +28,8 @@ export type ProtocolId =
   | "dkim"
   | "bimi"
   | "mta_sts"
-  | "security_txt";
+  | "security_txt"
+  | "tls_rpt";
 export type ProtocolResult =
   | MxResult
   | DmarcResult
@@ -34,7 +37,8 @@ export type ProtocolResult =
   | DkimResult
   | BimiResult
   | MtaStsResult
-  | SecurityTxtResult;
+  | SecurityTxtResult
+  | TlsRptResult;
 
 async function buildScanResult(
   domain: string,
@@ -89,6 +93,7 @@ export async function scan(
   const bimiDnsPromise = prefetchBimiDns(domain);
   const mxPromise = analyzeMx(domain);
   const securityTxtPromise = analyzeSecurityTxt(domain);
+  const tlsRptPromise = analyzeTlsRpt(domain);
 
   // Chain DKIM off MX so it starts as soon as MX resolves
   // without blocking on unrelated queries
@@ -118,6 +123,7 @@ export async function scan(
     bimiResult,
     mxResult,
     securityTxtResult,
+    tlsRptResult,
   ] = await Promise.all([
     dmarcPromise,
     spfPromise,
@@ -126,6 +132,7 @@ export async function scan(
     bimiPromise,
     mxPromise,
     securityTxtPromise,
+    tlsRptPromise,
   ]);
 
   Sentry.addBreadcrumb({
@@ -164,6 +171,12 @@ export async function scan(
     data: { protocol: "security_txt", status: securityTxtResult.status },
     level: "info",
   });
+  Sentry.addBreadcrumb({
+    category: "analyzer.complete",
+    message: `tls_rpt: ${tlsRptResult.status}`,
+    data: { protocol: "tls_rpt", status: tlsRptResult.status },
+    level: "info",
+  });
 
   return await buildScanResult(domain, {
     mx: mxResult,
@@ -173,6 +186,7 @@ export async function scan(
     bimi: bimiResult,
     mta_sts: mtaStsResult,
     security_txt: securityTxtResult,
+    tls_rpt: tlsRptResult,
   });
 }
 
@@ -192,6 +206,7 @@ export async function scanStreaming(
   const bimiDnsPromise = prefetchBimiDns(domain);
   const mxPromise = analyzeMx(domain);
   const securityTxtPromise = analyzeSecurityTxt(domain);
+  const tlsRptPromise = analyzeTlsRpt(domain);
 
   // Chain DKIM off MX so it starts as soon as MX resolves
   const dkimPromise = mxPromise.then((mxResult) => {
@@ -278,6 +293,16 @@ export async function scanStreaming(
     onResult("security_txt", r);
   });
 
+  tlsRptPromise.then((r) => {
+    Sentry.addBreadcrumb({
+      category: "analyzer.complete",
+      message: `tls_rpt: ${r.status}`,
+      data: { protocol: "tls_rpt", status: r.status },
+      level: "info",
+    });
+    onResult("tls_rpt", r);
+  });
+
   const [
     dmarcResult,
     spfResult,
@@ -286,6 +311,7 @@ export async function scanStreaming(
     bimiResult,
     mxResult,
     securityTxtResult,
+    tlsRptResult,
   ] = await Promise.all([
     dmarcPromise,
     spfPromise,
@@ -294,6 +320,7 @@ export async function scanStreaming(
     bimiPromise,
     mxPromise,
     securityTxtPromise,
+    tlsRptPromise,
   ]);
 
   return await buildScanResult(domain, {
@@ -304,5 +331,6 @@ export async function scanStreaming(
     bimi: bimiResult,
     mta_sts: mtaStsResult,
     security_txt: securityTxtResult,
+    tls_rpt: tlsRptResult,
   });
 }

--- a/src/shared/scoring.ts
+++ b/src/shared/scoring.ts
@@ -15,10 +15,10 @@ interface Protocols {
   bimi: BimiResult;
   mta_sts: MtaStsResult;
   // Optional in this internal interface so older test fixtures (which
-  // don't know about security_txt) keep typechecking against this shape.
-  // The orchestrator always populates it; informational only — does not
-  // affect grade resolution.
+  // don't know about security_txt or tls_rpt) keep typechecking.
+  // The orchestrator always populates both; neither affects grade resolution.
   security_txt?: SecurityTxtResult;
+  tls_rpt?: unknown;
   [key: string]: unknown;
 }
 

--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -7,6 +7,7 @@ import type {
   ScanResult,
   SecurityTxtResult,
   SpfResult,
+  TlsRptResult,
 } from "../analyzers/types.js";
 import { isIndexableScanDomain } from "../shared/indexable-domains.js";
 import { CSS_PATH, JS_PATH } from "./assets.js";
@@ -328,6 +329,23 @@ export function renderSecurityTxtCard(s: SecurityTxtResult): string {
   );
 }
 
+export function renderTlsRptCard(t: TlsRptResult): string {
+  const subtitle = t.record ? "Record found" : "Not configured";
+  let body = "";
+  if (t.tags?.rua) {
+    const rows: string[] = [];
+    rows.push(
+      `<div><strong>rua</strong></div><div><code>${esc(t.tags.rua)}</code></div>`,
+    );
+    body += `<div class="tag-grid">${rows.join("")}</div>`;
+  }
+  body += validationList(t.validations);
+  if (t.record) {
+    body += rawRecord(t.record);
+  }
+  return protocolCard("TLS-RPT", t.status, subtitle, body, false, "tls-rpt");
+}
+
 export function renderMxCard(mx: MxResult): string {
   const subtitle =
     mx.records.length > 0
@@ -338,7 +356,7 @@ export function renderMxCard(mx: MxResult): string {
 }
 
 function reportBody(result: ScanResult): string {
-  const { mx, dmarc, spf, dkim, bimi, mta_sts, security_txt } =
+  const { mx, dmarc, spf, dkim, bimi, mta_sts, security_txt, tls_rpt } =
     result.protocols;
 
   return `<main class="report">
@@ -367,6 +385,7 @@ function reportBody(result: ScanResult): string {
   ${renderBimiCard(bimi)}
   ${renderMtaStsCard(mta_sts)}
   ${security_txt ? renderSecurityTxtCard(security_txt) : ""}
+  ${tls_rpt ? renderTlsRptCard(tls_rpt) : ""}
   ${monitorSnapshotCard(result)}
   <div class="learn-link" style="margin-top:2.5rem">Analyze message headers: <a href="https://toolbox.googleapps.com/apps/messageheader/" target="_blank" rel="noopener">Google &#8599;</a> &middot; <a href="https://mha.azurewebsites.net/" target="_blank" rel="noopener">Microsoft &#8599;</a></div>
   <div class="learn-link" style="margin-top:0.4rem;margin-bottom:1rem"><a href="/scoring">How is my score calculated?</a> &middot; <a href="https://www.cloudflare.com/learning/email-security/dmarc-dkim-spf/" target="_blank" rel="noopener">What is email security? &#8599;</a></div>

--- a/test/tls-rpt.test.ts
+++ b/test/tls-rpt.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/dns/client.js", () => ({
+  queryTxt: vi.fn(),
+  queryMx: vi.fn(),
+  DnsLookupError: class DnsLookupError extends Error {
+    code: string;
+    constructor(code: string, message: string) {
+      super(message);
+      this.code = code;
+    }
+  },
+}));
+
+import { analyzeTlsRpt } from "../src/analyzers/tls-rpt.js";
+import { queryTxt } from "../src/dns/client.js";
+
+const mockQueryTxt = vi.mocked(queryTxt);
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("analyzeTlsRpt — no record", () => {
+  it("returns fail status when no TXT record at _smtp._tls", async () => {
+    mockQueryTxt.mockResolvedValueOnce(null);
+
+    const result = await analyzeTlsRpt("example.com");
+
+    expect(result.status).toBe("fail");
+    expect(result.record).toBeNull();
+    expect(result.tags).toBeNull();
+    expect(result.validations.some((v) => v.status === "fail")).toBe(true);
+    expect(mockQueryTxt).toHaveBeenCalledWith("_smtp._tls.example.com");
+  });
+
+  it("returns fail when TXT record exists but has no v=TLSRPTv1", async () => {
+    mockQueryTxt.mockResolvedValueOnce({
+      entries: ["v=spf1 include:example.com -all"],
+      raw: "v=spf1 include:example.com -all",
+    });
+
+    const result = await analyzeTlsRpt("example.com");
+
+    expect(result.status).toBe("fail");
+    expect(
+      result.validations.some(
+        (v) => v.status === "fail" && v.message.includes("v=TLSRPTv1"),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("analyzeTlsRpt — valid record", () => {
+  it("returns pass status for a well-formed v=TLSRPTv1 record with rua", async () => {
+    mockQueryTxt.mockResolvedValueOnce({
+      entries: ["v=TLSRPTv1; rua=mailto:reports@example.com"],
+      raw: "v=TLSRPTv1; rua=mailto:reports@example.com",
+    });
+
+    const result = await analyzeTlsRpt("example.com");
+
+    expect(result.status).toBe("pass");
+    expect(result.record).toBe("v=TLSRPTv1; rua=mailto:reports@example.com");
+    expect(result.tags?.rua).toBe("mailto:reports@example.com");
+    expect(result.validations.some((v) => v.status === "pass")).toBe(true);
+  });
+
+  it("returns pass for https:// rua destination", async () => {
+    mockQueryTxt.mockResolvedValueOnce({
+      entries: ["v=TLSRPTv1; rua=https://example.com/tls-report"],
+      raw: "v=TLSRPTv1; rua=https://example.com/tls-report",
+    });
+
+    const result = await analyzeTlsRpt("example.com");
+
+    expect(result.status).toBe("pass");
+  });
+
+  it("returns pass for multiple rua destinations", async () => {
+    mockQueryTxt.mockResolvedValueOnce({
+      entries: [
+        "v=TLSRPTv1; rua=mailto:tlsrpt@example.com,https://report.example.com/tls",
+      ],
+      raw: "v=TLSRPTv1; rua=mailto:tlsrpt@example.com,https://report.example.com/tls",
+    });
+
+    const result = await analyzeTlsRpt("example.com");
+
+    expect(result.status).toBe("pass");
+    expect(
+      result.validations.some(
+        (v) =>
+          v.status === "pass" && v.message.includes("2 reporting destination"),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("analyzeTlsRpt — warnings", () => {
+  it("warns when multiple TLS-RPT records are present", async () => {
+    mockQueryTxt.mockResolvedValueOnce({
+      entries: [
+        "v=TLSRPTv1; rua=mailto:a@example.com",
+        "v=TLSRPTv1; rua=mailto:b@example.com",
+      ],
+      raw: "v=TLSRPTv1; rua=mailto:a@example.com",
+    });
+
+    const result = await analyzeTlsRpt("example.com");
+
+    expect(
+      result.validations.some(
+        (v) => v.status === "warn" && v.message.includes("Multiple TLS-RPT"),
+      ),
+    ).toBe(true);
+  });
+
+  it("warns when unrelated TXT records exist at _smtp._tls", async () => {
+    mockQueryTxt.mockResolvedValueOnce({
+      entries: [
+        "v=TLSRPTv1; rua=mailto:reports@example.com",
+        "some unrelated record",
+      ],
+      raw: "v=TLSRPTv1; rua=mailto:reports@example.com",
+    });
+
+    const result = await analyzeTlsRpt("example.com");
+
+    expect(
+      result.validations.some(
+        (v) => v.status === "warn" && v.message.includes("unrelated TXT"),
+      ),
+    ).toBe(true);
+  });
+
+  it("warns when rua= tag is missing", async () => {
+    mockQueryTxt.mockResolvedValueOnce({
+      entries: ["v=TLSRPTv1"],
+      raw: "v=TLSRPTv1",
+    });
+
+    const result = await analyzeTlsRpt("example.com");
+
+    expect(result.status).toBe("warn");
+    expect(
+      result.validations.some(
+        (v) => v.status === "warn" && v.message.includes("rua="),
+      ),
+    ).toBe(true);
+  });
+
+  it("warns when rua= contains a malformed URI (not mailto: or https://)", async () => {
+    mockQueryTxt.mockResolvedValueOnce({
+      entries: ["v=TLSRPTv1; rua=ftp://invalid.example.com"],
+      raw: "v=TLSRPTv1; rua=ftp://invalid.example.com",
+    });
+
+    const result = await analyzeTlsRpt("example.com");
+
+    expect(
+      result.validations.some(
+        (v) => v.status === "warn" && v.message.includes("malformed"),
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds RFC 8460 TLS-RPT analyzer: looks up `_smtp._tls.<domain>` TXT for `v=TLSRPTv1` records
- Validates `rua=` destinations (accepts `mailto:` and `https://` URIs), warns on multiple records, unrelated TXT entries, missing rua, and malformed URIs
- Wired through orchestrator (`scan` + `scanStreaming`), HTML report card, `index.ts` streaming renderers, and type system; does not affect grade scoring

Closes #235

## Test plan

- [x] 9 new unit tests in `test/tls-rpt.test.ts` covering: no record, NXDOMAIN, valid record with mailto/https rua, multiple rua, multiple TLS-RPT records (warn), unrelated TXT (warn), missing rua (warn), malformed URI (warn)
- [x] 888 passing, 1 failing (pre-existing: `mta-sts-runtime.test.ts` requires live network, fails in sandbox — unrelated)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean

https://claude.ai/code/session_013KLcbwzgnEaQy2KjWpaKbk

---
_Generated by [Claude Code](https://claude.ai/code/session_013KLcbwzgnEaQy2KjWpaKbk)_