### PR TITLE
docs: move Database migrations rules to src/db/CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,11 +90,7 @@ Live at dmarc.mx | Repo: github.com/schmug/dmarcheck
 
 ## Database migrations
 
-- Migrations live in `src/db/migrations/`, named `NNNN_description.sql` with a monotonically-increasing 4-digit prefix. Pick the next prefix by listing the directory — never reuse one (PR #154 collided on `0003_` and had to be renamed).
-- Every schema change updates **both** `src/db/schema.sql` (fresh-DB shape) and a new migration file (delta against prod). The migration is what runs against the live D1; `schema.sql` is what self-hosters apply on first install.
-- **Additive-only**: new tables, new nullable or defaulted columns, new indexes. Column drops, renames, and type changes go through a two-PR expand/contract because `.github/workflows/migrate.yml` and the Cloudflare Git auto-deploy run in parallel — there is no ordering guarantee between schema change and code change.
-- Migrations apply automatically: `.github/workflows/migrate.yml` runs `wrangler d1 migrations apply dmarcheck-db --remote` after CI passes on `main`. **Do not** run `npx wrangler d1 execute --file=...` by hand anymore.
-- Wrangler tracks applied migrations in the `d1_migrations` table. If a migration is added, applied manually, and then automation tries to replay it, `ALTER TABLE ADD COLUMN` will fail. If you ever apply one out of band, also `INSERT INTO d1_migrations (name) VALUES ('NNNN_description.sql')` so the workflow skips it.
+Database migration rules: see `src/db/CLAUDE.md`.
 
 ## Testing
 

--- a/src/db/CLAUDE.md
+++ b/src/db/CLAUDE.md
@@ -1,0 +1,7 @@
+# Database migrations — dmarcheck
+
+- Migrations live in `src/db/migrations/`, named `NNNN_description.sql` with a monotonically-increasing 4-digit prefix. Pick the next prefix by listing the directory — never reuse one (PR #154 collided on `0003_` and had to be renamed).
+- Every schema change updates **both** `src/db/schema.sql` (fresh-DB shape) and a new migration file (delta against prod). The migration is what runs against the live D1; `schema.sql` is what self-hosters apply on first install.
+- **Additive-only**: new tables, new nullable or defaulted columns, new indexes. Column drops, renames, and type changes go through a two-PR expand/contract because `.github/workflows/migrate.yml` and the Cloudflare Git auto-deploy run in parallel — there is no ordering guarantee between schema change and code change.
+- Migrations apply automatically: `.github/workflows/migrate.yml` runs `wrangler d1 migrations apply dmarcheck-db --remote` after CI passes on `main`. **Do not** run `npx wrangler d1 execute --file=...` by hand anymore.
+- Wrangler tracks applied migrations in the `d1_migrations` table. If a migration is added, applied manually, and then automation tries to replay it, `ALTER TABLE ADD COLUMN` will fail. If you ever apply one out of band, also `INSERT INTO d1_migrations (name) VALUES ('NNNN_description.sql')` so the workflow skips it.


### PR DESCRIPTION
## Summary

- Extracted the full "Database migrations" block from root `CLAUDE.md` into a new `src/db/CLAUDE.md` so the high-stakes migration rules load additively only when an agent is working under `src/db/`.
- Root `CLAUDE.md` retains a one-line pointer (`Database migration rules: see \`src/db/CLAUDE.md\`.`) under the existing section heading.
- Zero information loss — every rule (prefix scheme, schema.sql + migration dual-update, additive-only/expand-contract, auto-apply via migrate.yml, d1_migrations bookkeeping) is verbatim in the new location.

Closes #283

## Test plan

- [x] `src/db/CLAUDE.md` exists and contains complete migration ruleset
- [x] `grep "expand/contract" src/db/CLAUDE.md` — found
- [x] `grep "d1_migrations" src/db/CLAUDE.md` — found
- [x] Root `CLAUDE.md` no longer contains the full block; has one-line pointer
- [x] No migration rule dropped or altered in meaning (verbatim copy)

## Deferred follow-ups

None — this is the complete scope of #283. Creating subdirectory CLAUDE.md files for other dirs is explicitly out of scope per the issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_019oy1L3gWueAKkfTpxk1Lvg)_