### PR TITLE
feat: associate webhook-format select with help text for screen readers

### DIFF
--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -2756,12 +2756,12 @@ ${retirementBanner}
       spellcheck="false"
     >
     <label for="webhook-format" style="display:block;font-size:0.875rem;color:var(--clr-text-muted);margin-bottom:0.4rem;margin-top:0.75rem">Format</label>
-    <select id="webhook-format" class="settings-input" name="format">
+    <select id="webhook-format" class="settings-input" name="format" aria-describedby="webhook-format-help">
       <option value="raw"${webhookFormat === "raw" ? " selected" : ""}>Raw (signed JSON envelope)</option>
       <option value="slack"${webhookFormat === "slack" ? " selected" : ""}>Slack incoming webhook</option>
       <option value="google_chat"${webhookFormat === "google_chat" ? " selected" : ""}>Google Chat incoming webhook</option>
     </select>
-    <p style="font-size:0.8125rem;color:var(--clr-text-muted);margin:0.4rem 0 0.75rem">
+    <p id="webhook-format-help" style="font-size:0.8125rem;color:var(--clr-text-muted);margin:0.4rem 0 0.75rem">
       Raw posts the signed envelope for your own receiver. Slack and Google Chat send a chat message and omit the signature header (those platforms don't verify it).
     </p>
     <button type="submit" class="btn">Save Webhook</button>


### PR DESCRIPTION
## Summary

Salvages the Settings-page accessibility association from stale PR #243, which is being closed as a duplicate of #286 and would otherwise lose this change.

In `src/views/dashboard.ts`, the webhook-format `<select>` and its following help paragraph (describing the Raw/Slack/Google Chat formats) were not programmatically linked. Screen readers therefore did not announce the format description when the control was focused.

- Added `aria-describedby="webhook-format-help"` to `<select id="webhook-format">`
- Added the matching `id="webhook-format-help"` to the help `<p>`

## Scope

Only the webhook-format association. The Add Domain wizard a11y work that also lived in #243 is **out of scope** here — it is handled by #286.

## Verification

- `npm run lint` — clean (124 files)
- `npm run typecheck` — passes
- `npm test` — 880 passed (54 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)