### PR TITLE
chore: add read-only command allowlist to reduce permission prompts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,17 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(pnpm lint *)",
+      "mcp__ccd_session_mgmt__search_session_transcripts",
+      "Bash(pnpm typecheck *)",
+      "Bash(git fetch *)",
+      "Bash(gh search code *)",
+      "Bash(pnpm test *)",
+      "Bash(npm test *)",
+      "Bash(gh label list *)",
+      "Bash(npm run typecheck)"
+    ]
+  },
   "hooks": {
     "PostToolUse": [
       {


### PR DESCRIPTION
## What

Adds a `permissions.allow` block to `.claude/settings.json` so 9 frequently-used, read-only commands stop prompting.

| Pattern | Count | Notes |
|---|---|---|
| `Bash(pnpm lint *)` | 31 | biome lint check (no --fix) |
| `mcp__ccd_session_mgmt__search_session_transcripts` | 25 | read/search MCP |
| `Bash(pnpm typecheck *)` | 14 | tsc --noEmit |
| `Bash(git fetch *)` | 8 | updates remote refs only |
| `Bash(gh search code *)` | 8 | code search |
| `Bash(pnpm test *)` | 8 | vitest, no side effects |
| `Bash(npm test *)` | 7 | vitest, no side effects |
| `Bash(gh label list *)` | 5 | label inspection |
| `Bash(npm run typecheck)` | 4 | tsc --noEmit (exact form) |

## Why

Generated by `/fewer-permission-prompts`: scanned the 50 most-recently-modified session transcripts (5,444 tool calls, 955 Bash). These were the top read-only patterns not already covered by Claude Code's built-in auto-allow.

## Reviewer notes

- Existing `hooks` (test+typecheck on commit, manual-deploy block, MTA-STS redirect guard) are preserved verbatim — only a new top-level `permissions` key was added.
- Excluded all mutating commands and every arbitrary-code-execution / package-runner pattern (awk, python3, npx/pnpm exec, etc.) per the command's safety rules.
- `git fetch` included as non-mutating to working tree; flag if you'd rather it prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)