### PR TITLE
chore: revert temporary validation cron to daily 17:06 UTC

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Live at dmarc.mx | Repo: github.com/schmug/dmarcheck
 ## Conventions
 
 - Each analyzer is a standalone async function returning a typed result
-- DNS errors (NXDOMAIN/NODATA) return null, not exceptions
+- DNS record absence (NXDOMAIN/NODATA) returns null, not exceptions; resolver errors (SERVFAIL/timeout) throw `DnsLookupError` so callers surface them as `warn` + `lookup_error` instead of false "not configured"
 - Status is `"pass"` | `"warn"` | `"fail"` for scored protocols, `"info"` for informational (MX)
 - HTML is generated server-side as template literal strings, no JSX or build step
 - Client-side JS is minimal (expand/collapse, tooltips) — inline script tag

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -21,11 +21,8 @@ port = 8790
 ACCESS_AUD = "7b283d5d9b56f6fffa342280310a4ae68f13cbb05dc27f3c1d2faec2deae507a"
 ACCESS_TEAM_DOMAIN = "coryrankin.cloudflareaccess.com"
 
-# TEMPORARY test cron — primary fire at 23:33 UTC with a 23:50 UTC safety
-# net to validate the end-to-end alert email pipeline against a seeded
-# alerts row. Revert to ["17 6 * * *"] after verification.
 [triggers]
-crons = ["33 23 * * *", "50 23 * * *"]
+crons = ["17 6 * * *"]
 
 [[d1_databases]]
 binding = "DB"


### PR DESCRIPTION
## Summary

Cleanup step of the #240/#241/#242 merge train. Two minimal changes:

- **`wrangler.toml`**: revert the temporary `["33 23 * * *", "50 23 * * *"]` validation cron back to the normal `["17 6 * * *"]` daily schedule, and drop the now-stale TEMPORARY comment block.
- **`CLAUDE.md`**: update the Conventions DNS line to reflect the post-#277 contract — NXDOMAIN/NODATA still return `null`, but SERVFAIL/timeout now throw `DnsLookupError` (surfaced as `warn` + `lookup_error`). Closes the documentation gap called out in #241's acceptance criteria.

## Validation that justifies the revert

The temp cron was kept for one post-fix cycle to verify #240. Night of **2026-05-15** (post-#268 deploy):

| Metric | Pre-fix cron nights (05-02/09/10) | Post-fix (05-15 23:50) |
|---|---|---|
| Rows | 112–225 | 5 |
| D/F share | ~100% | **0%** |
| Grades | uniform D/F | S, A+, B+, C+ |

Cron grades vs live `/check`: github.com C+/C+, dpi.nc.gov B+/B+, example.com B+/B+, cloudflare.com A+/A+ — **4/4 exact, 0-step delta**. False-fail cascade eliminated.

## Known follow-up (not addressed here)

The 23:33 **primary** cron fire produced zero `scan_history` rows on 2026-05-15; the 23:50 safety-net fire produced the 5. Filing a separate issue to confirm the primary scheduled() fire is healthy. Not a blocker — the safety net behaved as designed and the cascade is fixed.

## Test plan

- [ ] No code paths changed; `wrangler.toml` cron expression + a docs line only
- [ ] CI `check` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)