### PR TITLE
fix: await terminal done SSE event in live-scan path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -619,7 +619,7 @@ app.get("/api/check/stream", async (c) => {
       persistBearerScanIfWatched(c, bearer.userId, domain, result);
     }
 
-    stream.writeSSE({
+    await stream.writeSSE({
       event: "done",
       data: JSON.stringify({
         grade: result.grade,


### PR DESCRIPTION
## Summary

The live-scan branch of `/api/check/stream` (`src/index.ts:622`) wrote the terminal `done` SSE event **without awaiting it**, so the frame could be lost when `stream.close()` ran before it flushed. The cached-result path (`src/index.ts:589`) already awaited correctly — this aligns the live path.

## Context

- Test coverage for this stream path landed independently in #292 (closes #193).
- #271 carried both the tests **and** this one-line fix, but is now a textual duplicate of merged #292 (add/add conflicts on `test/api-check-stream.test.ts` + `test/helpers/drain-sse.ts`).
- This PR extracts the unique production fix from #271. **#271 will be closed as superseded.**

## Verification

- `npm run typecheck` clean
- `npm test` — 958 passing, 0 failing (includes the #292-added stream tests now on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)