### PR TITLE
chore: session-end CLAUDE.md reminder Stop hook (closes #284)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,18 @@
     ]
   },
   "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "git log main..HEAD --oneline 2>/dev/null | grep -qm1 '.' && printf '\\n— Session had commits. Run /revise-claude-md to capture any new gotchas or conventions in CLAUDE.md.\\n' || true",
+            "statusMessage": "Checking for CLAUDE.md update opportunities..."
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 dist/
 .dev.vars
 .worktrees/
+.claude/worktrees/
 docs/internal/
 pnpm-lock.yaml
 .jules/


### PR DESCRIPTION
## Summary

Extracts the two salvageable, not-yet-on-main pieces from #293:

1. **`.claude/settings.json`** — a `Stop` hook that prints a one-line reminder to run `/revise-claude-md` when a session produced commits ahead of `main`. No-op for commit-less sessions; never edits CLAUDE.md; never blocks exit. Closes #284.
2. **`.gitignore`** — ignore `.claude/worktrees/` so multi-clauding scratch worktrees aren't accidentally staged.

## Why not just merge #293

#293 bundled these with a `GET /dashboard/export` feature (superseded by merged #270), a `test/helpers/drain-sse.ts` helper (duped by merged #292 / #303), and a large unreviewed `package-lock.json` re-flatten. Cherry-picking the two clean files here lets #293 be closed without losing this work or merging the risky lockfile churn.

## Verification

- `jq empty .claude/settings.json` — valid JSON
- Hook is a no-op shell guard; no app code touched, no test impact.

Closes #284.

🤖 Generated with [Claude Code](https://claude.com/claude-code)