### PR TITLE
fix: denylist the gate's own code (prevent self-modification auto-merge)

### DIFF
--- a/scripts/routine-gate/__tests__/gate-core.test.ts
+++ b/scripts/routine-gate/__tests__/gate-core.test.ts
@@ -193,6 +193,21 @@ describe("evaluateGate ambiguity + provenance source-of-truth", () => {
   });
 });
 
+describe("gate self-modification is denylisted", () => {
+  it("blocks changes to the gate core", () => {
+    expect(touchesRiskPath(["scripts/routine-gate/gate-core.ts"], CONFIG.riskPathDenylist).length).toBe(1);
+  });
+  it("blocks changes to the gate config", () => {
+    expect(touchesRiskPath(["scripts/routine-gate/config.ts"], CONFIG.riskPathDenylist).length).toBe(1);
+  });
+  it("blocks changes to pipeline scripts/prompts", () => {
+    expect(touchesRiskPath(["scripts/routine-pipeline/routine-reviewer.md"], CONFIG.riskPathDenylist).length).toBe(1);
+  });
+  it("still allows ordinary source", () => {
+    expect(touchesRiskPath(["src/analyzers/spf.ts"], CONFIG.riskPathDenylist).length).toBe(0);
+  });
+});
+
 describe("denylist hardening + normalization", () => {
   it("blocks nested wrangler.toml", () => {
     expect(touchesRiskPath(["packages/x/wrangler.toml"], CONFIG.riskPathDenylist).length).toBe(1);

--- a/scripts/routine-gate/config.ts
+++ b/scripts/routine-gate/config.ts
@@ -31,5 +31,6 @@ export const CONFIG = {
     "**/*cloudflare*access*", "**/*access*cloudflare*",
     "infra/**", "**/terraform/**", "**/*.tf",
     "**/wrangler.toml", "**/wrangler.jsonc",
+    "scripts/routine-gate/**", "scripts/routine-pipeline/**",
   ],
 };


### PR DESCRIPTION
## Security fix — follow-up to #306 (https://github.com/schmug/dmarcheck/pull/306)

#306 merged without this. The reviewer Routine runs `scripts/routine-gate/gate.ts` **from the PR's own checkout**, and `scripts/routine-gate/**` / `scripts/routine-pipeline/**` were NOT in the risk-path denylist — so a PR modifying the gate would be judged by its own modified logic and could auto-merge a weakened gate.

## Change
- `scripts/routine-gate/config.ts`: add `"scripts/routine-gate/**"`, `"scripts/routine-pipeline/**"` to `riskPathDenylist` → any PR touching the gate/pipeline force-escalates, never auto-merges.
- `gate-core.test.ts`: 4 TDD tests (gate-core, config, pipeline prompt blocked; ordinary `src/` still allowed).

## Validation
- Gate suite: 46 passing (was 42). `npx tsc -p scripts/routine-gate/tsconfig.json` clean.
- Full suite: 1020 passing, 0 failing.

## Note / residual
This closes the denylist half. The defense-in-depth complement — having the reviewer run the gate from `main`'s version rather than the PR checkout — is tracked separately (filed as a follow-up issue). enforce_admins is false on branch protection, so the owner can still bypass intentionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)