### PR TITLE
docs: run reviewer gate logic from main, not PR checkout

### DIFF
--- a/docs/routine-pipeline.md
+++ b/docs/routine-pipeline.md
@@ -14,6 +14,30 @@ protection is the independent backstop. Note: the gate over-blocks on ambiguous
 `Closes` refs and code-fenced examples (fails safe → escalates, never
 auto-merges).
 
+## Gate self-modification defence (belt-and-suspenders)
+Two layered controls prevent a PR from weakening the gate and then being
+auto-merged by the weakened gate:
+
+1. **Denylist** (primary, PR #311): any PR that touches `scripts/routine-gate/**`
+   matches a risk-path and force-escalates to `needs-you` regardless of any other
+   condition.
+
+2. **Gate-from-main** (secondary, issue #312): the reviewer Routine always
+   executes the gate binary from a fresh `main` worktree, not from the PR branch.
+   The gate queries PR diff/metadata via `gh` (not the working tree), so running
+   it from `main` is transparent — only the gate *code* origin changes.
+   Command sequence (see `scripts/routine-pipeline/routine-reviewer.md` step 3a):
+   ```
+   git worktree add /tmp/gate-from-main main
+   cd /tmp/gate-from-main
+   npx tsx scripts/routine-gate/gate.ts --repo <REPO> --pr P
+   EXIT_CODE=$?
+   cd -
+   git worktree remove --force /tmp/gate-from-main
+   ```
+   Even if the denylist were later weakened or bypassed, this layer ensures the
+   evaluation logic itself cannot be modified by the PR under review.
+
 ## Cap math (Max = 15 Routine runs/day)
 4 cycles/day × (implementer + reviewer) = 8 runs/day. Implementer 6 issues/run ×
 4 = up to 24 issues/day. One-off scheduled runs don't count against the cap.

--- a/scripts/routine-pipeline/routine-reviewer.md
+++ b/scripts/routine-pipeline/routine-reviewer.md
@@ -6,7 +6,22 @@ The gate is a deterministic script — TRUST ITS EXIT CODE, do not re-judge.
 1. `gh pr list --repo <REPO> --label auto-impl --state open --json number,labels`
 2. Skip any PR that already has the `needs-you` label (idempotent).
 3. For EACH remaining PR #P:
-   a. Run: `npx tsx scripts/routine-gate/gate.ts --repo <REPO> --pr P`
+   a. Run the gate from the `main` branch, NOT from the current working checkout
+      (so a PR that modifies the gate cannot be judged by its own modified logic).
+      The gate queries PR diff/metadata via `gh` — only the gate *code* must come
+      from `main`. Exact command sequence:
+      ```
+      git worktree add /tmp/gate-from-main main
+      cd /tmp/gate-from-main
+      npx tsx scripts/routine-gate/gate.ts --repo <REPO> --pr P
+      EXIT_CODE=$?
+      cd -
+      git worktree remove --force /tmp/gate-from-main
+      ```
+      Capture stdout (JSON verdict) and `$EXIT_CODE`.
+      If the `git worktree add` step fails (e.g. `/tmp/gate-from-main` already
+      exists from a crashed prior run), remove it first:
+      `git worktree remove --force /tmp/gate-from-main 2>/dev/null; git worktree add /tmp/gate-from-main main`
    b. Capture stdout (JSON verdict) and the exit code.
    c. If exit code == 0 (PASS):
       `gh pr merge P --repo <REPO> --squash --auto --delete-branch`


### PR DESCRIPTION
Superseded by #326 (same issue, cleaner implementation). Closing.