### PR TITLE
fix: surface DnsLookupError in TLS-RPT analyzer

### DIFF
--- a/src/analyzers/tls-rpt.ts
+++ b/src/analyzers/tls-rpt.ts
@@ -1,4 +1,4 @@
-import { queryTxt } from "../dns/client.js";
+import { DnsLookupError, queryTxt } from "../dns/client.js";
 import { parseTags } from "../shared/parse-tags.js";
 import type { TlsRptResult, Validation } from "./types.js";
 
@@ -8,7 +8,26 @@ import type { TlsRptResult, Validation } from "./types.js";
 // not change the enforcement posture.
 
 export async function analyzeTlsRpt(domain: string): Promise<TlsRptResult> {
-  const txt = await queryTxt(`_smtp._tls.${domain}`);
+  let txt: Awaited<ReturnType<typeof queryTxt>>;
+  try {
+    txt = await queryTxt(`_smtp._tls.${domain}`);
+  } catch (err) {
+    if (err instanceof DnsLookupError) {
+      return {
+        status: "warn",
+        record: null,
+        tags: null,
+        lookup_error: { code: err.code, message: err.message },
+        validations: [
+          {
+            status: "warn",
+            message: `TLS-RPT lookup failed (${err.code}) — result may be incomplete`,
+          },
+        ],
+      };
+    }
+    throw err;
+  }
 
   if (!txt || txt.entries.length === 0) {
     return {

--- a/src/analyzers/types.ts
+++ b/src/analyzers/types.ts
@@ -110,6 +110,7 @@ export interface TlsRptResult {
   record: string | null;
   tags: Record<string, string> | null;
   validations: Validation[];
+  lookup_error?: { code: string; message: string };
 }
 
 export interface ScanSummary {

--- a/test/tls-rpt.test.ts
+++ b/test/tls-rpt.test.ts
@@ -5,9 +5,17 @@ import { analyzeTlsRpt } from "../src/analyzers/tls-rpt.js";
 vi.mock("../src/dns/client.js", () => ({
   queryTxt: vi.fn(),
   queryMx: vi.fn(),
+  DnsLookupError: class DnsLookupError extends Error {
+    code: string;
+    constructor(code: string, message: string) {
+      super(message);
+      this.name = "DnsLookupError";
+      this.code = code;
+    }
+  },
 }));
 
-import { queryTxt } from "../src/dns/client.js";
+import { DnsLookupError, queryTxt } from "../src/dns/client.js";
 
 const mockQueryTxt = vi.mocked(queryTxt);
 
@@ -170,5 +178,47 @@ describe("analyzeTlsRpt", () => {
     });
     const result = await analyzeTlsRpt("example.com");
     expect(result.status).toBe("pass");
+  });
+
+  it("returns warn + lookup_error on SERVFAIL", async () => {
+    mockQueryTxt.mockRejectedValue(
+      new DnsLookupError("ESERVFAIL", "DNS server failure (SERVFAIL)"),
+    );
+    const result = await analyzeTlsRpt("example.com");
+    expect(result.status).toBe("warn");
+    expect(result.record).toBeNull();
+    expect(result.tags).toBeNull();
+    expect(result.lookup_error).toEqual({
+      code: "ESERVFAIL",
+      message: "DNS server failure (SERVFAIL)",
+    });
+    expect(
+      result.validations.some(
+        (v) => v.status === "warn" && v.message.includes("ESERVFAIL"),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns warn + lookup_error on DNS timeout", async () => {
+    mockQueryTxt.mockRejectedValue(
+      new DnsLookupError("DNS_TIMEOUT", "DNS query timed out"),
+    );
+    const result = await analyzeTlsRpt("example.com");
+    expect(result.status).toBe("warn");
+    expect(result.lookup_error?.code).toBe("DNS_TIMEOUT");
+  });
+
+  it("re-throws non-DnsLookupError errors", async () => {
+    mockQueryTxt.mockRejectedValue(new Error("unexpected error"));
+    await expect(analyzeTlsRpt("example.com")).rejects.toThrow(
+      "unexpected error",
+    );
+  });
+
+  it("returns info (no lookup_error) when record is absent (NXDOMAIN)", async () => {
+    mockQueryTxt.mockResolvedValue(null);
+    const result = await analyzeTlsRpt("example.com");
+    expect(result.status).toBe("info");
+    expect(result.lookup_error).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- Mirrors the `DnsLookupError` handling pattern from DMARC/SPF (post-#277) in `analyzeTlsRpt`: a SERVFAIL or timeout on the `_smtp._tls` TXT lookup now returns `warn` status with `lookup_error: { code, message }` instead of being silently treated as "no record found".
- NXDOMAIN/NODATA continue to return `null` from `queryTxt`, producing the existing `info` / "No TLS-RPT record found" path — unchanged.
- Adds `lookup_error?` field to `TlsRptResult` type (matching the pattern on `DmarcResult`, `SpfResult`, `MxResult`).

Closes #298

## Test plan

- [ ] `npm test` passes (1023/1024 — 1 pre-existing integration test fails due to no live network in the sandbox)
- [ ] `npm run typecheck` passes with no errors
- [ ] `npm run lint` clean
- [ ] New test: SERVFAIL → `status: "warn"`, `lookup_error.code: "ESERVFAIL"`, validation message includes `"ESERVFAIL"`
- [ ] New test: DNS timeout → `status: "warn"`, `lookup_error.code: "DNS_TIMEOUT"`
- [ ] New test: non-DnsLookupError re-throws
- [ ] New test: NXDOMAIN (null return) → `status: "info"`, no `lookup_error`

https://claude.ai/code/session_01BGsvgHfdJAfrW9iM2fgTQH

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGsvgHfdJAfrW9iM2fgTQH)_