### PR TITLE
docs: add per-merge audit comment and pipeline kill switch to Routine prompts

### DIFF
--- a/docs/routine-pipeline.md
+++ b/docs/routine-pipeline.md
@@ -25,5 +25,42 @@ prompt file contents, set schedule (implementer every 4h; reviewer offset +1h),
 enable `claude/`-branch pushes for the implementer. Routine commits appear as
 `schmug`.
 
+## Kill switch (emergency pause)
+
+Both Routines check for the `pipeline-paused` repo label as their very first
+action. While that label exists, neither Routine will open PRs, merge, push
+branches, comment on issues, or modify any label — they exit immediately with a
+clear no-op message.
+
+**To pause the pipeline:**
+```
+gh label create pipeline-paused --repo schmug/dmarcheck --color B60205 \
+  --description "Kill switch: both Routines no-op while this label exists" \
+  --force
+```
+Or create it in the GitHub UI: repo → Issues → Labels → New label,
+name `pipeline-paused`, color `#B60205`.
+
+**To resume the pipeline:**
+```
+gh label delete pipeline-paused --repo schmug/dmarcheck --yes
+```
+Or delete it in the GitHub UI: repo → Issues → Labels → delete `pipeline-paused`.
+
+The `setup-labels.sh` script creates this label along with the other pipeline
+labels, so it is available from first setup. The kill switch is idempotent:
+running `setup-labels.sh` again will not re-pause a running pipeline; the label
+must be present for Routines to no-op.
+
+## Audit trail
+
+Every auto-merged PR receives a comment from the reviewer Routine containing the
+full gate verdict JSON (`pass: true`, `reasons` array) before the merge is
+triggered. This gives an immutable record on each PR of exactly why the gate
+passed it, supporting forensics after any unexpected merge.
+
+Escalated PRs (exit code 2) also receive a comment with the `reasons` array, as
+before.
+
 ## Pilot validation log
 Filled in during go-live. Scenario → expected → actual.

--- a/scripts/routine-pipeline/routine-implementer.md
+++ b/scripts/routine-pipeline/routine-implementer.md
@@ -3,11 +3,17 @@
 You are the implementer for the issue→PR pipeline. The repo is checked out at the
 working directory. Do exactly this:
 
-1. List candidate issues:
+1. **Kill-switch check (do this first, before any other action):**
+   Run: `gh label list --repo <REPO> --json name | jq -e '.[] | select(.name == "pipeline-paused")' > /dev/null 2>&1`
+   If the `pipeline-paused` label exists on the repo, stop immediately. Output:
+   "Pipeline is paused (pipeline-paused label is set). No-op. Mutating nothing."
+   Do not open any PR, push any branch, comment on any issue, or modify any label. Exit the run.
+
+2. List candidate issues:
    `gh issue list --repo <REPO> --label spec-approved --state open --json number,author,createdAt`
-2. Discard any whose `author.login` is not `schmug`. Sort the rest oldest-first.
+3. Discard any whose `author.login` is not `schmug`. Sort the rest oldest-first.
    Take at most the first **6**.
-3. For EACH selected issue #N (one at a time, fully, before the next):
+4. For EACH selected issue #N (one at a time, fully, before the next):
    a. `git checkout <base>` (base = `main` for dmarcheck) `&& git pull`.
    b. `git checkout -b claude/issue-N`.
    c. Read issue #N. Implement it **strictly within** the file pointers in its
@@ -20,6 +26,6 @@ working directory. Do exactly this:
    f. If green: open ONE PR with `gh pr create`, base = `main`, body MUST contain
       `Closes #N`, a conventional-commit title (`feat:`/`fix:`/etc.), and the
       test results. Add the `auto-impl` label to the PR.
-4. NEVER add, remove, or modify the `spec-approved` label anywhere.
-5. NEVER merge anything. Your job ends at "PR opened" or "impl-blocked".
-6. End your run with a one-line summary: issues processed, PRs opened, blocked.
+5. NEVER add, remove, or modify the `spec-approved` label anywhere.
+6. NEVER merge anything. Your job ends at "PR opened" or "impl-blocked".
+7. End your run with a one-line summary: issues processed, PRs opened, blocked.

--- a/scripts/routine-pipeline/routine-reviewer.md
+++ b/scripts/routine-pipeline/routine-reviewer.md
@@ -3,13 +3,22 @@
 You are the reviewer/merger. The repo is checked out at the working directory.
 The gate is a deterministic script — TRUST ITS EXIT CODE, do not re-judge.
 
+0. **Kill-switch check (do this first, before any other action):**
+   Run: `gh label list --repo <REPO> --json name | jq -e '.[] | select(.name == "pipeline-paused")' > /dev/null 2>&1`
+   If the `pipeline-paused` label exists on the repo, stop immediately. Output:
+   "Pipeline is paused (pipeline-paused label is set). No-op. Mutating nothing."
+   Do not open, merge, comment on, or label any PR or issue. Exit the run.
+
 1. `gh pr list --repo <REPO> --label auto-impl --state open --json number,labels`
 2. Skip any PR that already has the `needs-you` label (idempotent).
 3. For EACH remaining PR #P:
    a. Run: `npx tsx scripts/routine-gate/gate.ts --repo <REPO> --pr P`
    b. Capture stdout (JSON verdict) and the exit code.
    c. If exit code == 0 (PASS):
-      `gh pr merge P --repo <REPO> --squash --auto --delete-branch`
+      First, post the full gate verdict as a PR comment (for audit trail):
+      `gh pr comment P --repo <REPO> --body "Gate verdict (auto-merge): \`\`\`json\n<verdict JSON>\n\`\`\`"`
+      where `<verdict JSON>` is the full stdout from step (b), containing `pass` and `reasons`.
+      Then merge: `gh pr merge P --repo <REPO> --squash --auto --delete-branch`
       Then comment the one-line outcome on the issue the PR closes.
    d. If exit code == 2 (FAIL): add the `needs-you` label to PR #P and add a PR
       comment containing the `reasons` array from the JSON verdict.

--- a/scripts/routine-pipeline/setup-labels.sh
+++ b/scripts/routine-pipeline/setup-labels.sh
@@ -7,8 +7,9 @@ REPO="${1:?usage: setup-labels.sh owner/name}"
 create() { # name color description
   gh label create "$1" --repo "$REPO" --color "$2" --description "$3" --force
 }
-create "spec-approved" "0E8A16" "Issue spec'd by owner in interactive session; trust token for auto-merge"
-create "auto-impl"     "1D76DB" "PR opened by the implementer Routine"
-create "needs-you"     "D93F0B" "Escalated by the reviewer Routine; needs owner decision"
-create "impl-blocked"  "B60205" "Implementer Routine could not produce a green PR"
+create "spec-approved"    "0E8A16" "Issue spec'd by owner in interactive session; trust token for auto-merge"
+create "auto-impl"        "1D76DB" "PR opened by the implementer Routine"
+create "needs-you"        "D93F0B" "Escalated by the reviewer Routine; needs owner decision"
+create "impl-blocked"     "B60205" "Implementer Routine could not produce a green PR"
+create "pipeline-paused"  "B60205" "Kill switch: both Routines no-op while this label exists on the repo"
 echo "labels ensured on $REPO"


### PR DESCRIPTION
Superseded by #336 (same issue, cleaner implementation). Closing.