### PR TITLE
feat: add per-user notify-on-change-only setting

### DIFF
--- a/src/cron/rescan.ts
+++ b/src/cron/rescan.ts
@@ -8,6 +8,7 @@ import type { ScanResult } from "../analyzers/types.js";
 import { recordAlert } from "../db/alerts.js";
 import { type Domain, getDueDomains } from "../db/domains.js";
 import { recordScan } from "../db/scans.js";
+import { getUserById } from "../db/users.js";
 import { scan as defaultScan } from "../orchestrator.js";
 import { fireScanCompletedWebhook } from "../webhooks/triggers.js";
 
@@ -17,11 +18,23 @@ export interface RescanResult {
   errors: number;
 }
 
+type WebhookFireFn = (
+  db: D1Database,
+  userId: string,
+  input: {
+    domain: string;
+    grade: string;
+    scanId: string | number;
+    trigger: "cron";
+  },
+) => Promise<void>;
+
 interface RescanDeps {
   db: D1Database;
   now: number;
   batchSize?: number;
   scanFn?: (domain: string) => Promise<ScanResult>;
+  fireWebhookFn?: WebhookFireFn;
 }
 
 interface PreviousProtocolStatuses {
@@ -73,6 +86,23 @@ function extractStatuses(result: ScanResult): PreviousProtocolStatuses {
   };
 }
 
+function resultChanged(
+  domain: Domain,
+  prevStatuses: PreviousProtocolStatuses | null,
+  result: ScanResult,
+): boolean {
+  if (result.grade !== domain.last_grade) return true;
+  if (!prevStatuses) return true;
+  const next = extractStatuses(result);
+  return (
+    prevStatuses.dmarc !== next.dmarc ||
+    prevStatuses.spf !== next.spf ||
+    prevStatuses.dkim !== next.dkim ||
+    prevStatuses.bimi !== next.bimi ||
+    prevStatuses.mta_sts !== next.mta_sts
+  );
+}
+
 async function rescanOne(
   deps: RescanDeps,
   domain: Domain,
@@ -95,12 +125,18 @@ async function rescanOne(
     scannedAt: deps.now,
   });
 
-  await fireScanCompletedWebhook(deps.db, domain.user_id, {
-    domain: domain.domain,
-    grade: result.grade,
-    scanId: domain.id,
-    trigger: "cron",
-  });
+  const user = await getUserById(deps.db, domain.user_id);
+  const shouldFireWebhook =
+    !user?.notify_on_change_only || resultChanged(domain, prevStatuses, result);
+  if (shouldFireWebhook) {
+    const fireWebhook = deps.fireWebhookFn ?? fireScanCompletedWebhook;
+    await fireWebhook(deps.db, domain.user_id, {
+      domain: domain.domain,
+      grade: result.grade,
+      scanId: domain.id,
+      trigger: "cron",
+    });
+  }
 
   const alerts: AlertPayload[] = [];
   const gradeAlert = detectGradeDrop(domain.last_grade, result.grade);

--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -40,6 +40,7 @@ import {
   acknowledgeApiKeyRetirement,
   getUserById,
   setEmailAlertsEnabled,
+  setNotifyOnChangeOnly,
 } from "../db/users.js";
 import { getRecentDeliveriesForUser } from "../db/webhook-deliveries.js";
 import { scan } from "../orchestrator.js";
@@ -901,6 +902,7 @@ dashboardRoutes.get("/settings", async (c) => {
       plan,
       billingEnabled: Boolean(env.STRIPE_SECRET_KEY),
       emailAlertsEnabled: user.email_alerts_enabled === 1,
+      notifyOnChangeOnly: user.notify_on_change_only === 1,
       showRetirementBanner: user.api_key_retirement_acknowledged_at === null,
       recentDeliveries: deliveries.map((row) => ({
         eventType: row.event_type,
@@ -922,6 +924,16 @@ dashboardRoutes.post("/settings/email-alerts", async (c) => {
   const body = await c.req.parseBody();
   const enabled = body.enabled === "on" || body.enabled === "1";
   await setEmailAlertsEnabled(db, session.sub, enabled);
+  return c.redirect("/dashboard/settings");
+});
+
+// Toggle notify-on-change-only preference. Same checkbox semantics as email-alerts.
+dashboardRoutes.post("/settings/notify-on-change", async (c) => {
+  const session = c.get("user" as never) as SessionPayload;
+  const db = (c.env as { DB: D1Database }).DB;
+  const body = await c.req.parseBody();
+  const enabled = body.enabled === "on" || body.enabled === "1";
+  await setNotifyOnChangeOnly(db, session.sub, enabled);
   return c.redirect("/dashboard/settings");
 });
 

--- a/src/db/migrations/0008_notify_on_change.sql
+++ b/src/db/migrations/0008_notify_on_change.sql
@@ -1,0 +1,5 @@
+-- Per-user opt-in to suppress scan.completed webhook when a cron rescan
+-- produces an identical result vs. the previous scan (same grade + same
+-- per-protocol statuses). DEFAULT 0 = off; existing behavior (notify every
+-- cron scan) is preserved unless the user explicitly enables this setting.
+ALTER TABLE users ADD COLUMN notify_on_change_only INTEGER NOT NULL DEFAULT 0;

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -5,6 +5,7 @@ CREATE TABLE IF NOT EXISTS users (
   email_domain TEXT NOT NULL,
   stripe_customer_id TEXT,
   email_alerts_enabled INTEGER NOT NULL DEFAULT 1,
+  notify_on_change_only INTEGER NOT NULL DEFAULT 0,
   api_key_retirement_acknowledged_at INTEGER,
   created_at INTEGER NOT NULL DEFAULT (unixepoch())
 );

--- a/src/db/users.ts
+++ b/src/db/users.ts
@@ -4,6 +4,7 @@ export interface User {
   email_domain: string;
   stripe_customer_id: string | null;
   email_alerts_enabled: number;
+  notify_on_change_only: number;
   api_key_retirement_acknowledged_at: number | null;
   created_at: number;
 }
@@ -69,6 +70,17 @@ export async function setEmailAlertsEnabled(
 ): Promise<void> {
   await db
     .prepare("UPDATE users SET email_alerts_enabled = ? WHERE id = ?")
+    .bind(enabled ? 1 : 0, userId)
+    .run();
+}
+
+export async function setNotifyOnChangeOnly(
+  db: D1Database,
+  userId: string,
+  enabled: boolean,
+): Promise<void> {
+  await db
+    .prepare("UPDATE users SET notify_on_change_only = ? WHERE id = ?")
     .bind(enabled ? 1 : 0, userId)
     .run();
 }

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -2690,6 +2690,7 @@ export function renderSettingsPage({
   plan,
   billingEnabled,
   emailAlertsEnabled,
+  notifyOnChangeOnly,
   showRetirementBanner,
   recentDeliveries = [],
   testFlash = null,
@@ -2700,6 +2701,7 @@ export function renderSettingsPage({
   plan: "free" | "pro";
   billingEnabled: boolean;
   emailAlertsEnabled: boolean;
+  notifyOnChangeOnly: boolean;
   showRetirementBanner: boolean;
   recentDeliveries?: RecentWebhookDelivery[];
   testFlash?: WebhookTestFlash | null;
@@ -2786,6 +2788,20 @@ ${retirementBanner}
     <label style="display:flex;align-items:center;gap:0.5rem;margin-bottom:0.75rem">
       <input type="checkbox" name="enabled" ${emailAlertsEnabled ? "checked" : ""}>
       <span>Send me grade-drop alerts by email</span>
+    </label>
+    <button type="submit" class="btn btn-secondary">Save Preference</button>
+  </form>
+</div>
+
+<div class="settings-section">
+  <h2>Scan Notifications</h2>
+  <p style="font-size:0.875rem;color:var(--clr-text-muted);margin-bottom:0.75rem">
+    By default, your webhook receives a <code>scan.completed</code> event on every scheduled rescan. Enable this to receive events only when something actually changed.
+  </p>
+  <form method="POST" action="/dashboard/settings/notify-on-change">
+    <label style="display:flex;align-items:center;gap:0.5rem;margin-bottom:0.75rem">
+      <input type="checkbox" name="enabled" ${notifyOnChangeOnly ? "checked" : ""}>
+      <span>Only notify me when a scan result changes (grade or protocol status)</span>
     </label>
     <button type="submit" class="btn btn-secondary">Save Preference</button>
   </form>

--- a/test/cron-rescan.test.ts
+++ b/test/cron-rescan.test.ts
@@ -1,6 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { runDueRescans } from "../src/cron/rescan.js";
 
+interface UserRow {
+  id: string;
+  email: string;
+  email_domain: string;
+  stripe_customer_id: string | null;
+  email_alerts_enabled: number;
+  notify_on_change_only: number;
+  api_key_retirement_acknowledged_at: number | null;
+  created_at: number;
+}
+
 interface DomainRow {
   id: number;
   user_id: string;
@@ -31,6 +42,7 @@ interface ScanHistoryRow {
   scanned_at: number;
 }
 
+let users: Map<string, UserRow>;
 let domains: Map<number, DomainRow>;
 let alerts: Map<number, AlertRow>;
 let history: Map<number, ScanHistoryRow>;
@@ -95,6 +107,10 @@ function makeD1Mock(): D1Database {
             .filter((r) => r.domain_id === domainId)
             .sort((a, b) => b.scanned_at - a.scanned_at);
           return (rows[0] ?? null) as T | null;
+        }
+        if (/FROM users WHERE id = \?/i.test(sql)) {
+          const [userId] = params as [string];
+          return (users.get(userId) ?? null) as T | null;
         }
         return null;
       },
@@ -177,6 +193,7 @@ describe("cron/runDueRescans", () => {
   const weekSeconds = 7 * 24 * 60 * 60;
 
   beforeEach(() => {
+    users = new Map();
     domains = new Map();
     alerts = new Map();
     history = new Map();
@@ -467,5 +484,154 @@ describe("cron/runDueRescans", () => {
     }
     // Zero tolerance for false-fail cascade: every grade must match exactly
     expect(falseFails).toBe(0);
+  });
+
+  describe("notify_on_change_only webhook gating", () => {
+    const monthSeconds = 30 * 24 * 60 * 60;
+
+    function makeDomain(overrides: Partial<DomainRow> = {}): DomainRow {
+      return {
+        id: 1,
+        user_id: "u1",
+        domain: "stable.com",
+        is_free: 1,
+        scan_frequency: "monthly",
+        last_scanned_at: now - monthSeconds - 1,
+        last_grade: "A",
+        created_at: 0,
+        ...overrides,
+      };
+    }
+
+    function makeUser(notifyOnChangeOnly: number): UserRow {
+      return {
+        id: "u1",
+        email: "user@example.com",
+        email_domain: "example.com",
+        stripe_customer_id: null,
+        email_alerts_enabled: 1,
+        notify_on_change_only: notifyOnChangeOnly,
+        api_key_retirement_acknowledged_at: null,
+        created_at: 0,
+      };
+    }
+
+    it("default off (setting=0): webhook fires even when result is identical", async () => {
+      users.set("u1", makeUser(0));
+      domains.set(1, makeDomain({ last_grade: "A" }));
+      history.set(99, {
+        id: 99,
+        domain_id: 1,
+        grade: "A",
+        score_factors: null,
+        protocol_results: JSON.stringify({
+          dmarc: { status: "pass" },
+          spf: { status: "pass" },
+          dkim: { status: "pass" },
+          bimi: { status: "pass" },
+          mta_sts: { status: "pass" },
+        }),
+        scanned_at: now - monthSeconds - 1,
+      });
+
+      const webhookFn = vi.fn().mockResolvedValue(undefined);
+      const scanFn = vi
+        .fn()
+        .mockResolvedValue(makeScanResult("stable.com", "A", {}));
+
+      await runDueRescans({
+        db: makeD1Mock(),
+        now,
+        scanFn: scanFn as never,
+        fireWebhookFn: webhookFn as never,
+      });
+
+      expect(webhookFn).toHaveBeenCalledOnce();
+    });
+
+    it("setting=1, no change: webhook suppressed", async () => {
+      users.set("u1", makeUser(1));
+      domains.set(1, makeDomain({ last_grade: "A" }));
+      history.set(99, {
+        id: 99,
+        domain_id: 1,
+        grade: "A",
+        score_factors: null,
+        protocol_results: JSON.stringify({
+          dmarc: { status: "pass" },
+          spf: { status: "pass" },
+          dkim: { status: "pass" },
+          bimi: { status: "pass" },
+          mta_sts: { status: "pass" },
+        }),
+        scanned_at: now - monthSeconds - 1,
+      });
+
+      const webhookFn = vi.fn().mockResolvedValue(undefined);
+      const scanFn = vi
+        .fn()
+        .mockResolvedValue(makeScanResult("stable.com", "A", {}));
+
+      await runDueRescans({
+        db: makeD1Mock(),
+        now,
+        scanFn: scanFn as never,
+        fireWebhookFn: webhookFn as never,
+      });
+
+      expect(webhookFn).not.toHaveBeenCalled();
+    });
+
+    it("setting=1, grade dropped: webhook fires", async () => {
+      users.set("u1", makeUser(1));
+      domains.set(1, makeDomain({ last_grade: "A" }));
+
+      const webhookFn = vi.fn().mockResolvedValue(undefined);
+      const scanFn = vi
+        .fn()
+        .mockResolvedValue(makeScanResult("stable.com", "C", {}));
+
+      await runDueRescans({
+        db: makeD1Mock(),
+        now,
+        scanFn: scanFn as never,
+        fireWebhookFn: webhookFn as never,
+      });
+
+      expect(webhookFn).toHaveBeenCalledOnce();
+    });
+
+    it("setting=1, grade improved: webhook fires", async () => {
+      users.set("u1", makeUser(1));
+      domains.set(1, makeDomain({ last_grade: "B" }));
+      history.set(99, {
+        id: 99,
+        domain_id: 1,
+        grade: "B",
+        score_factors: null,
+        protocol_results: JSON.stringify({
+          dmarc: { status: "pass" },
+          spf: { status: "pass" },
+          dkim: { status: "pass" },
+          bimi: { status: "pass" },
+          mta_sts: { status: "pass" },
+        }),
+        scanned_at: now - monthSeconds - 1,
+      });
+
+      const webhookFn = vi.fn().mockResolvedValue(undefined);
+      const scanFn = vi
+        .fn()
+        .mockResolvedValue(makeScanResult("stable.com", "A+", {}));
+
+      await runDueRescans({
+        db: makeD1Mock(),
+        now,
+        scanFn: scanFn as never,
+        fireWebhookFn: webhookFn as never,
+      });
+
+      expect(webhookFn).toHaveBeenCalledOnce();
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Adds `notify_on_change_only` boolean column to `users` table (migration `0008_notify_on_change.sql`, default 0 = off)
- Gates `scan.completed` webhook in cron rescan on change detection (grade or per-protocol statuses) when setting is on
- Adds Settings toggle UI at `/dashboard/settings` and `POST /dashboard/settings/notify-on-change` handler

## Closes #310

## Test plan

- [ ] `npm test`: 883 passing, 1 pre-existing failure (MTA-STS network integration test, unrelated)
- [ ] `npm run typecheck`: 0 errors
- [ ] `npm run lint`: clean
- [ ] 4 new tests in `test/cron-rescan.test.ts`: default-off fires always, setting=1 no-change suppresses, setting=1 grade-drop fires, setting=1 grade-improvement fires
- [ ] Migration follows numbered pattern (`0008_` after `0007_webhook_format.sql`); `schema.sql` updated in same PR
- [ ] Webhook bulk path (`fireBulkScanWebhooks`) is unaffected — suppression scoped to cron rescan only

https://claude.ai/code/session_01BGsvgHfdJAfrW9iM2fgTQH

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGsvgHfdJAfrW9iM2fgTQH)_