### PR TITLE
feat: add remote MCP server (closes #181)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 docs/internal/
 pnpm-lock.yaml
 .jules/
+.claude/

--- a/src/api/agent-skills.ts
+++ b/src/api/agent-skills.ts
@@ -138,8 +138,8 @@ export async function getAgentSkillsIndexJson(
         name: "scan_domain",
         type: "mcp",
         description:
-          "MCP streamable-HTTP tool — call scan_domain via JSON-RPC 2.0 at POST /mcp.",
-        url: `${origin}/mcp`,
+          "MCP streamable-HTTP tool — call scan_domain via JSON-RPC 2.0 at POST /mcp. This url serves the MCP server card (the POST transport lives at /mcp).",
+        url: `${origin}/.well-known/mcp/server-card.json`,
         sha256: mcpCardSha,
       },
     ],

--- a/src/api/agent-skills.ts
+++ b/src/api/agent-skills.ts
@@ -9,6 +9,7 @@
 // don't allow top-level await. Cached per Worker instance after the first
 // request.
 
+import { MCP_SERVER_CARD } from "../mcp/handler.js";
 import { CANONICAL_ORIGIN } from "./catalog.js";
 import { OPENAPI_JSON } from "./openapi.js";
 
@@ -61,6 +62,14 @@ per request. See the OpenAPI doc for the request/response shape.
 curl -H 'Accept: application/json' 'https://dmarc.mx/api/check?domain=dmarc.mx'
 \`\`\`
 
+## MCP variant
+
+The same scan is also available as an MCP tool via the streamable-HTTP
+transport at \`https://dmarc.mx/mcp\`. Each POST is a complete JSON-RPC 2.0
+exchange; the server is stateless. Supported methods: \`initialize\`,
+\`tools/list\`, \`tools/call\` (tool: \`scan_domain\`).
+Server card at \`https://dmarc.mx/.well-known/mcp/server-card.json\`.
+
 ## Related
 
 - API catalog: \`https://dmarc.mx/.well-known/api-catalog\` (RFC 9727)
@@ -100,9 +109,10 @@ export async function getAgentSkillsIndexJson(
   const cached = cache.get(origin);
   if (cached) return cached;
 
-  const [skillSha, openapiSha] = await Promise.all([
+  const [skillSha, openapiSha, mcpCardSha] = await Promise.all([
     sha256Hex(SCAN_DOMAIN_SKILL_MD),
     sha256Hex(OPENAPI_JSON),
+    sha256Hex(MCP_SERVER_CARD),
   ]);
 
   const index: SkillsIndex = {
@@ -123,6 +133,14 @@ export async function getAgentSkillsIndexJson(
           "OpenAPI 3.1 description of the scan API and related endpoints.",
         url: `${origin}/openapi.json`,
         sha256: openapiSha,
+      },
+      {
+        name: "scan_domain",
+        type: "mcp",
+        description:
+          "MCP streamable-HTTP tool — call scan_domain via JSON-RPC 2.0 at POST /mcp.",
+        url: `${origin}/mcp`,
+        sha256: mcpCardSha,
       },
     ],
   };

--- a/src/api/catalog.ts
+++ b/src/api/catalog.ts
@@ -30,6 +30,7 @@ export function buildApiCatalog(origin: string = CANONICAL_ORIGIN): ApiCatalog {
       // anchors for parameterized resources. Agents resolve `{name}` from
       // the OpenAPI path parameter.
       { anchor: `${origin}/api/domain/{name}/history`, ...sharedRefs },
+      { anchor: `${origin}/mcp`, ...sharedRefs },
     ],
   };
 }

--- a/src/api/openapi.ts
+++ b/src/api/openapi.ts
@@ -425,6 +425,112 @@ export const OPENAPI_DOCUMENT = {
         },
       },
     },
+    "/mcp": {
+      post: {
+        summary: "MCP streamable-HTTP transport (JSON-RPC 2.0)",
+        description:
+          "Stateless MCP endpoint. Each POST is a complete JSON-RPC 2.0 exchange. Implements the `scan_domain` tool — equivalent to `GET /api/check` but wrapped in the Model Context Protocol (2025-03-26). Rate-limited to 10 req/IP/60s. Discover via `/.well-known/mcp/server-card.json`.",
+        operationId: "mcpRpc",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["jsonrpc", "method"],
+                properties: {
+                  jsonrpc: { type: "string", enum: ["2.0"] },
+                  id: {
+                    oneOf: [
+                      { type: "string" },
+                      { type: "number" },
+                      { type: "null" },
+                    ],
+                  },
+                  method: { type: "string" },
+                  params: { type: "object" },
+                },
+              },
+              examples: {
+                initialize: {
+                  summary: "Initialize handshake",
+                  value: {
+                    jsonrpc: "2.0",
+                    id: 1,
+                    method: "initialize",
+                    params: {
+                      protocolVersion: "2025-03-26",
+                      clientInfo: { name: "my-agent", version: "1.0" },
+                    },
+                  },
+                },
+                toolsList: {
+                  summary: "List available tools",
+                  value: { jsonrpc: "2.0", id: 2, method: "tools/list" },
+                },
+                scanDomain: {
+                  summary: "Call scan_domain tool",
+                  value: {
+                    jsonrpc: "2.0",
+                    id: 3,
+                    method: "tools/call",
+                    params: {
+                      name: "scan_domain",
+                      arguments: { domain: "dmarc.mx" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description:
+              "JSON-RPC 2.0 response (always 200; errors use the JSON-RPC `error` field)",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: ["jsonrpc", "id"],
+                  properties: {
+                    jsonrpc: { type: "string", enum: ["2.0"] },
+                    id: {
+                      oneOf: [
+                        { type: "string" },
+                        { type: "number" },
+                        { type: "null" },
+                      ],
+                    },
+                    result: { type: "object" },
+                    error: {
+                      type: "object",
+                      required: ["code", "message"],
+                      properties: {
+                        code: { type: "integer" },
+                        message: { type: "string" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          "204": {
+            description:
+              "Notification acknowledged (no JSON-RPC `id` — no response body per spec)",
+          },
+          "429": {
+            description: "Rate limit exceeded (10 req/min per IP)",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Error" },
+              },
+            },
+          },
+        },
+      },
+    },
     "/.well-known/api-catalog": {
       get: {
         summary: "RFC 9727 API catalog",

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ import { recordScan } from "./db/scans.js";
 import { getPlanForUser } from "./db/subscriptions.js";
 import { setEmailAlertsEnabled } from "./db/users.js";
 import type { Env } from "./env.js";
+import { handleMcpRequest, MCP_SERVER_CARD } from "./mcp/handler.js";
 import type { ProtocolId, ProtocolResult } from "./orchestrator.js";
 import { scan, scanStreaming } from "./orchestrator.js";
 import {
@@ -510,6 +511,14 @@ app.use(
   ),
 );
 
+// MCP endpoint runs a full scan on cache miss — same per-IP budget as /api/check.
+app.use(
+  "/mcp",
+  rateLimitMiddleware((c, result, headers) =>
+    c.json({ error: blockedMessage(result) }, { status: 429, headers }),
+  ),
+);
+
 const protocolRenderers: Record<
   ProtocolId,
   (result: ProtocolResult) => string
@@ -826,6 +835,34 @@ app.get("/.well-known/agent-skills/index.json", async (c) => {
 app.get("/.well-known/agent-skills/scan-domain/SKILL.md", (c) => {
   return c.body(SCAN_DOMAIN_SKILL_MD, 200, {
     "Content-Type": "text/markdown; charset=utf-8",
+    "Cache-Control": "public, max-age=3600",
+  });
+});
+
+// Remote MCP server — streamable-HTTP transport (POST only; stateless).
+// Agents discover this endpoint via /.well-known/mcp/server-card.json and
+// the agent-skills index.
+app.post("/mcp", async (c) => {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json(
+      {
+        jsonrpc: "2.0",
+        id: null,
+        error: { code: -32700, message: "Parse error" },
+      },
+      400,
+    );
+  }
+  return handleMcpRequest(body, { executionCtx: c.executionCtx });
+});
+
+// SEP-1649 MCP server card — minimal shape, served before the RFC finalises.
+app.get("/.well-known/mcp/server-card.json", (c) => {
+  return c.body(MCP_SERVER_CARD, 200, {
+    "Content-Type": "application/json; charset=utf-8",
     "Cache-Control": "public, max-age=3600",
   });
 });

--- a/src/mcp/handler.ts
+++ b/src/mcp/handler.ts
@@ -1,0 +1,203 @@
+// MCP streamable-HTTP transport handler.
+// Stateless — each POST /mcp is a complete JSON-RPC 2.0 exchange.
+// Implements: initialize, notifications/initialized, tools/list, tools/call
+// Protocol: https://modelcontextprotocol.io/specification (2025-03-26)
+
+import { getCachedScan, setCachedScan } from "../cache.js";
+import { scan } from "../orchestrator.js";
+import { normalizeDomain } from "../shared/domain.js";
+
+// DKIM selector charset per RFC 6376 §3.1 — mirrors VALID_SELECTOR in index.ts.
+const VALID_SELECTOR = /^[A-Za-z0-9._-]+$/;
+
+function parseSelectorsFromArray(raw: string[]): string[] {
+  return raw.filter((s) => s.length > 0 && VALID_SELECTOR.test(s));
+}
+
+export const MCP_PROTOCOL_VERSION = "2025-03-26";
+
+const SERVER_INFO = { name: "dmarcheck", version: "1.0.0" };
+
+// SEP-1649 server card — minimal shape until the RFC finalises.
+// https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127
+export const MCP_SERVER_CARD = JSON.stringify({
+  name: "dmarcheck",
+  version: "1.0.0",
+  description:
+    "DNS email-security scanner (DMARC, SPF, DKIM, BIMI, MTA-STS, MX). Rate-limited to 10 req/IP/60s.",
+  url: "https://dmarc.mx/mcp",
+  tools: [{ name: "scan_domain" }],
+});
+
+const SCAN_DOMAIN_TOOL = {
+  name: "scan_domain",
+  description:
+    "Analyse a domain's email-security DNS posture (DMARC, SPF, DKIM, BIMI, MTA-STS, MX) and return a graded result. Equivalent to GET /api/check.",
+  inputSchema: {
+    type: "object",
+    required: ["domain"],
+    properties: {
+      domain: {
+        type: "string",
+        description: "Domain to scan, e.g. 'dmarc.mx'",
+        pattern: "^[a-z0-9.-]+$",
+        maxLength: 253,
+      },
+      dkim_selectors: {
+        type: "array",
+        items: { type: "string", pattern: "^[A-Za-z0-9._-]+$" },
+        description:
+          "Extra DKIM selectors to probe beyond the built-in defaults.",
+      },
+    },
+  },
+};
+
+interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id?: string | number | null;
+  method: string;
+  params?: unknown;
+}
+
+interface JsonRpcSuccess {
+  jsonrpc: "2.0";
+  id: string | number | null;
+  result: unknown;
+}
+
+interface JsonRpcError {
+  jsonrpc: "2.0";
+  id: string | number | null;
+  error: { code: number; message: string; data?: unknown };
+}
+
+function ok(
+  id: string | number | null | undefined,
+  result: unknown,
+): JsonRpcSuccess {
+  return { jsonrpc: "2.0", id: id ?? null, result };
+}
+
+function rpcError(
+  id: string | number | null | undefined,
+  code: number,
+  message: string,
+  data?: unknown,
+): JsonRpcError {
+  return { jsonrpc: "2.0", id: id ?? null, error: { code, message, data } };
+}
+
+export interface McpEnv {
+  executionCtx: ExecutionContext;
+}
+
+export async function handleMcpRequest(
+  body: unknown,
+  env: McpEnv,
+): Promise<Response> {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return jsonRpcResponse(rpcError(null, -32600, "Invalid Request"));
+  }
+
+  const req = body as JsonRpcRequest;
+  if (req.jsonrpc !== "2.0" || typeof req.method !== "string") {
+    return jsonRpcResponse(rpcError(req.id ?? null, -32600, "Invalid Request"));
+  }
+
+  const { id, method, params } = req;
+
+  switch (method) {
+    case "initialize":
+      return jsonRpcResponse(
+        ok(id, {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: { tools: {} },
+          serverInfo: SERVER_INFO,
+        }),
+      );
+
+    case "notifications/initialized":
+      // Notification — no response per JSON-RPC 2.0 spec.
+      return new Response(null, { status: 204 });
+
+    case "tools/list":
+      return jsonRpcResponse(ok(id, { tools: [SCAN_DOMAIN_TOOL] }));
+
+    case "tools/call":
+      return handleToolCall(id ?? null, params, env);
+
+    default:
+      return jsonRpcResponse(rpcError(id, -32601, "Method not found"));
+  }
+}
+
+async function handleToolCall(
+  id: string | number | null,
+  params: unknown,
+  env: McpEnv,
+): Promise<Response> {
+  if (typeof params !== "object" || params === null) {
+    return jsonRpcResponse(rpcError(id, -32602, "Invalid params"));
+  }
+
+  const p = params as Record<string, unknown>;
+  if (p.name !== "scan_domain") {
+    return jsonRpcResponse(rpcError(id, -32602, `Unknown tool: ${p.name}`));
+  }
+
+  const args = p.arguments as Record<string, unknown> | undefined;
+  const rawDomain = typeof args?.domain === "string" ? args.domain : undefined;
+  const domain = normalizeDomain(rawDomain);
+  if (!domain) {
+    return jsonRpcResponse(
+      ok(id, {
+        content: [{ type: "text", text: "Invalid or missing domain." }],
+        isError: true,
+      }),
+    );
+  }
+
+  const rawSelectors = args?.dkim_selectors;
+  const selectors: string[] = Array.isArray(rawSelectors)
+    ? parseSelectorsFromArray(
+        rawSelectors.filter((s): s is string => typeof s === "string"),
+      )
+    : [];
+
+  try {
+    const cached = await getCachedScan(domain, selectors);
+    const result = cached ?? (await scan(domain, selectors));
+    if (!cached) {
+      const pendingWrite = setCachedScan(domain, selectors, result);
+      if (pendingWrite) {
+        env.executionCtx.waitUntil(pendingWrite.catch(() => {}));
+      }
+    }
+    return jsonRpcResponse(
+      ok(id, {
+        content: [{ type: "text", text: JSON.stringify(result) }],
+        isError: false,
+      }),
+    );
+  } catch (err) {
+    return jsonRpcResponse(
+      ok(id, {
+        content: [
+          {
+            type: "text",
+            text: err instanceof Error ? err.message : "Scan failed.",
+          },
+        ],
+        isError: true,
+      }),
+    );
+  }
+}
+
+function jsonRpcResponse(payload: JsonRpcSuccess | JsonRpcError): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/test/agent-discovery.test.ts
+++ b/test/agent-discovery.test.ts
@@ -63,11 +63,12 @@ describe("/.well-known/api-catalog", () => {
         status: Array<{ href: string }>;
       }>;
     };
-    expect(body.linkset).toHaveLength(3);
+    expect(body.linkset).toHaveLength(4);
     const anchors = body.linkset.map((e) => e.anchor);
     expect(anchors).toContain("https://dmarc.mx/api/check");
     expect(anchors).toContain("https://dmarc.mx/api/bulk-scan");
     expect(anchors).toContain("https://dmarc.mx/api/domain/{name}/history");
+    expect(anchors).toContain("https://dmarc.mx/mcp");
     for (const entry of body.linkset) {
       expect(entry["service-desc"][0].href).toBe(
         "https://dmarc.mx/openapi.json",

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1,0 +1,235 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  handleMcpRequest,
+  MCP_PROTOCOL_VERSION,
+  MCP_SERVER_CARD,
+} from "../src/mcp/handler.js";
+
+vi.mock("../src/cache.js", () => ({
+  getCachedScan: vi.fn().mockResolvedValue(null),
+  setCachedScan: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("../src/orchestrator.js", () => ({
+  scan: vi.fn().mockResolvedValue({
+    domain: "example.com",
+    timestamp: "2026-01-01T00:00:00Z",
+    grade: "A",
+    breakdown: {
+      grade: "A",
+      tier: "A",
+      tierReason: "",
+      modifier: 0,
+      modifierLabel: "",
+      factors: [],
+      recommendations: [],
+      protocolSummaries: {},
+    },
+    summary: { mx_records: 1, mx_providers: [], dmarc_policy: "reject" },
+    protocols: {
+      mx: { status: "info" },
+      dmarc: { status: "pass" },
+      spf: { status: "pass" },
+      dkim: { status: "pass" },
+      bimi: { status: "pass" },
+      mta_sts: { status: "pass" },
+    },
+  }),
+}));
+
+function makeEnv(): { executionCtx: ExecutionContext } {
+  return {
+    executionCtx: {
+      waitUntil: vi.fn(),
+      passThroughOnException: vi.fn(),
+    } as unknown as ExecutionContext,
+  };
+}
+
+async function rpc(body: unknown, env = makeEnv()) {
+  const res = await handleMcpRequest(body, env);
+  const json = await res.json<{
+    jsonrpc: string;
+    id: unknown;
+    result?: unknown;
+    error?: unknown;
+  }>();
+  return { res, json };
+}
+
+describe("MCP_SERVER_CARD", () => {
+  it("is valid JSON with expected fields", () => {
+    const card = JSON.parse(MCP_SERVER_CARD);
+    expect(card.name).toBe("dmarcheck");
+    expect(card.tools).toEqual([{ name: "scan_domain" }]);
+  });
+});
+
+describe("handleMcpRequest — protocol", () => {
+  it("returns -32600 for a non-object body", async () => {
+    const { json } = await rpc("bad");
+    expect(json.error).toMatchObject({ code: -32600 });
+  });
+
+  it("returns -32600 for array body", async () => {
+    const { json } = await rpc([]);
+    expect(json.error).toMatchObject({ code: -32600 });
+  });
+
+  it("returns -32600 when jsonrpc field is wrong", async () => {
+    const { json } = await rpc({ jsonrpc: "1.0", id: 1, method: "initialize" });
+    expect(json.error).toMatchObject({ code: -32600 });
+  });
+
+  it("returns -32601 for unknown method", async () => {
+    const { json } = await rpc({
+      jsonrpc: "2.0",
+      id: 9,
+      method: "not/a/method",
+    });
+    expect(json.error).toMatchObject({
+      code: -32601,
+      message: "Method not found",
+    });
+    expect(json.id).toBe(9);
+  });
+
+  it("returns 204 for notifications/initialized (no body)", async () => {
+    const res = await handleMcpRequest(
+      { jsonrpc: "2.0", method: "notifications/initialized" },
+      makeEnv(),
+    );
+    expect(res.status).toBe(204);
+    expect(await res.text()).toBe("");
+  });
+});
+
+describe("handleMcpRequest — initialize", () => {
+  it("returns protocolVersion and serverInfo", async () => {
+    const { json } = await rpc({ jsonrpc: "2.0", id: 1, method: "initialize" });
+    expect(json.result).toMatchObject({
+      protocolVersion: MCP_PROTOCOL_VERSION,
+      capabilities: { tools: {} },
+      serverInfo: { name: "dmarcheck" },
+    });
+    expect(json.id).toBe(1);
+  });
+});
+
+describe("handleMcpRequest — tools/list", () => {
+  it("returns scan_domain tool with required schema", async () => {
+    const { json } = await rpc({ jsonrpc: "2.0", id: 2, method: "tools/list" });
+    const result = json.result as {
+      tools: Array<{ name: string; inputSchema: unknown }>;
+    };
+    expect(result.tools).toHaveLength(1);
+    expect(result.tools[0].name).toBe("scan_domain");
+    const schema = result.tools[0].inputSchema as { required: string[] };
+    expect(schema.required).toContain("domain");
+  });
+});
+
+describe("handleMcpRequest — tools/call", () => {
+  it("returns -32602 for non-object params", async () => {
+    const { json } = await rpc({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/call",
+      params: "bad",
+    });
+    expect(json.error).toMatchObject({ code: -32602 });
+  });
+
+  it("returns -32602 for unknown tool name", async () => {
+    const { json } = await rpc({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/call",
+      params: { name: "unknown_tool" },
+    });
+    expect(json.error).toMatchObject({ code: -32602 });
+  });
+
+  it("returns isError:true for missing domain", async () => {
+    const { json } = await rpc({
+      jsonrpc: "2.0",
+      id: 4,
+      method: "tools/call",
+      params: { name: "scan_domain", arguments: {} },
+    });
+    const result = json.result as {
+      isError: boolean;
+      content: Array<{ type: string; text: string }>;
+    };
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Invalid");
+  });
+
+  it("returns isError:true for invalid domain characters", async () => {
+    const { json } = await rpc({
+      jsonrpc: "2.0",
+      id: 5,
+      method: "tools/call",
+      params: { name: "scan_domain", arguments: { domain: "evil<script>" } },
+    });
+    const result = json.result as { isError: boolean };
+    expect(result.isError).toBe(true);
+  });
+
+  it("calls scan and returns JSON-serialised result on success", async () => {
+    const { json } = await rpc({
+      jsonrpc: "2.0",
+      id: 6,
+      method: "tools/call",
+      params: { name: "scan_domain", arguments: { domain: "example.com" } },
+    });
+    const result = json.result as {
+      isError: boolean;
+      content: Array<{ type: string; text: string }>;
+    };
+    expect(result.isError).toBe(false);
+    expect(result.content[0].type).toBe("text");
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.domain).toBe("example.com");
+    expect(payload.grade).toBe("A");
+  });
+
+  it("strips invalid dkim_selectors silently", async () => {
+    const { scan } = await import("../src/orchestrator.js");
+    const { json } = await rpc({
+      jsonrpc: "2.0",
+      id: 7,
+      method: "tools/call",
+      params: {
+        name: "scan_domain",
+        arguments: {
+          domain: "example.com",
+          dkim_selectors: ["valid-sel", "bad sel!", ""],
+        },
+      },
+    });
+    const result = json.result as { isError: boolean };
+    expect(result.isError).toBe(false);
+    // scan was called — invalid selectors were stripped, not rejected
+    expect(vi.mocked(scan)).toHaveBeenCalled();
+  });
+
+  it("preserves JSON-RPC id across the full call", async () => {
+    const { json } = await rpc({
+      jsonrpc: "2.0",
+      id: "req-abc",
+      method: "tools/call",
+      params: { name: "scan_domain", arguments: { domain: "example.com" } },
+    });
+    expect(json.id).toBe("req-abc");
+  });
+
+  it("id defaults to null when omitted", async () => {
+    const { json } = await rpc({
+      jsonrpc: "2.0",
+      method: "tools/call",
+      params: { name: "scan_domain", arguments: { domain: "example.com" } },
+    });
+    expect(json.id).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a stateless MCP streamable-HTTP endpoint at `POST /mcp` (JSON-RPC 2.0, protocol `2025-03-26`) exposing the existing `scan_domain` capability
- Wraps the existing `scan()` orchestrator and SSE cache — no logic duplication
- Rate-limited identically to `/api/check` (10 req/IP/60s)
- Discovery surfaces atomically: `/.well-known/mcp/server-card.json` (SEP-1649), `/.well-known/api-catalog`, `/openapi.json`, and `/.well-known/agent-skills/index.json` (new `mcp`-type entry with sha256 of server card) all updated in this PR
- `SKILL.md` updated to document the MCP transport variant

## New files

- `src/mcp/handler.ts` — stateless JSON-RPC dispatcher handling `initialize`, `notifications/initialized`, `tools/list`, `tools/call`
- `test/mcp.test.ts` — 16 unit tests covering protocol errors, initialize, tools/list, tools/call (success + error paths), selector stripping, id propagation

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 895 pass, 1 pre-existing network-dependent integration test fails (unrelated)
- [x] 16 new MCP unit tests all pass
- [x] `agent-discovery` test updated to expect 4 linkset entries (added `/mcp`)

Closes #181

https://claude.ai/code/session_01BGsvgHfdJAfrW9iM2fgTQH

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGsvgHfdJAfrW9iM2fgTQH)_