### PR TITLE
fix: surface DnsLookupError in TLS-RPT analyzer on SERVFAIL/timeout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -370,8 +370,7 @@
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260516.1.tgz",
       "integrity": "sha512-aPckyZSPQXhOo+nSIvGLtXVl9M2qmf2GwFZYmvut9z47F1XTjHYcaYpI9/BvxrI+Q5l99UtXZU4bmQtX10JG+w==",
       "devOptional": true,
-      "license": "MIT OR Apache-2.0",
-      "peer": true
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -392,7 +391,6 @@
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -404,7 +402,6 @@
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1809,7 +1806,6 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -1878,7 +1874,6 @@
       "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.5",
         "pathe": "^2.0.3"
@@ -1893,7 +1888,6 @@
       "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "4.1.5",
         "@vitest/utils": "4.1.5",
@@ -2522,7 +2516,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3286,7 +3279,6 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -3297,7 +3289,6 @@
       "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3376,7 +3367,6 @@
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",

--- a/src/analyzers/tls-rpt.ts
+++ b/src/analyzers/tls-rpt.ts
@@ -1,4 +1,4 @@
-import { queryTxt } from "../dns/client.js";
+import { DnsLookupError, queryTxt } from "../dns/client.js";
 import { parseTags } from "../shared/parse-tags.js";
 import type { TlsRptResult, Validation } from "./types.js";
 
@@ -8,7 +8,26 @@ import type { TlsRptResult, Validation } from "./types.js";
 // not change the enforcement posture.
 
 export async function analyzeTlsRpt(domain: string): Promise<TlsRptResult> {
-  const txt = await queryTxt(`_smtp._tls.${domain}`);
+  let txt: Awaited<ReturnType<typeof queryTxt>>;
+  try {
+    txt = await queryTxt(`_smtp._tls.${domain}`);
+  } catch (err) {
+    if (err instanceof DnsLookupError) {
+      return {
+        status: "warn",
+        record: null,
+        tags: null,
+        lookup_error: { code: err.code, message: err.message },
+        validations: [
+          {
+            status: "warn",
+            message: `TLS-RPT lookup failed (${err.code}) — result may be incomplete`,
+          },
+        ],
+      };
+    }
+    throw err;
+  }
 
   if (!txt || txt.entries.length === 0) {
     return {

--- a/src/analyzers/types.ts
+++ b/src/analyzers/types.ts
@@ -110,6 +110,7 @@ export interface TlsRptResult {
   record: string | null;
   tags: Record<string, string> | null;
   validations: Validation[];
+  lookup_error?: { code: string; message: string };
 }
 
 export interface ScanSummary {

--- a/test/tls-rpt.test.ts
+++ b/test/tls-rpt.test.ts
@@ -5,9 +5,17 @@ import { analyzeTlsRpt } from "../src/analyzers/tls-rpt.js";
 vi.mock("../src/dns/client.js", () => ({
   queryTxt: vi.fn(),
   queryMx: vi.fn(),
+  DnsLookupError: class DnsLookupError extends Error {
+    code: string;
+    constructor(code: string, message: string) {
+      super(message);
+      this.name = "DnsLookupError";
+      this.code = code;
+    }
+  },
 }));
 
-import { queryTxt } from "../src/dns/client.js";
+import { DnsLookupError, queryTxt } from "../src/dns/client.js";
 
 const mockQueryTxt = vi.mocked(queryTxt);
 
@@ -170,5 +178,47 @@ describe("analyzeTlsRpt", () => {
     });
     const result = await analyzeTlsRpt("example.com");
     expect(result.status).toBe("pass");
+  });
+
+  it("returns warn + lookup_error on SERVFAIL", async () => {
+    mockQueryTxt.mockRejectedValue(
+      new DnsLookupError("ESERVFAIL", "DNS server failure (SERVFAIL)"),
+    );
+    const result = await analyzeTlsRpt("example.com");
+    expect(result.status).toBe("warn");
+    expect(result.record).toBeNull();
+    expect(result.tags).toBeNull();
+    expect(result.lookup_error).toEqual({
+      code: "ESERVFAIL",
+      message: "DNS server failure (SERVFAIL)",
+    });
+    expect(
+      result.validations.some(
+        (v) => v.status === "warn" && v.message.includes("ESERVFAIL"),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns warn + lookup_error on DNS timeout", async () => {
+    mockQueryTxt.mockRejectedValue(
+      new DnsLookupError("DNS_TIMEOUT", "DNS query timed out"),
+    );
+    const result = await analyzeTlsRpt("example.com");
+    expect(result.status).toBe("warn");
+    expect(result.lookup_error?.code).toBe("DNS_TIMEOUT");
+  });
+
+  it("re-throws non-DnsLookupError errors", async () => {
+    mockQueryTxt.mockRejectedValue(new Error("unexpected error"));
+    await expect(analyzeTlsRpt("example.com")).rejects.toThrow(
+      "unexpected error",
+    );
+  });
+
+  it("still returns info with no record when NXDOMAIN (null)", async () => {
+    mockQueryTxt.mockResolvedValue(null);
+    const result = await analyzeTlsRpt("example.com");
+    expect(result.status).toBe("info");
+    expect(result.lookup_error).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- Wraps the `_smtp._tls` TXT lookup in `analyzeTlsRpt` with a `try/catch` matching the DMARC/SPF/MX pattern from #277
- SERVFAIL or DNS timeout now returns `{ status: "warn", lookup_error: { code, message } }` instead of being silently treated as "no record"
- NXDOMAIN/NODATA still returns `null` → `info` status (unchanged)
- Adds `lookup_error?` field to `TlsRptResult` in `src/analyzers/types.ts`

Closes #298

## Test plan

- [x] `analyzeTlsRpt` returns `warn` + `lookup_error.code === "ESERVFAIL"` on SERVFAIL
- [x] `analyzeTlsRpt` returns `warn` + `lookup_error.code === "DNS_TIMEOUT"` on timeout
- [x] Non-`DnsLookupError` errors are re-thrown unchanged
- [x] NXDOMAIN (null from `queryTxt`) still returns `info` with no `lookup_error`
- [x] All 15 tests in `test/tls-rpt.test.ts` pass (11 pre-existing + 4 new)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean

## Deferred
None — all Acceptance items shipped.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3UBXeNMGwJ1ZLFbm2NsLB)_