### PR TITLE
fix: routine pipeline audit comment on every auto-merge + pipeline-paused kill switch

### DIFF
--- a/docs/routine-pipeline.md
+++ b/docs/routine-pipeline.md
@@ -25,5 +25,37 @@ prompt file contents, set schedule (implementer every 4h; reviewer offset +1h),
 enable `claude/`-branch pushes for the implementer. Routine commits appear as
 `schmug`.
 
+## Kill switch (pipeline-paused label)
+
+Both Routines check for the `pipeline-paused` repo label **before any other
+action**. If the label is present, the Routine exits immediately with a no-op
+message and mutates nothing (no PRs opened, no merges, no comments).
+
+**To pause the pipeline:**
+```
+gh label create pipeline-paused --repo schmug/dmarcheck \
+  --color 5319E7 --description "Kill switch: both Routines will no-op while this label exists" \
+  --force
+```
+(If `setup-labels.sh` has already been run, the label already exists — you only
+need to ensure it is present; `--force` makes this idempotent.)
+
+**To resume the pipeline:**
+```
+gh label delete pipeline-paused --repo schmug/dmarcheck --yes
+```
+
+Once the label is deleted, the next scheduled Routine run resumes normal
+operation automatically — no config change required.
+
+## Audit trail (gate verdict comments)
+
+On every auto-merged PR the reviewer Routine posts a comment containing the full
+gate verdict JSON (`pass: true`, `reasons` array) as returned by
+`scripts/routine-gate/gate.ts`. This creates an immutable per-PR record of
+exactly why the gate passed the PR, supporting forensics after the fact.
+Escalated PRs have always carried a `reasons` comment; auto-merges now carry an
+equivalent comment.
+
 ## Pilot validation log
 Filled in during go-live. Scenario → expected → actual.

--- a/scripts/routine-pipeline/routine-implementer.md
+++ b/scripts/routine-pipeline/routine-implementer.md
@@ -3,6 +3,13 @@
 You are the implementer for the issue→PR pipeline. The repo is checked out at the
 working directory. Do exactly this:
 
+0. **Kill-switch check (do this FIRST, before any other action):**
+   Run: `gh label list --repo <REPO> --json name | jq -e '.[].name | select(. == "pipeline-paused")' > /dev/null 2>&1`
+   If the `pipeline-paused` label exists on the repo, stop immediately. Open NO
+   PRs, comment NOTHING, mutate NOTHING. Output exactly:
+   `Pipeline is paused (pipeline-paused label is set). Implementer Routine exiting — no-op.`
+   Then end the run. Do not proceed to step 1.
+
 1. List candidate issues:
    `gh issue list --repo <REPO> --label spec-approved --state open --json number,author,createdAt`
 2. Discard any whose `author.login` is not `schmug`. Sort the rest oldest-first.

--- a/scripts/routine-pipeline/routine-reviewer.md
+++ b/scripts/routine-pipeline/routine-reviewer.md
@@ -3,6 +3,13 @@
 You are the reviewer/merger. The repo is checked out at the working directory.
 The gate is a deterministic script — TRUST ITS EXIT CODE, do not re-judge.
 
+0. **Kill-switch check (do this FIRST, before any other action):**
+   Run: `gh label list --repo <REPO> --json name | jq -e '.[].name | select(. == "pipeline-paused")' > /dev/null 2>&1`
+   If the `pipeline-paused` label exists on the repo, stop immediately. Post NO
+   comments, merge NOTHING, mutate NOTHING. Output exactly:
+   `Pipeline is paused (pipeline-paused label is set). Reviewer Routine exiting — no-op.`
+   Then end the run. Do not proceed to step 1.
+
 1. `gh pr list --repo <REPO> --label auto-impl --state open --json number,labels`
 2. Skip any PR that already has the `needs-you` label (idempotent).
 3. For EACH remaining PR #P:
@@ -10,6 +17,15 @@ The gate is a deterministic script — TRUST ITS EXIT CODE, do not re-judge.
    b. Capture stdout (JSON verdict) and the exit code.
    c. If exit code == 0 (PASS):
       `gh pr merge P --repo <REPO> --squash --auto --delete-branch`
+      Post a comment on PR #P containing the full gate verdict JSON (the complete
+      stdout captured in step 3b), formatted as a code block, e.g.:
+      ```
+      gh pr comment P --repo <REPO> --body "**Gate verdict (auto-merged)**
+      \`\`\`json
+      <full stdout JSON here>
+      \`\`\`"
+      ```
+      This creates an immutable audit record of exactly why the gate passed this PR.
       Then comment the one-line outcome on the issue the PR closes.
    d. If exit code == 2 (FAIL): add the `needs-you` label to PR #P and add a PR
       comment containing the `reasons` array from the JSON verdict.

--- a/scripts/routine-pipeline/setup-labels.sh
+++ b/scripts/routine-pipeline/setup-labels.sh
@@ -7,8 +7,9 @@ REPO="${1:?usage: setup-labels.sh owner/name}"
 create() { # name color description
   gh label create "$1" --repo "$REPO" --color "$2" --description "$3" --force
 }
-create "spec-approved" "0E8A16" "Issue spec'd by owner in interactive session; trust token for auto-merge"
-create "auto-impl"     "1D76DB" "PR opened by the implementer Routine"
-create "needs-you"     "D93F0B" "Escalated by the reviewer Routine; needs owner decision"
-create "impl-blocked"  "B60205" "Implementer Routine could not produce a green PR"
+create "spec-approved"    "0E8A16" "Issue spec'd by owner in interactive session; trust token for auto-merge"
+create "auto-impl"        "1D76DB" "PR opened by the implementer Routine"
+create "needs-you"        "D93F0B" "Escalated by the reviewer Routine; needs owner decision"
+create "impl-blocked"     "B60205" "Implementer Routine could not produce a green PR"
+create "pipeline-paused"  "5319E7" "Kill switch: both Routines will no-op while this label exists"
 echo "labels ensured on $REPO"


### PR DESCRIPTION
Superseded by #336 (same issue, cleaner implementation). Closing.