### PR TITLE
fix: run routine gate from main branch, not PR checkout

### DIFF
--- a/docs/routine-pipeline.md
+++ b/docs/routine-pipeline.md
@@ -14,6 +14,19 @@ protection is the independent backstop. Note: the gate over-blocks on ambiguous
 `Closes` refs and code-fenced examples (fails safe → escalates, never
 auto-merges).
 
+### Gate-from-main invariant (defence-in-depth)
+The reviewer Routine always runs gate code from the **`main` branch**, not from
+the PR being evaluated. It uses `git show main:scripts/routine-gate/<file>` to
+extract each gate source file into a temporary directory, symlinks the repo's
+`node_modules` there, then runs `npx tsx <tmpdir>/gate.ts`. The temp dir is
+removed after each PR.
+
+This means a PR that edits `scripts/routine-gate/` is still evaluated by the
+unmodified `main` gate — it cannot weaken its own judge. The denylist entry for
+`scripts/routine-gate/**` (added in #311) is the primary control; running from
+`main` is belt-and-suspenders. PR *metadata* (diff, files, CI status) continues
+to be fetched live via `gh`, unaffected by this change.
+
 ## Cap math (Max = 15 Routine runs/day)
 4 cycles/day × (implementer + reviewer) = 8 runs/day. Implementer 6 issues/run ×
 4 = up to 24 issues/day. One-off scheduled runs don't count against the cap.

--- a/scripts/routine-pipeline/routine-reviewer.md
+++ b/scripts/routine-pipeline/routine-reviewer.md
@@ -9,11 +9,29 @@ The gate is a deterministic script — TRUST ITS EXIT CODE, do not re-judge.
    "Pipeline paused: `pipeline-paused` label detected. No-op this run."
    Do NOT open, merge, comment on, or label any PR or issue.
 
+**Security invariant:** always run the gate from the `main` branch, never from
+the PR branch. This ensures a PR that modifies `scripts/routine-gate/` cannot
+be judged by its own weakened gate code. PR metadata (diff, files, CI status)
+is still fetched live from GitHub via `gh`.
+
 1. `gh pr list --repo <REPO> --label auto-impl --state open --json number,labels`
 2. Skip any PR that already has the `needs-you` label (idempotent).
 3. For EACH remaining PR #P:
-   a. Run: `npx tsx scripts/routine-gate/gate.ts --repo <REPO> --pr P`
-   b. Capture stdout (JSON verdict) and the exit code.
+   a. Extract the gate from `main` into a temp dir and run it there:
+      ```sh
+      GATE_TMP=$(mktemp -d)
+      for f in gate.ts gate-core.ts config.ts github.ts tsconfig.json; do
+        git show main:scripts/routine-gate/$f > "$GATE_TMP/$f"
+      done
+      ln -s "$(pwd)/node_modules" "$GATE_TMP/node_modules"
+      GATE_OUT=$(npx tsx "$GATE_TMP/gate.ts" --repo <REPO> --pr P 2>gate_stderr.txt)
+      EXIT_CODE=$?
+      rm -rf "$GATE_TMP"
+      ```
+      The `git show main:...` commands extract each file verbatim from the
+      merged `main` tree — the PR checkout has no effect on gate logic.
+   b. `GATE_OUT` holds the JSON verdict; `EXIT_CODE` holds the exit code.
+      On crash, check `gate_stderr.txt` for the error message.
    c. If exit code == 0 (PASS):
       `gh pr merge P --repo <REPO> --squash --auto --delete-branch`
       Post the full gate verdict as a PR comment (for audit trail):


### PR DESCRIPTION
## Summary

- The reviewer Routine (`scripts/routine-pipeline/routine-reviewer.md`) previously ran the gate with `npx tsx scripts/routine-gate/gate.ts` from the PR checkout, which allowed a PR modifying gate code to be judged by its own version.
- Step 3a is updated to extract all gate source files from `main` via `git show main:scripts/routine-gate/<file>` into a temp dir, symlink `node_modules`, and run `npx tsx` from there. The temp dir is removed after each PR.
- PR metadata (diff, changed files, CI status rollup) is unchanged — still fetched live via `gh`.
- Documented the gate-from-main invariant in `docs/routine-pipeline.md` under a new subsection.
- No new runtime dependencies; exit-code contract (0 = merge, 2 = escalate) unchanged.

## Test plan

- [ ] `npm test` — 1043/1044 tests pass (1 pre-existing network-integration failure unrelated to this change)
- [ ] `npm run typecheck` — 0 errors
- [ ] Verify step 3a shell block: for a PR that edits `scripts/routine-gate/gate-core.ts`, the Routine extracts gate files from `main`, not the PR branch
- [ ] Confirm the `GATE_OUT` / `EXIT_CODE` / `gate_stderr.txt` variables feed correctly into steps 3c/3d/3e

Closes #312

https://claude.ai/code/session_01W7vMz1qNUds1WpAynFsU9y

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7vMz1qNUds1WpAynFsU9y)_