### PR TITLE
fix: harden parseClosesIssue to ignore code-fenced and unterminated-comment Closes refs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -370,8 +370,7 @@
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260516.1.tgz",
       "integrity": "sha512-aPckyZSPQXhOo+nSIvGLtXVl9M2qmf2GwFZYmvut9z47F1XTjHYcaYpI9/BvxrI+Q5l99UtXZU4bmQtX10JG+w==",
       "devOptional": true,
-      "license": "MIT OR Apache-2.0",
-      "peer": true
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -392,7 +391,6 @@
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -404,7 +402,6 @@
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1809,7 +1806,6 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -1878,7 +1874,6 @@
       "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.5",
         "pathe": "^2.0.3"
@@ -1893,7 +1888,6 @@
       "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "4.1.5",
         "@vitest/utils": "4.1.5",
@@ -2522,7 +2516,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3286,7 +3279,6 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -3297,7 +3289,6 @@
       "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3376,7 +3367,6 @@
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",

--- a/scripts/routine-gate/__tests__/gate-core.test.ts
+++ b/scripts/routine-gate/__tests__/gate-core.test.ts
@@ -174,6 +174,21 @@ describe("parseClosesIssue / closesIssueRefs hardening", () => {
     expect(parseClosesIssue("Closes #42 and again Closes #42")).toBe(42);
     expect(closesIssueRefs("Closes #42 Closes #42")).toEqual([42]);
   });
+  it("ignores Closes inside inline code spans", () => {
+    expect(parseClosesIssue("Example: `Closes #999`\n\nCloses #42")).toBe(42);
+  });
+  it("ignores Closes inside fenced code blocks", () => {
+    expect(parseClosesIssue("```\nCloses #999\n```\n\nCloses #42")).toBe(42);
+  });
+  it("ignores Closes in fenced block with language specifier", () => {
+    expect(parseClosesIssue("```markdown\nCloses #999\n```\n\nCloses #42")).toBe(42);
+  });
+  it("strips unterminated HTML comment through end of body", () => {
+    expect(parseClosesIssue("Closes #42\n<!--\nold ref: Closes #999")).toBe(42);
+  });
+  it("fails closed (no refs) when the only Closes is in an unterminated comment", () => {
+    expect(parseClosesIssue("<!-- Closes #42")).toBeNull();
+  });
 });
 
 describe("evaluateGate ambiguity + provenance source-of-truth", () => {

--- a/scripts/routine-gate/gate-core.ts
+++ b/scripts/routine-gate/gate-core.ts
@@ -19,10 +19,12 @@ export interface PrInfo {
 
 type Cfg = typeof CONFIG_T;
 
-// Strip HTML comments and markdown blockquote lines, then collect DISTINCT issue refs.
+// Strip HTML comments, code blocks, and blockquote lines, then collect DISTINCT issue refs.
 export function closesIssueRefs(body: string): number[] {
   const cleaned = body
-    .replace(/<!--[\s\S]*?-->/g, " ")          // drop HTML comments
+    .replace(/<!--[\s\S]*?(?:-->|$)/g, " ")    // drop HTML comments (incl. unterminated)
+    .replace(/```[\s\S]*?```/g, " ")            // drop fenced code blocks
+    .replace(/`[^`]*`/g, " ")                   // drop inline code spans
     .split("\n")
     .filter((line) => !/^\s*>/.test(line))      // drop blockquote lines
     .join("\n");


### PR DESCRIPTION
Superseded by #338 (same issue, cleaner implementation). Closing.