### PR TITLE
🎨 Palette: Make dashboard empty states actionable

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-05-16 - Add ARIA live region for dynamic form validation
 **Learning:** For multi-step wizard forms or dynamic client-side validation, screen readers need explicit context when errors appear. Using a hidden error div without `role="alert"` and `aria-live="polite"` prevents the error from being announced.
 **Action:** Always link the input field to its error container using `aria-describedby` and dynamically toggle `aria-invalid="true"` on the input when it fails validation.
+
+## 2026-05-19 - Make empty states actionable
+**Learning:** Empty states that simply say "No data" or "No history yet" represent a missed opportunity to guide the user. Providing actionable guidance or calls-to-action reduces friction and improves usability.
+**Action:** When designing empty states for arrays or lists, always include a call to action or an explanation of how the user can populate the list (e.g., "Click 'Scan Now' to run your first scan").

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -2290,7 +2290,7 @@ export function renderDomainDetailPage({
   const historySection =
     scanHistory.length > 0
       ? `<ul class="history-list">${historyItems}</ul>`
-      : `<p style="color:var(--clr-text-muted);font-size:0.875rem;padding:0.75rem 0">No scan history yet.</p>`;
+      : `<p style="color:var(--clr-text-muted);font-size:0.875rem;padding:0.75rem 0">No scan history yet. Click 'Scan Now' to run your first scan.</p>`;
 
   const body = `<div class="domain-detail-header">
   <span class="grade-badge ${gradeClass(grade)}">${esc(grade)}</span>
@@ -2358,7 +2358,7 @@ const GRADE_RANK_FOR_SPARKLINE: Record<string, number> = {
 
 function renderSparkline(entries: HistoryScanEntry[]): string {
   if (entries.length === 0) {
-    return `<p style="color:var(--clr-text-muted);font-size:0.875rem;padding:0.75rem 0">No scans yet to chart.</p>`;
+    return `<p style="color:var(--clr-text-muted);font-size:0.875rem;padding:0.75rem 0">No scans yet to chart. Click 'Scan Now' to generate data.</p>`;
   }
   const width = 600;
   const height = 80;
@@ -2408,7 +2408,7 @@ function renderDriftCell(
 
 function renderDriftTable(entries: HistoryScanEntry[]): string {
   if (entries.length === 0) {
-    return `<p style="color:var(--clr-text-muted);font-size:0.875rem;padding:0.75rem 0">No scans yet.</p>`;
+    return `<p style="color:var(--clr-text-muted);font-size:0.875rem;padding:0.75rem 0">No scans yet. Click 'Scan Now' to compare scan results.</p>`;
   }
   // Rows are newest-first. To highlight "changed vs the prior (older) scan",
   // we compare each row to the NEXT row in the list (which is chronologically
@@ -2940,7 +2940,7 @@ export function renderApiKeysPage({
 
   let table: string;
   if (keys.length === 0) {
-    table = `<p style="color:var(--clr-text-muted);font-size:0.875rem">No API keys yet.</p>`;
+    table = `<p style="color:var(--clr-text-muted);font-size:0.875rem">No API keys yet. Generate your first one above.</p>`;
   } else {
     const rows = keys
       .map((k) => {

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   handleMcpRequest,
   MCP_PROTOCOL_VERSION,


### PR DESCRIPTION
### 💡 What
Updated multiple empty state messages across the dashboard (such as the API Keys list, scan history, sparklines, and drift tables) to be more actionable. 

### 🎯 Why
Empty states that merely say "No data" or "No API keys yet" present a dead end to the user. By adding a clear call-to-action or an explanation (e.g., "Click 'Scan Now' to run your first scan"), we reduce friction, guide the user on what to do next, and improve overall usability and conversion.

### 📸 Before/After
**Before:** "No API keys yet."
**After:** "No API keys yet. Generate your first one above."

**Before:** "No scan history yet."
**After:** "No scan history yet. Click 'Scan Now' to run your first scan."

### ♿ Accessibility
While primarily a usability and cognitive load improvement, clearer instructions benefit all users, especially those using screen readers, by clearly conveying how to resolve the empty state.

---
*PR created automatically by Jules for task [16650756197987872646](https://jules.google.com/task/16650756197987872646) started by @schmug*