### PR TITLE
⚡ Bolt: Batch database inserts for alerts to improve cron rescan performance

### DIFF
--- a/src/cron/rescan.ts
+++ b/src/cron/rescan.ts
@@ -5,7 +5,7 @@ import {
   detectProtocolRegressions,
 } from "../alerts/detector.js";
 import type { ScanResult } from "../analyzers/types.js";
-import { recordAlert } from "../db/alerts.js";
+import { recordAlerts } from "../db/alerts.js";
 import { type Domain, getDueDomains } from "../db/domains.js";
 import { recordScan } from "../db/scans.js";
 import { getUserById } from "../db/users.js";
@@ -147,14 +147,17 @@ async function rescanOne(
   );
   alerts.push(...protocolAlerts);
 
-  for (const alert of alerts) {
-    await recordAlert(deps.db, {
-      domainId: domain.id,
-      type: alert.type,
-      previousValue: alert.previousValue,
-      newValue: alert.newValue,
-      createdAt: deps.now,
-    });
+  if (alerts.length > 0) {
+    await recordAlerts(
+      deps.db,
+      alerts.map((alert) => ({
+        domainId: domain.id,
+        type: alert.type,
+        previousValue: alert.previousValue,
+        newValue: alert.newValue,
+        createdAt: deps.now,
+      })),
+    );
   }
 
   return { alerts: alerts.length };

--- a/src/db/alerts.ts
+++ b/src/db/alerts.ts
@@ -38,6 +38,28 @@ export async function recordAlert(
     .run();
 }
 
+export async function recordAlerts(
+  db: D1Database,
+  inputs: RecordAlertInput[],
+): Promise<void> {
+  if (inputs.length === 0) return;
+  const stmts = inputs.map((input) => {
+    const createdAt = input.createdAt ?? Math.floor(Date.now() / 1000);
+    return db
+      .prepare(
+        "INSERT INTO alerts (domain_id, alert_type, previous_value, new_value, created_at) VALUES (?, ?, ?, ?, ?)",
+      )
+      .bind(
+        input.domainId,
+        input.type,
+        input.previousValue,
+        input.newValue,
+        createdAt,
+      );
+  });
+  await db.batch(stmts);
+}
+
 // Returns alerts that haven't been delivered yet (notified_via IS NULL).
 // Joins to domains to expose the owning user_id for alert routing.
 export interface UnsentAlert extends AlertRow {

--- a/test/db-alerts.test.ts
+++ b/test/db-alerts.test.ts
@@ -7,6 +7,7 @@ import {
   listUnsentAlerts,
   markAlertNotified,
   recordAlert,
+  recordAlerts,
 } from "../src/db/alerts.js";
 
 let alertStore: Map<number, AlertRow>;
@@ -121,7 +122,16 @@ function makeD1Mock(): D1Database {
       },
     }),
   });
-  return { prepare } as unknown as D1Database;
+  return {
+    prepare,
+    batch: async (stmts) => {
+      const results = [];
+      for (const stmt of stmts) {
+        results.push(await stmt.run());
+      }
+      return results;
+    },
+  } as unknown as D1Database;
 }
 
 describe("db/alerts", () => {
@@ -135,6 +145,40 @@ describe("db/alerts", () => {
     ]);
     nextId = 1;
     db = makeD1Mock();
+  });
+
+  describe("recordAlerts", () => {
+    it("inserts multiple alerts in a batch", async () => {
+      await recordAlerts(db, [
+        {
+          domainId: 7,
+          type: "grade_drop",
+          previousValue: "A",
+          newValue: "C",
+          createdAt: 1_700_000_000,
+        },
+        {
+          domainId: 7,
+          type: "protocol_regression",
+          previousValue: "dmarc:pass",
+          newValue: "dmarc:fail",
+          createdAt: 1_700_000_001,
+        },
+      ]);
+
+      expect(alertStore.size).toBe(2);
+      const rows = [...alertStore.values()];
+
+      expect(rows[0].domain_id).toBe(7);
+      expect(rows[0].alert_type).toBe("grade_drop");
+      expect(rows[0].previous_value).toBe("A");
+      expect(rows[0].new_value).toBe("C");
+
+      expect(rows[1].domain_id).toBe(7);
+      expect(rows[1].alert_type).toBe("protocol_regression");
+      expect(rows[1].previous_value).toBe("dmarc:pass");
+      expect(rows[1].new_value).toBe("dmarc:fail");
+    });
   });
 
   describe("recordAlert", () => {

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   handleMcpRequest,
   MCP_PROTOCOL_VERSION,


### PR DESCRIPTION
💡 **What:**
Implemented a batched alert insertion function (`recordAlerts`) in `src/db/alerts.ts` and updated the `rescanOne` loop in `src/cron/rescan.ts` to use it instead of making sequential `recordAlert` calls. 

🎯 **Why:**
When a scan detects multiple issues (e.g., a grade drop + multiple protocol regressions), the original code awaited individual database inserts sequentially. Since this runs for multiple domains in a cron job, these sequential network round-trips to Cloudflare D1 created unnecessary latency. `db.batch()` consolidates these inserts into a single request.

📊 **Impact:**
Reduces database latency for alert generation from N network round-trips (where N is the number of alerts generated for a domain in one scan) to exactly 1 round-trip.

🔬 **Measurement:**
Tested locally via Vitest to verify identical logical behavior. The new `recordAlerts` method uses the exact same `INSERT` statement but wraps it in `db.batch`. All tests pass.

---
*PR created automatically by Jules for task [1110855468627316471](https://jules.google.com/task/1110855468627316471) started by @schmug*