### PR TITLE
feat: add per-merge audit comment and pipeline kill switch

### DIFF
--- a/docs/routine-pipeline.md
+++ b/docs/routine-pipeline.md
@@ -25,5 +25,27 @@ prompt file contents, set schedule (implementer every 4h; reviewer offset +1h),
 enable `claude/`-branch pushes for the implementer. Routine commits appear as
 `schmug`.
 
+## Kill switch — pausing both Routines
+
+Both the implementer and reviewer check for the `pipeline-paused` label **as
+their very first action** (step 0). If the label is present, the Routine exits
+immediately with "Pipeline is paused. No-op." and mutates nothing — no PRs
+opened, no merges, no escalations.
+
+**To pause:** add (or create) the `pipeline-paused` label on the repo:
+```
+gh label create pipeline-paused --repo schmug/dmarcheck \
+  --color CCCCCC --description "Pauses both Routines; remove to resume" --force
+```
+Or use `scripts/routine-pipeline/setup-labels.sh schmug/dmarcheck` (idempotent;
+creates all five labels including `pipeline-paused`).
+
+**To resume:** delete the label:
+```
+gh label delete pipeline-paused --repo schmug/dmarcheck --yes
+```
+
+The label is the sole gate — no cloud Routine config needs editing.
+
 ## Pilot validation log
 Filled in during go-live. Scenario → expected → actual.

--- a/scripts/routine-pipeline/routine-implementer.md
+++ b/scripts/routine-pipeline/routine-implementer.md
@@ -3,6 +3,10 @@
 You are the implementer for the issue→PR pipeline. The repo is checked out at the
 working directory. Do exactly this:
 
+0. **Kill switch check (first action — mutate nothing if paused):**
+   `gh label list --repo <REPO> | grep -q "^pipeline-paused" && echo "Pipeline is paused. No-op." && exit 0`
+   If the `pipeline-paused` label exists on the repo, stop immediately and do nothing else.
+
 1. List candidate issues:
    `gh issue list --repo <REPO> --label spec-approved --state open --json number,author,createdAt`
 2. Discard any whose `author.login` is not `schmug`. Sort the rest oldest-first.

--- a/scripts/routine-pipeline/routine-reviewer.md
+++ b/scripts/routine-pipeline/routine-reviewer.md
@@ -3,13 +3,19 @@
 You are the reviewer/merger. The repo is checked out at the working directory.
 The gate is a deterministic script — TRUST ITS EXIT CODE, do not re-judge.
 
+0. **Kill switch check (first action — mutate nothing if paused):**
+   `gh label list --repo <REPO> | grep -q "^pipeline-paused" && echo "Pipeline is paused. No-op." && exit 0`
+   If the `pipeline-paused` label exists on the repo, stop immediately and do nothing else.
+
 1. `gh pr list --repo <REPO> --label auto-impl --state open --json number,labels`
 2. Skip any PR that already has the `needs-you` label (idempotent).
 3. For EACH remaining PR #P:
-   a. Run: `npx tsx scripts/routine-gate/gate.ts --repo <REPO> --pr P`
-   b. Capture stdout (JSON verdict) and the exit code.
+   a. Run: `npx tsx scripts/routine-gate/gate.ts --repo <REPO> --pr P 2>/tmp/gate-stderr.txt | tee /tmp/verdict.json; GATE_EXIT=${PIPESTATUS[0]}`
+   b. The verdict JSON is now in `/tmp/verdict.json`; exit code is in `$GATE_EXIT`.
    c. If exit code == 0 (PASS):
       `gh pr merge P --repo <REPO> --squash --auto --delete-branch`
+      Post the full gate verdict as an audit comment on PR #P:
+      `gh pr comment P --repo <REPO> --body "Gate verdict: $(cat /tmp/verdict.json)"`
       Then comment the one-line outcome on the issue the PR closes.
    d. If exit code == 2 (FAIL): add the `needs-you` label to PR #P and add a PR
       comment containing the `reasons` array from the JSON verdict.

--- a/scripts/routine-pipeline/setup-labels.sh
+++ b/scripts/routine-pipeline/setup-labels.sh
@@ -7,8 +7,9 @@ REPO="${1:?usage: setup-labels.sh owner/name}"
 create() { # name color description
   gh label create "$1" --repo "$REPO" --color "$2" --description "$3" --force
 }
-create "spec-approved" "0E8A16" "Issue spec'd by owner in interactive session; trust token for auto-merge"
-create "auto-impl"     "1D76DB" "PR opened by the implementer Routine"
-create "needs-you"     "D93F0B" "Escalated by the reviewer Routine; needs owner decision"
-create "impl-blocked"  "B60205" "Implementer Routine could not produce a green PR"
+create "spec-approved"    "0E8A16" "Issue spec'd by owner in interactive session; trust token for auto-merge"
+create "auto-impl"        "1D76DB" "PR opened by the implementer Routine"
+create "needs-you"        "D93F0B" "Escalated by the reviewer Routine; needs owner decision"
+create "impl-blocked"     "B60205" "Implementer Routine could not produce a green PR"
+create "pipeline-paused"  "CCCCCC" "Pauses both Routines; remove to resume"
 echo "labels ensured on $REPO"


### PR DESCRIPTION
## Summary

- Every auto-merged PR now receives a gate verdict JSON comment (`pass: true, reasons: []`) immediately after merge, creating an immutable audit trail of why the gate passed it.
- Both the implementer and reviewer Routines now check for a `pipeline-paused` repo label as their **first action (step 0)**; if present, they exit with "Pipeline is paused. No-op." and mutate nothing.
- `scripts/routine-pipeline/setup-labels.sh` creates the `pipeline-paused` label (color: `CCCCCC`, description: "Pauses both Routines; remove to resume").
- `docs/routine-pipeline.md` documents the kill switch: how to pause (add the label) and resume (delete it).

## Acceptance criteria shipped

- [x] Every auto-merged PR has a comment containing the gate verdict JSON (`pass`, `reasons`).
- [x] With `pipeline-paused` present, both Routines no-op and mutate nothing (step 0 guard in both `routine-reviewer.md` and `routine-implementer.md`).
- [x] `setup-labels.sh` creates `pipeline-paused`.
- [x] `docs/routine-pipeline.md` documents pause/resume.

## Test plan

- [x] `npm test` — 1043 passed, 1 pre-existing network-integration failure (same baseline as `main`; unrelated to these changes).
- [ ] Manual: create `pipeline-paused` label on a test repo run; confirm Routine logs "Pipeline is paused. No-op." with no side effects.
- [ ] Manual: auto-merge a test PR through the gate; confirm verdict comment appears on the PR.

Closes #314

https://claude.ai/code/session_01N42cjH3f4WASC6m1vSJtji

---
_Generated by [Claude Code](https://claude.ai/code/session_01N42cjH3f4WASC6m1vSJtji)_