### PR TITLE
fix: strip code spans, fenced blocks, and unterminated HTML comments from parseClosesIssue

### DIFF
--- a/scripts/routine-gate/__tests__/gate-core.test.ts
+++ b/scripts/routine-gate/__tests__/gate-core.test.ts
@@ -174,6 +174,26 @@ describe("parseClosesIssue / closesIssueRefs hardening", () => {
     expect(parseClosesIssue("Closes #42 and again Closes #42")).toBe(42);
     expect(closesIssueRefs("Closes #42 Closes #42")).toEqual([42]);
   });
+  it("ignores Closes inside backtick inline code", () => {
+    expect(parseClosesIssue("Example: `Closes #999`\n\nCloses #42")).toBe(42);
+  });
+  it("ignores Closes inside a fenced code block (triple backtick)", () => {
+    expect(parseClosesIssue("```\nCloses #999\n```\n\nCloses #42")).toBe(42);
+  });
+  it("ignores Closes inside a fenced code block (triple tilde)", () => {
+    expect(parseClosesIssue("~~~\nCloses #999\n~~~\n\nCloses #42")).toBe(42);
+  });
+  it("ignores Closes inside an unterminated HTML comment fragment", () => {
+    expect(parseClosesIssue("<!-- Closes #999\n\nCloses #42")).toBe(42);
+  });
+  it("fails closed when the only real ref is inside stripped content", () => {
+    expect(parseClosesIssue("`Closes #42`")).toBeNull();
+    expect(parseClosesIssue("```\nCloses #42\n```")).toBeNull();
+    expect(parseClosesIssue("<!-- Closes #42")).toBeNull();
+  });
+  it("still fails closed on two real refs outside code/comments", () => {
+    expect(parseClosesIssue("`Closes #999`\nCloses #42\nCloses #99")).toBeNull();
+  });
 });
 
 describe("evaluateGate ambiguity + provenance source-of-truth", () => {

--- a/scripts/routine-gate/gate-core.ts
+++ b/scripts/routine-gate/gate-core.ts
@@ -19,10 +19,14 @@ export interface PrInfo {
 
 type Cfg = typeof CONFIG_T;
 
-// Strip HTML comments and markdown blockquote lines, then collect DISTINCT issue refs.
+// Strip HTML comments, code spans/blocks, and markdown blockquote lines, then collect DISTINCT issue refs.
 export function closesIssueRefs(body: string): number[] {
   const cleaned = body
-    .replace(/<!--[\s\S]*?-->/g, " ")          // drop HTML comments
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/~~~[\s\S]*?~~~/g, " ")
+    .replace(/`[^`\n]+`/g, " ")
+    .replace(/<!--[\s\S]*?-->/g, " ")          // drop complete HTML comments
+    .replace(/<!--[^\n]*/g, " ")               // drop unterminated HTML comment fragments
     .split("\n")
     .filter((line) => !/^\s*>/.test(line))      // drop blockquote lines
     .join("\n");


### PR DESCRIPTION
## Summary

- `closesIssueRefs` now strips inline code spans (`` `Closes #N` ``), triple-backtick and triple-tilde fenced code blocks before searching for Closes refs, so code examples in PR bodies no longer cause false ambiguity.
- Unterminated HTML comment fragments (`<!-- Closes #N` with no closing `-->`) are stripped line-by-line, so leftover template stubs no longer count as real refs.
- Fail-closed guarantee is unchanged: genuinely ambiguous refs outside stripped zones still produce `null` and escalate.

Closes #309

## Test plan

- [x] `parseClosesIssue("Example: \`Closes #999\`\n\nCloses #42")` → `42` (inline code stripped)
- [x] Triple-backtick fenced block containing `Closes #999` + real `Closes #42` outside → `42`
- [x] Triple-tilde fenced block same pattern → `42`
- [x] `<!-- Closes #999\n\nCloses #42` (unterminated comment) → `42`
- [x] Only ref inside stripped content → `null` (fail-closed)
- [x] Two real refs outside code/comments → `null` (fail-closed, unchanged)
- [x] All 52 gate-core tests pass; 1049/1050 total (1 pre-existing integration test fails due to network unavailability in CI sandbox — `mta-sts-runtime.test.ts` requires live access to dmarc.mx)

## Deferred

None.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MPeE4Apc6y6C58RNDdvV6t)_