### PR TITLE
⚡ Bolt: Optimize batch insertions for alerts using D1 batch

### DIFF
--- a/src/cron/rescan.ts
+++ b/src/cron/rescan.ts
@@ -5,7 +5,7 @@ import {
   detectProtocolRegressions,
 } from "../alerts/detector.js";
 import type { ScanResult } from "../analyzers/types.js";
-import { recordAlert } from "../db/alerts.js";
+import { recordAlerts } from "../db/alerts.js";
 import { type Domain, getDueDomains } from "../db/domains.js";
 import { recordScan } from "../db/scans.js";
 import { getUserById } from "../db/users.js";
@@ -147,14 +147,17 @@ async function rescanOne(
   );
   alerts.push(...protocolAlerts);
 
-  for (const alert of alerts) {
-    await recordAlert(deps.db, {
-      domainId: domain.id,
-      type: alert.type,
-      previousValue: alert.previousValue,
-      newValue: alert.newValue,
-      createdAt: deps.now,
-    });
+  if (alerts.length > 0) {
+    await recordAlerts(
+      deps.db,
+      alerts.map((alert) => ({
+        domainId: domain.id,
+        type: alert.type,
+        previousValue: alert.previousValue,
+        newValue: alert.newValue,
+        createdAt: deps.now,
+      })),
+    );
   }
 
   return { alerts: alerts.length };

--- a/src/db/alerts.ts
+++ b/src/db/alerts.ts
@@ -38,6 +38,28 @@ export async function recordAlert(
     .run();
 }
 
+export async function recordAlerts(
+  db: D1Database,
+  inputs: RecordAlertInput[],
+): Promise<void> {
+  if (inputs.length === 0) return;
+  const stmt = db.prepare(
+    "INSERT INTO alerts (domain_id, alert_type, previous_value, new_value, created_at) VALUES (?, ?, ?, ?, ?)",
+  );
+  const now = Math.floor(Date.now() / 1000);
+  await db.batch(
+    inputs.map((input) =>
+      stmt.bind(
+        input.domainId,
+        input.type,
+        input.previousValue,
+        input.newValue,
+        input.createdAt ?? now,
+      ),
+    ),
+  );
+}
+
 // Returns alerts that haven't been delivered yet (notified_via IS NULL).
 // Joins to domains to expose the owning user_id for alert routing.
 export interface UnsentAlert extends AlertRow {

--- a/test/db-alerts.test.ts
+++ b/test/db-alerts.test.ts
@@ -7,6 +7,7 @@ import {
   listUnsentAlerts,
   markAlertNotified,
   recordAlert,
+  recordAlerts,
 } from "../src/db/alerts.js";
 
 let alertStore: Map<number, AlertRow>;
@@ -121,7 +122,15 @@ function makeD1Mock(): D1Database {
       },
     }),
   });
-  return { prepare } as unknown as D1Database;
+  return {
+    prepare,
+    batch: async (
+      stmts: Array<{ run: () => Promise<{ success: boolean }> }>,
+    ) => {
+      for (const stmt of stmts) await stmt.run();
+      return [];
+    },
+  } as unknown as D1Database;
 }
 
 describe("db/alerts", () => {
@@ -135,6 +144,43 @@ describe("db/alerts", () => {
     ]);
     nextId = 1;
     db = makeD1Mock();
+  });
+
+  describe("recordAlerts", () => {
+    it("inserts multiple alerts in a single batch", async () => {
+      await recordAlerts(db, [
+        {
+          domainId: 7,
+          type: "grade_drop",
+          previousValue: "A",
+          newValue: "C",
+          createdAt: 1_700_000_000,
+        },
+        {
+          domainId: 9,
+          type: "protocol_regression",
+          previousValue: "dmarc:pass",
+          newValue: "dmarc:fail",
+          createdAt: 1_700_000_001,
+        },
+      ]);
+
+      expect(alertStore.size).toBe(2);
+
+      const rows = [...alertStore.values()];
+      expect(rows[0].domain_id).toBe(7);
+      expect(rows[0].alert_type).toBe("grade_drop");
+      expect(rows[0].created_at).toBe(1_700_000_000);
+
+      expect(rows[1].domain_id).toBe(9);
+      expect(rows[1].alert_type).toBe("protocol_regression");
+      expect(rows[1].created_at).toBe(1_700_000_001);
+    });
+
+    it("does nothing when given an empty array", async () => {
+      await recordAlerts(db, []);
+      expect(alertStore.size).toBe(0);
+    });
   });
 
   describe("recordAlert", () => {

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   handleMcpRequest,
   MCP_PROTOCOL_VERSION,


### PR DESCRIPTION
### 💡 What
Introduced `recordAlerts` in `src/db/alerts.ts` to utilize Cloudflare D1's `.batch()` functionality for inserting multiple alerts at once. Updated the rescan cron job to use this new function instead of looping over alerts and awaiting sequential inserts.

### 🎯 Why
During the nightly rescan cron job (`src/cron/rescan.ts`), if a domain triggered multiple protocol regressions or grade drops, the application would run a `for` loop, awaiting `recordAlert` for each individual alert. With Cloudflare D1, every query is an HTTP round-trip over the network. Sequential queries create significant N+1 overhead and slow down the processing pipeline. 

### 📊 Impact
Reduces database round-trips from O(N) (where N is the number of alerts for a single domain rescan) to O(1) by batching all inserts into a single D1 execution. This improves performance and reduces the overall latency of the rescan pipeline. 

### 🔬 Measurement
Verified via `pnpm lint` and `pnpm test`. The mock D1 testing harness in `test/db-alerts.test.ts` was updated to support `.batch()`, and tests were added to ensure `recordAlerts` correctly inserts multiple rows at once.

---
*PR created automatically by Jules for task [9347889395329885113](https://jules.google.com/task/9347889395329885113) started by @schmug*