### PR TITLE
🎨 Palette: Improve API Keys empty state and revoke button UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-05-16 - Add ARIA live region for dynamic form validation
 **Learning:** For multi-step wizard forms or dynamic client-side validation, screen readers need explicit context when errors appear. Using a hidden error div without `role="alert"` and `aria-live="polite"` prevents the error from being announced.
 **Action:** Always link the input field to its error container using `aria-describedby` and dynamically toggle `aria-invalid="true"` on the input when it fails validation.
+
+## 2026-05-21 - Actionable Empty States and Destructive Actions
+**Learning:** Empty states should provide actionable guidance rather than just stating a lack of data. Destructive actions like 'Revoke' should use the '.btn-danger' class to clearly communicate their severity.
+**Action:** Always include a call-to-action in empty states and use '.btn-danger' for destructive buttons.

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -2940,7 +2940,7 @@ export function renderApiKeysPage({
 
   let table: string;
   if (keys.length === 0) {
-    table = `<p style="color:var(--clr-text-muted);font-size:0.875rem">No API keys yet.</p>`;
+    table = `<p style="color:var(--clr-text-muted);font-size:0.875rem">No API keys yet. Generate your first one above.</p>`;
   } else {
     const rows = keys
       .map((k) => {
@@ -2956,7 +2956,7 @@ export function renderApiKeysPage({
           ? ""
           : `<form method="POST" action="/dashboard/settings/api-keys/revoke" style="display:inline" onsubmit="return confirm('Revoke this key? Requests using it will start failing.');">
               <input type="hidden" name="id" value="${esc(k.id)}">
-              <button type="submit" class="btn btn-secondary" style="padding:0.25rem 0.6rem;font-size:0.8125rem" aria-label="Revoke API key ${labelName}">Revoke</button>
+              <button type="submit" class="btn btn-danger" style="padding:0.25rem 0.6rem;font-size:0.8125rem" aria-label="Revoke API key ${labelName}">Revoke</button>
             </form>`;
         return `<tr>
   <td>${name}</td>


### PR DESCRIPTION
**💡 What**
- Updated the API keys empty state to explicitly direct the user to the key generation form above.
- Applied the standard `.btn-danger` CSS class to the API key 'Revoke' button instead of the default secondary button style.

**🎯 Why**
- Empty states that just state a lack of data leave users hanging. Adding a clear call-to-action ("Generate your first one above") guides them to the next logical step, reducing friction.
- The 'Revoke' action is destructive and irreversible. Styling it as a standard secondary button underplays its severity. The `.btn-danger` class leverages the app's standard failure colors (`var(--clr-fail)`) to intuitively warn users before they click.

**📸 Before/After**
*Before:* Empty state read "No API keys yet." Revoke button looked like a standard, safe action.
*After:* Empty state reads "No API keys yet. Generate your first one above." Revoke button is styled in red to indicate a destructive action.

**♿ Accessibility**
- While primarily visual/UX, the color change reinforces the severity of the action for sighted users, complementing the existing `aria-label`s and standard browser confirmation dialogues.

---
*PR created automatically by Jules for task [10594889214917896487](https://jules.google.com/task/10594889214917896487) started by @schmug*