### PR TITLE
fix: strip inline code and unterminated HTML comments in parseClosesIssue

### DIFF
--- a/scripts/routine-gate/__tests__/gate-core.test.ts
+++ b/scripts/routine-gate/__tests__/gate-core.test.ts
@@ -174,6 +174,15 @@ describe("parseClosesIssue / closesIssueRefs hardening", () => {
     expect(parseClosesIssue("Closes #42 and again Closes #42")).toBe(42);
     expect(closesIssueRefs("Closes #42 Closes #42")).toEqual([42]);
   });
+  it("ignores Closes inside inline code span", () => {
+    expect(parseClosesIssue("Example: `Closes #999`\n\nCloses #42")).toBe(42);
+  });
+  it("ignores Closes inside fenced code block", () => {
+    expect(parseClosesIssue("```\nCloses #999\n```\n\nCloses #42")).toBe(42);
+  });
+  it("ignores Closes inside unterminated HTML comment (strips to end of line)", () => {
+    expect(parseClosesIssue("<!-- Closes #999\n\nCloses #42")).toBe(42);
+  });
 });
 
 describe("evaluateGate ambiguity + provenance source-of-truth", () => {

--- a/scripts/routine-gate/gate-core.ts
+++ b/scripts/routine-gate/gate-core.ts
@@ -19,10 +19,13 @@ export interface PrInfo {
 
 type Cfg = typeof CONFIG_T;
 
-// Strip HTML comments and markdown blockquote lines, then collect DISTINCT issue refs.
+// Strip code spans, HTML comments, and markdown blockquote lines, then collect DISTINCT issue refs.
 export function closesIssueRefs(body: string): number[] {
   const cleaned = body
-    .replace(/<!--[\s\S]*?-->/g, " ")          // drop HTML comments
+    .replace(/```[\s\S]*?```/g, " ")           // drop fenced code blocks
+    .replace(/`[^`\n]+`/g, " ")               // drop inline code spans
+    .replace(/<!--[\s\S]*?-->/g, " ")          // drop complete HTML comments
+    .replace(/<!--[^\n]*/g, " ")              // drop unterminated HTML comment starts (to end of line)
     .split("\n")
     .filter((line) => !/^\s*>/.test(line))      // drop blockquote lines
     .join("\n");


### PR DESCRIPTION
## Summary

- Strip backtick inline code spans (`` `Closes #N` ``) and triple-backtick fenced code blocks before matching `Closes #N` refs — eliminates false-positive refs from code examples in PR bodies.
- Strip unterminated HTML comments (`<!--` with no closing `-->`) to end-of-line, so a forgotten `<!--` on a template line no longer poisons the ref count.
- Fail-closed guarantee is unchanged: genuinely ambiguous bodies (multiple distinct real refs outside stripped zones) still return `null`.

Closes #309

## Test plan

- [ ] `"Example: \`Closes #999\`\n\nCloses #42"` → returns `42` (inline code stripped)
- [ ] `"```\nCloses #999\n```\n\nCloses #42"` → returns `42` (fenced block stripped)
- [ ] `"<!-- Closes #999\n\nCloses #42"` → returns `42` (unterminated comment stripped to EOL)
- [ ] `"Closes #42\nCloses #999"` → returns `null` (still fail-closed on genuinely ambiguous)
- [ ] All 1032 node-pool tests pass (`npx vitest run --project node`)

## Deferred

- Tilde fenced blocks (`~~~`) and nested backtick code spans — not referenced in the issue; out of scope per issue spec.
- Multi-line unterminated HTML comments with real `Closes` refs on interior lines — remain fail-closed (degenerate case; safe over-block).

https://claude.ai/code/session_019RpMnK4fQgn6W5k6QXKckU

---
_Generated by [Claude Code](https://claude.ai/code/session_019RpMnK4fQgn6W5k6QXKckU)_