### PR TITLE
feat: add pipeline kill switch and per-PR gate verdict audit comments

### DIFF
--- a/docs/routine-pipeline.md
+++ b/docs/routine-pipeline.md
@@ -25,5 +25,25 @@ prompt file contents, set schedule (implementer every 4h; reviewer offset +1h),
 enable `claude/`-branch pushes for the implementer. Routine commits appear as
 `schmug`.
 
+## Kill switch (pause / resume)
+
+To pause both Routines immediately without editing cloud Routine config:
+1. Apply the `pipeline-paused` label to any open issue (e.g. the ledger issue #304).
+2. Both the implementer and reviewer Routines check this label as their very first
+   action. If any open issue carries it, they exit with a no-op message and mutate
+   nothing (no PRs opened, no merges, no labels added, no ledger updates).
+
+To resume: remove the `pipeline-paused` label from all issues.
+
+The `pipeline-paused` label is created by `setup-labels.sh`. It is never applied
+automatically — a human operator must apply and remove it.
+
+## Audit comments on auto-merged PRs
+
+Every PR that the reviewer Routine auto-merges receives a PR comment containing the
+full gate verdict JSON (`pass` + `reasons`) before the merge command runs. This
+provides an immutable per-PR record of why the gate approved the change, enabling
+forensic review after the fact.
+
 ## Pilot validation log
 Filled in during go-live. Scenario → expected → actual.

--- a/scripts/routine-pipeline/routine-implementer.md
+++ b/scripts/routine-pipeline/routine-implementer.md
@@ -3,6 +3,12 @@
 You are the implementer for the issue→PR pipeline. The repo is checked out at the
 working directory. Do exactly this:
 
+0. Pause-check (do this first; if paused, stop immediately and mutate nothing):
+   `gh issue list --repo <REPO> --label pipeline-paused --state open --json number`
+   If the result is a non-empty array: output "Pipeline paused — pipeline-paused
+   label is active. Exiting with no-op." and stop. Do NOT process any issues,
+   open PRs, or add labels.
+
 1. List candidate issues:
    `gh issue list --repo <REPO> --label spec-approved --state open --json number,author,createdAt`
 2. Discard any whose `author.login` is not `schmug`. Sort the rest oldest-first.

--- a/scripts/routine-pipeline/routine-reviewer.md
+++ b/scripts/routine-pipeline/routine-reviewer.md
@@ -3,13 +3,23 @@
 You are the reviewer/merger. The repo is checked out at the working directory.
 The gate is a deterministic script — TRUST ITS EXIT CODE, do not re-judge.
 
+0. Pause-check (do this first; if paused, stop immediately and mutate nothing):
+   `gh issue list --repo <REPO> --label pipeline-paused --state open --json number`
+   If the result is a non-empty array: output "Pipeline paused — pipeline-paused
+   label is active. Exiting with no-op." and stop. Do NOT process any PRs, add
+   labels, post comments, or update the ledger.
+
 1. `gh pr list --repo <REPO> --label auto-impl --state open --json number,labels`
 2. Skip any PR that already has the `needs-you` label (idempotent).
 3. For EACH remaining PR #P:
    a. Run: `npx tsx scripts/routine-gate/gate.ts --repo <REPO> --pr P`
    b. Capture stdout (JSON verdict) and the exit code.
    c. If exit code == 0 (PASS):
-      `gh pr merge P --repo <REPO> --squash --auto --delete-branch`
+      Post the full gate verdict JSON as an auditable PR comment:
+      `gh pr comment P --repo <REPO> --body "Gate verdict (auto-merged):\n\`\`\`json\n<VERDICT_JSON>\n\`\`\`"`
+      (Replace <VERDICT_JSON> with the complete captured stdout, which contains
+      both the `pass` field and the `reasons` array.)
+      Then: `gh pr merge P --repo <REPO> --squash --auto --delete-branch`
       Then comment the one-line outcome on the issue the PR closes.
    d. If exit code == 2 (FAIL): add the `needs-you` label to PR #P and add a PR
       comment containing the `reasons` array from the JSON verdict.

--- a/scripts/routine-pipeline/setup-labels.sh
+++ b/scripts/routine-pipeline/setup-labels.sh
@@ -11,4 +11,5 @@ create "spec-approved" "0E8A16" "Issue spec'd by owner in interactive session; t
 create "auto-impl"     "1D76DB" "PR opened by the implementer Routine"
 create "needs-you"     "D93F0B" "Escalated by the reviewer Routine; needs owner decision"
 create "impl-blocked"  "B60205" "Implementer Routine could not produce a green PR"
+create "pipeline-paused" "FBCA04" "Kill switch: apply to any open issue to pause both Routines immediately"
 echo "labels ensured on $REPO"


### PR DESCRIPTION
## Summary

- Both Routines (implementer + reviewer) now check for open issues with the `pipeline-paused` label as their very first action — if any open issue carries it, the Routine exits immediately with a no-op message and mutates nothing (no PRs opened, no merges, no labels added, no ledger updates).
- Reviewer now posts the full gate verdict JSON (`pass` + `reasons`) as a PR comment on every auto-merged PR before the merge command runs, providing an immutable per-PR audit record for forensics.
- `setup-labels.sh` creates the new `pipeline-paused` label (yellow, `FBCA04`).
- `docs/routine-pipeline.md` documents the kill switch (pause/resume steps) and the new audit comment behavior.

Closes #314

## Test plan

- [ ] `setup-labels.sh` runs without error; `pipeline-paused` label appears in the repo with yellow color
- [ ] Apply `pipeline-paused` label to any open issue → next implementer Routine run exits with no-op message, opens no PRs
- [ ] Apply `pipeline-paused` label to any open issue → next reviewer Routine run exits with no-op message, merges nothing, posts no comments, skips ledger update
- [ ] Remove `pipeline-paused` label from all issues → both Routines resume normal operation
- [ ] On an auto-merge path (gate exit 0): PR receives a comment containing the full JSON verdict before the merge
- [ ] Existing escalation path (gate exit 2) is unchanged: `needs-you` label + `reasons` comment, no verdict comment

## Deferred follow-ups

None — all acceptance criteria shipped in this PR.

https://claude.ai/code/session_01Qy1gPuzCRPGGVsXdAqFWvc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qy1gPuzCRPGGVsXdAqFWvc)_