### PR TITLE
🎨 Palette: Make dashboard empty states actionable

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-05-16 - Add ARIA live region for dynamic form validation
 **Learning:** For multi-step wizard forms or dynamic client-side validation, screen readers need explicit context when errors appear. Using a hidden error div without `role="alert"` and `aria-live="polite"` prevents the error from being announced.
 **Action:** Always link the input field to its error container using `aria-describedby` and dynamically toggle `aria-invalid="true"` on the input when it fails validation.
+## 2024-05-19 - Actionable Empty States
+**Learning:** Generic empty states ("No X found") create dead ends for users. Providing a clear "Next Step" or CTA directly inside the empty state message drastically improves usability.
+**Action:** When creating or reviewing list/table empty states, ensure the text explicitly tells the user *how* to populate the list or *why* it's empty.

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -2290,7 +2290,7 @@ export function renderDomainDetailPage({
   const historySection =
     scanHistory.length > 0
       ? `<ul class="history-list">${historyItems}</ul>`
-      : `<p style="color:var(--clr-text-muted);font-size:0.875rem;padding:0.75rem 0">No scan history yet.</p>`;
+      : `<p style="color:var(--clr-text-muted);font-size:0.875rem;padding:0.75rem 0">No scan history yet. Use 'Scan Now' above to generate your first grade.</p>`;
 
   const body = `<div class="domain-detail-header">
   <span class="grade-badge ${gradeClass(grade)}">${esc(grade)}</span>
@@ -2358,7 +2358,7 @@ const GRADE_RANK_FOR_SPARKLINE: Record<string, number> = {
 
 function renderSparkline(entries: HistoryScanEntry[]): string {
   if (entries.length === 0) {
-    return `<p style="color:var(--clr-text-muted);font-size:0.875rem;padding:0.75rem 0">No scans yet to chart.</p>`;
+    return `<p style="color:var(--clr-text-muted);font-size:0.875rem;padding:0.75rem 0">No scans yet to chart. Check back after your first scan completes.</p>`;
   }
   const width = 600;
   const height = 80;
@@ -2408,7 +2408,7 @@ function renderDriftCell(
 
 function renderDriftTable(entries: HistoryScanEntry[]): string {
   if (entries.length === 0) {
-    return `<p style="color:var(--clr-text-muted);font-size:0.875rem;padding:0.75rem 0">No scans yet.</p>`;
+    return `<p style="color:var(--clr-text-muted);font-size:0.875rem;padding:0.75rem 0">No scans yet. Protocol drift will appear here once multiple scans have been completed.</p>`;
   }
   // Rows are newest-first. To highlight "changed vs the prior (older) scan",
   // we compare each row to the NEXT row in the list (which is chronologically
@@ -2940,7 +2940,7 @@ export function renderApiKeysPage({
 
   let table: string;
   if (keys.length === 0) {
-    table = `<p style="color:var(--clr-text-muted);font-size:0.875rem">No API keys yet.</p>`;
+    table = `<p style="color:var(--clr-text-muted);font-size:0.875rem">No API keys yet. Generate your first one above to authenticate API requests.</p>`;
   } else {
     const rows = keys
       .map((k) => {

--- a/src/views/scripts.ts
+++ b/src/views/scripts.ts
@@ -1163,7 +1163,7 @@ if (typeof navigator !== 'undefined' && navigator.modelContext && typeof navigat
     children.push(sectionTitle('Recent scans'));
     var hist = data.history || [];
     if (hist.length === 0) {
-      children.push(el('p', { class: 'drawer-history-empty', text: 'No scan history yet.' }));
+      children.push(el('p', { class: 'drawer-history-empty', text: 'No scan history yet. Use Scan Now below to generate your first grade.' }));
     } else {
       var histList = el('div', { class: 'drawer-history-list' });
       hist.slice(0, 8).forEach(function(h) { histList.appendChild(historyRowEl(h)); });

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   handleMcpRequest,
   MCP_PROTOCOL_VERSION,


### PR DESCRIPTION
💡 **What**
Updated generic empty state messages across the dashboard (API Keys, Scan History, Sparkline, Protocol Drift) to include actionable next steps or clear explanations of when data will appear.

🎯 **Why**
Generic empty states like "No scans yet" create dead ends for users. Providing context and a clear call-to-action (e.g., "Use 'Scan Now' above to generate your first grade") reduces friction and guides new users toward successful interactions.

📸 **Before/After**
*(Visuals verified via Playwright screenshot during development)*
*Before:* "No API keys yet."
*After:* "No API keys yet. Generate your first one above to authenticate API requests."

♿ **Accessibility**
Clearer, more descriptive text benefits all users, particularly those using screen readers, by providing explicit context for why a region is empty and what action is required.

---
*PR created automatically by Jules for task [17049872055934848411](https://jules.google.com/task/17049872055934848411) started by @schmug*