### PR TITLE
chore: pipeline kill switch and per-merge audit comment

### DIFF
--- a/docs/routine-pipeline.md
+++ b/docs/routine-pipeline.md
@@ -25,5 +25,22 @@ prompt file contents, set schedule (implementer every 4h; reviewer offset +1h),
 enable `claude/`-branch pushes for the implementer. Routine commits appear as
 `schmug`.
 
+## Kill switch (emergency pause)
+
+Add the `pipeline-paused` label to the repo to no-op both Routines immediately.
+While the label exists, neither the implementer nor the reviewer will open PRs,
+merge anything, or update the ledger — they exit cleanly after the pause check.
+
+To pause: `gh label create pipeline-paused --repo schmug/dmarcheck --color 5319E7 --description "Kill switch" --force`
+To resume: `gh label delete pipeline-paused --repo schmug/dmarcheck --yes`
+
+`setup-labels.sh` creates the label idempotently. Routines detect it via step 0.
+
+## Audit trail
+
+Every auto-merged PR receives a comment containing the full gate verdict JSON
+(`pass`, `reasons`). This provides an immutable per-PR record of why the gate
+passed it, enabling post-hoc forensics if a bad merge slips through.
+
 ## Pilot validation log
 Filled in during go-live. Scenario → expected → actual.

--- a/scripts/routine-pipeline/routine-implementer.md
+++ b/scripts/routine-pipeline/routine-implementer.md
@@ -3,6 +3,11 @@
 You are the implementer for the issue→PR pipeline. The repo is checked out at the
 working directory. Do exactly this:
 
+0. **Kill switch check (first action — abort if paused):**
+   Run: `gh label list --repo <REPO> --json name --jq '.[].name' | grep -q pipeline-paused`
+   If `pipeline-paused` exists as a repo label, output "Pipeline paused — no-op."
+   and stop immediately. Do NOT list issues, open PRs, or add any labels.
+
 1. List candidate issues:
    `gh issue list --repo <REPO> --label spec-approved --state open --json number,author,createdAt`
 2. Discard any whose `author.login` is not `schmug`. Sort the rest oldest-first.

--- a/scripts/routine-pipeline/routine-reviewer.md
+++ b/scripts/routine-pipeline/routine-reviewer.md
@@ -3,6 +3,11 @@
 You are the reviewer/merger. The repo is checked out at the working directory.
 The gate is a deterministic script — TRUST ITS EXIT CODE, do not re-judge.
 
+0. **Kill switch check (first action — abort if paused):**
+   Run: `gh label list --repo <REPO> --json name --jq '.[].name' | grep -q pipeline-paused`
+   If `pipeline-paused` exists as a repo label, output "Pipeline paused — no-op."
+   and stop immediately. Do NOT list PRs, merge anything, or update the ledger.
+
 1. `gh pr list --repo <REPO> --label auto-impl --state open --json number,labels`
 2. Skip any PR that already has the `needs-you` label (idempotent).
 3. For EACH remaining PR #P:
@@ -10,6 +15,8 @@ The gate is a deterministic script — TRUST ITS EXIT CODE, do not re-judge.
    b. Capture stdout (JSON verdict) and the exit code.
    c. If exit code == 0 (PASS):
       `gh pr merge P --repo <REPO> --squash --auto --delete-branch`
+      Post a PR comment with the full gate verdict JSON for audit trail:
+      `gh pr comment P --repo <REPO> --body "Gate verdict (auto-merged):\n\`\`\`json\n<verdict JSON>\n\`\`\`"`
       Then comment the one-line outcome on the issue the PR closes.
    d. If exit code == 2 (FAIL): add the `needs-you` label to PR #P and add a PR
       comment containing the `reasons` array from the JSON verdict.

--- a/scripts/routine-pipeline/setup-labels.sh
+++ b/scripts/routine-pipeline/setup-labels.sh
@@ -7,8 +7,9 @@ REPO="${1:?usage: setup-labels.sh owner/name}"
 create() { # name color description
   gh label create "$1" --repo "$REPO" --color "$2" --description "$3" --force
 }
-create "spec-approved" "0E8A16" "Issue spec'd by owner in interactive session; trust token for auto-merge"
-create "auto-impl"     "1D76DB" "PR opened by the implementer Routine"
-create "needs-you"     "D93F0B" "Escalated by the reviewer Routine; needs owner decision"
-create "impl-blocked"  "B60205" "Implementer Routine could not produce a green PR"
+create "spec-approved"   "0E8A16" "Issue spec'd by owner in interactive session; trust token for auto-merge"
+create "auto-impl"       "1D76DB" "PR opened by the implementer Routine"
+create "needs-you"       "D93F0B" "Escalated by the reviewer Routine; needs owner decision"
+create "impl-blocked"    "B60205" "Implementer Routine could not produce a green PR"
+create "pipeline-paused" "5319E7" "Kill switch: both Routines no-op while this label exists on the repo"
 echo "labels ensured on $REPO"


### PR DESCRIPTION
## Summary

- Both Routines now check for the `pipeline-paused` repo label as step 0 (first action) and no-op immediately if present, mutating nothing — gives the owner a fast documented stop without touching cloud Routine config.
- Every auto-merged PR now receives a comment with the full gate verdict JSON (`pass`, `reasons`), creating an immutable per-PR forensics record.
- `setup-labels.sh` creates the `pipeline-paused` label (purple `5319E7`).
- `docs/routine-pipeline.md` documents pause/resume CLI commands and the audit trail behavior.

Closes #314

## Test plan

- [ ] Verify routine-reviewer.md step 0 exits cleanly when `pipeline-paused` label exists
- [ ] Verify routine-implementer.md step 0 exits cleanly when `pipeline-paused` label exists
- [ ] Run `setup-labels.sh schmug/dmarcheck` — confirm `pipeline-paused` label appears in repo
- [ ] Trigger a reviewer Routine pass on a passing PR — confirm verdict comment is posted
- [ ] Check `docs/routine-pipeline.md` for pause/resume instructions

https://claude.ai/code/session_01QJ4y6h1G37d92i4dDtKi1G

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJ4y6h1G37d92i4dDtKi1G)_