### PR TITLE
chore: run gate from main branch, not PR checkout

### DIFF
--- a/docs/routine-pipeline.md
+++ b/docs/routine-pipeline.md
@@ -25,5 +25,22 @@ prompt file contents, set schedule (implementer every 4h; reviewer offset +1h),
 enable `claude/`-branch pushes for the implementer. Routine commits appear as
 `schmug`.
 
+## Kill switch (emergency pause)
+
+Add the `pipeline-paused` label to the repo to no-op both Routines immediately.
+While the label exists, neither the implementer nor the reviewer will open PRs,
+merge anything, or update the ledger — they exit cleanly after the pause check.
+
+To pause: `gh label create pipeline-paused --repo schmug/dmarcheck --color 5319E7 --description "Kill switch" --force`
+To resume: `gh label delete pipeline-paused --repo schmug/dmarcheck --yes`
+
+`setup-labels.sh` creates the label idempotently. Routines detect it via step 0.
+
+## Audit trail
+
+Every auto-merged PR receives a comment containing the full gate verdict JSON
+(`pass`, `reasons`). This provides an immutable per-PR record of why the gate
+passed it, enabling post-hoc forensics if a bad merge slips through.
+
 ## Pilot validation log
 Filled in during go-live. Scenario → expected → actual.

--- a/docs/routine-pipeline.md
+++ b/docs/routine-pipeline.md
@@ -25,6 +25,15 @@ prompt file contents, set schedule (implementer every 4h; reviewer offset +1h),
 enable `claude/`-branch pushes for the implementer. Routine commits appear as
 `schmug`.
 
+## Gate integrity (belt-and-suspenders)
+
+The reviewer Routine always runs the gate from the `main` branch's code, not from
+the PR's checkout. For each PR, it uses `git archive main -- scripts/routine-gate/`
+to extract a clean copy into a temp dir, runs it there, then deletes the temp dir.
+This means a PR that weakens `scripts/routine-gate/gate-core.ts` is still evaluated
+by the unmodified `main` gate. The denylist (`config.ts` risk paths) is the primary
+control; this is belt-and-suspenders.
+
 ## Kill switch (emergency pause)
 
 Add the `pipeline-paused` label to the repo to no-op both Routines immediately.

--- a/scripts/routine-pipeline/routine-implementer.md
+++ b/scripts/routine-pipeline/routine-implementer.md
@@ -3,6 +3,11 @@
 You are the implementer for the issue→PR pipeline. The repo is checked out at the
 working directory. Do exactly this:
 
+0. **Kill switch check (first action — abort if paused):**
+   Run: `gh label list --repo <REPO> --json name --jq '.[].name' | grep -q pipeline-paused`
+   If `pipeline-paused` exists as a repo label, output "Pipeline paused — no-op."
+   and stop immediately. Do NOT list issues, open PRs, or add any labels.
+
 1. List candidate issues:
    `gh issue list --repo <REPO> --label spec-approved --state open --json number,author,createdAt`
 2. Discard any whose `author.login` is not `schmug`. Sort the rest oldest-first.

--- a/scripts/routine-pipeline/routine-reviewer.md
+++ b/scripts/routine-pipeline/routine-reviewer.md
@@ -11,7 +11,14 @@ The gate is a deterministic script — TRUST ITS EXIT CODE, do not re-judge.
 1. `gh pr list --repo <REPO> --label auto-impl --state open --json number,labels`
 2. Skip any PR that already has the `needs-you` label (idempotent).
 3. For EACH remaining PR #P:
-   a. Run: `npx tsx scripts/routine-gate/gate.ts --repo <REPO> --pr P`
+   a. Extract the gate from `main` into a temp dir (so a PR that edits gate code
+      cannot judge itself):
+      ```
+      GATE_TMP=$(mktemp -d)
+      git archive main -- scripts/routine-gate/ | tar -x -C "$GATE_TMP"
+      ```
+      Run: `npx tsx "$GATE_TMP/scripts/routine-gate/gate.ts" --repo <REPO> --pr P`
+      Then clean up: `rm -rf "$GATE_TMP"`
    b. Capture stdout (JSON verdict) and the exit code.
    c. If exit code == 0 (PASS):
       `gh pr merge P --repo <REPO> --squash --auto --delete-branch`

--- a/scripts/routine-pipeline/routine-reviewer.md
+++ b/scripts/routine-pipeline/routine-reviewer.md
@@ -3,6 +3,11 @@
 You are the reviewer/merger. The repo is checked out at the working directory.
 The gate is a deterministic script — TRUST ITS EXIT CODE, do not re-judge.
 
+0. **Kill switch check (first action — abort if paused):**
+   Run: `gh label list --repo <REPO> --json name --jq '.[].name' | grep -q pipeline-paused`
+   If `pipeline-paused` exists as a repo label, output "Pipeline paused — no-op."
+   and stop immediately. Do NOT list PRs, merge anything, or update the ledger.
+
 1. `gh pr list --repo <REPO> --label auto-impl --state open --json number,labels`
 2. Skip any PR that already has the `needs-you` label (idempotent).
 3. For EACH remaining PR #P:
@@ -10,6 +15,8 @@ The gate is a deterministic script — TRUST ITS EXIT CODE, do not re-judge.
    b. Capture stdout (JSON verdict) and the exit code.
    c. If exit code == 0 (PASS):
       `gh pr merge P --repo <REPO> --squash --auto --delete-branch`
+      Post a PR comment with the full gate verdict JSON for audit trail:
+      `gh pr comment P --repo <REPO> --body "Gate verdict (auto-merged):\n\`\`\`json\n<verdict JSON>\n\`\`\`"`
       Then comment the one-line outcome on the issue the PR closes.
    d. If exit code == 2 (FAIL): add the `needs-you` label to PR #P and add a PR
       comment containing the `reasons` array from the JSON verdict.

--- a/scripts/routine-pipeline/setup-labels.sh
+++ b/scripts/routine-pipeline/setup-labels.sh
@@ -7,8 +7,9 @@ REPO="${1:?usage: setup-labels.sh owner/name}"
 create() { # name color description
   gh label create "$1" --repo "$REPO" --color "$2" --description "$3" --force
 }
-create "spec-approved" "0E8A16" "Issue spec'd by owner in interactive session; trust token for auto-merge"
-create "auto-impl"     "1D76DB" "PR opened by the implementer Routine"
-create "needs-you"     "D93F0B" "Escalated by the reviewer Routine; needs owner decision"
-create "impl-blocked"  "B60205" "Implementer Routine could not produce a green PR"
+create "spec-approved"   "0E8A16" "Issue spec'd by owner in interactive session; trust token for auto-merge"
+create "auto-impl"       "1D76DB" "PR opened by the implementer Routine"
+create "needs-you"       "D93F0B" "Escalated by the reviewer Routine; needs owner decision"
+create "impl-blocked"    "B60205" "Implementer Routine could not produce a green PR"
+create "pipeline-paused" "5319E7" "Kill switch: both Routines no-op while this label exists on the repo"
 echo "labels ensured on $REPO"


### PR DESCRIPTION
## Summary

- Reviewer Routine (step 3a) now extracts gate code from `main` via `git archive` into a temp dir, runs the gate there, then deletes the temp dir.
- A PR that edits `scripts/routine-gate/gate-core.ts` to weaken the gate is still evaluated by the unmodified `main` gate.
- Gate's PR diff/metadata queries (`gh` API calls) are unchanged — only the gate *code* is sourced from `main`.
- `docs/routine-pipeline.md` documents the belt-and-suspenders rationale.

Closes #312

## Test plan

- [ ] Verify reviewer prompt step 3a uses `git archive main -- scripts/routine-gate/` pattern
- [ ] Manually verify: a PR that modifies `gate-core.ts` would still be evaluated by main's gate (no bypass possible)
- [ ] Check `docs/routine-pipeline.md` for "Gate integrity" section
- [ ] Confirm temp dir is created and cleaned up in the step description

**Note:** This PR stacks on top of the #314 kill switch changes. If merged before #356, the `routine-reviewer.md` diff will include both sets of changes — they are in different sections and apply cleanly.

https://claude.ai/code/session_01QJ4y6h1G37d92i4dDtKi1G

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJ4y6h1G37d92i4dDtKi1G)_