### PR TITLE
feat: add pipeline-paused kill switch and per-PR gate verdict audit trail

### DIFF
--- a/docs/routine-pipeline.md
+++ b/docs/routine-pipeline.md
@@ -25,5 +25,26 @@ prompt file contents, set schedule (implementer every 4h; reviewer offset +1h),
 enable `claude/`-branch pushes for the implementer. Routine commits appear as
 `schmug`.
 
+## Kill switch (emergency pause)
+
+To pause both Routines without touching cloud Routine config:
+
+1. Apply the `pipeline-paused` label to any open issue (e.g. the ledger issue #304):
+   `gh issue edit 304 --repo schmug/dmarcheck --add-label pipeline-paused`
+2. Both Routines check for this label as step 0 and no-op if present — they print a
+   clear message and mutate nothing (no PRs opened, no merges, no comments).
+
+To resume:
+   `gh issue edit 304 --repo schmug/dmarcheck --remove-label pipeline-paused`
+
+The `pipeline-paused` label is created by `scripts/routine-pipeline/setup-labels.sh`.
+
+## Audit trail
+
+Every auto-merged PR receives a comment from the reviewer Routine containing the full
+gate verdict JSON (`pass`, `reasons`). This provides an immutable per-PR record of
+why the gate passed the PR, enabling forensics after any unexpected auto-merge.
+Escalated PRs already receive a verdict comment with the `reasons` array.
+
 ## Pilot validation log
 Filled in during go-live. Scenario → expected → actual.

--- a/scripts/routine-pipeline/routine-implementer.md
+++ b/scripts/routine-pipeline/routine-implementer.md
@@ -3,6 +3,12 @@
 You are the implementer for the issue→PR pipeline. The repo is checked out at the
 working directory. Do exactly this:
 
+0. **Kill-switch check (FIRST — mutate nothing if paused):**
+   Run: `gh issue list --repo <REPO> --label pipeline-paused --state open --json number`
+   If the output contains any issues, stop immediately. Print:
+   "Pipeline paused: `pipeline-paused` label detected. No-op this run."
+   Do NOT open any PRs, comment on issues, or modify any labels.
+
 1. List candidate issues:
    `gh issue list --repo <REPO> --label spec-approved --state open --json number,author,createdAt`
 2. Discard any whose `author.login` is not `schmug`. Sort the rest oldest-first.

--- a/scripts/routine-pipeline/routine-reviewer.md
+++ b/scripts/routine-pipeline/routine-reviewer.md
@@ -3,6 +3,12 @@
 You are the reviewer/merger. The repo is checked out at the working directory.
 The gate is a deterministic script — TRUST ITS EXIT CODE, do not re-judge.
 
+0. **Kill-switch check (FIRST — mutate nothing if paused):**
+   Run: `gh issue list --repo <REPO> --label pipeline-paused --state open --json number`
+   If the output contains any issues, stop immediately. Print:
+   "Pipeline paused: `pipeline-paused` label detected. No-op this run."
+   Do NOT open, merge, comment on, or label any PR or issue.
+
 1. `gh pr list --repo <REPO> --label auto-impl --state open --json number,labels`
 2. Skip any PR that already has the `needs-you` label (idempotent).
 3. For EACH remaining PR #P:
@@ -10,6 +16,8 @@ The gate is a deterministic script — TRUST ITS EXIT CODE, do not re-judge.
    b. Capture stdout (JSON verdict) and the exit code.
    c. If exit code == 0 (PASS):
       `gh pr merge P --repo <REPO> --squash --auto --delete-branch`
+      Post the full gate verdict as a PR comment (for audit trail):
+      `gh pr comment P --repo <REPO> --body "Gate verdict (auto-merged):\n\`\`\`json\n<stdout from step 3a>\n\`\`\`"`
       Then comment the one-line outcome on the issue the PR closes.
    d. If exit code == 2 (FAIL): add the `needs-you` label to PR #P and add a PR
       comment containing the `reasons` array from the JSON verdict.

--- a/scripts/routine-pipeline/setup-labels.sh
+++ b/scripts/routine-pipeline/setup-labels.sh
@@ -7,8 +7,9 @@ REPO="${1:?usage: setup-labels.sh owner/name}"
 create() { # name color description
   gh label create "$1" --repo "$REPO" --color "$2" --description "$3" --force
 }
-create "spec-approved" "0E8A16" "Issue spec'd by owner in interactive session; trust token for auto-merge"
-create "auto-impl"     "1D76DB" "PR opened by the implementer Routine"
-create "needs-you"     "D93F0B" "Escalated by the reviewer Routine; needs owner decision"
-create "impl-blocked"  "B60205" "Implementer Routine could not produce a green PR"
+create "spec-approved"   "0E8A16" "Issue spec'd by owner in interactive session; trust token for auto-merge"
+create "auto-impl"       "1D76DB" "PR opened by the implementer Routine"
+create "needs-you"       "D93F0B" "Escalated by the reviewer Routine; needs owner decision"
+create "impl-blocked"    "B60205" "Implementer Routine could not produce a green PR"
+create "pipeline-paused" "E4E669" "Kill switch: both Routines no-op while this label is on any open issue"
 echo "labels ensured on $REPO"


### PR DESCRIPTION
## Summary

- **Kill switch:** Both Routines check for a `pipeline-paused` label on any open issue as step 0. If present, they print a clear no-op message and halt — no PRs opened, no merges, no comments, no label changes.
- **Audit trail:** The reviewer Routine now posts the full gate verdict JSON (`pass`, `reasons`) as a PR comment on every auto-merged PR, providing an immutable per-PR record of why the gate passed it.
- **Label + docs:** `setup-labels.sh` creates the `pipeline-paused` label; `docs/routine-pipeline.md` documents pause/resume steps and the audit trail rationale.

Closes #314

## Test plan

- [ ] `setup-labels.sh schmug/dmarcheck` — verify `pipeline-paused` label created (yellow `E4E669`)
- [ ] Apply `pipeline-paused` to any open issue (e.g. `gh issue edit 304 --add-label pipeline-paused`) — both Routines should print no-op message and exit without mutating anything
- [ ] Remove the label — Routines resume normal processing on next run
- [ ] On next auto-merge: PR should have a comment containing the gate verdict JSON block

## Deferred follow-ups

None.

https://claude.ai/code/session_018i41oh1iF815sGZNvjdacN

---
_Generated by [Claude Code](https://claude.ai/code/session_018i41oh1iF815sGZNvjdacN)_