### PR TITLE
fix: redirect mta-sts.dmarc.mx root and non-policy paths to dmarc.mx

### DIFF
--- a/mta-sts-worker/src/index.ts
+++ b/mta-sts-worker/src/index.ts
@@ -20,6 +20,6 @@ export default {
       });
     }
 
-    return new Response("Not found", { status: 404 });
+    return Response.redirect("https://dmarc.mx/", 301);
   },
 };


### PR DESCRIPTION
## Summary

- Replaces the final `return new Response("Not found", { status: 404 })` in `mta-sts-worker/src/index.ts` with `return Response.redirect("https://dmarc.mx/", 301)` — one line, no other logic touched.
- Fixes the GSC "Not found (404)" entry for `https://mta-sts.dmarc.mx/` that Googlebot crawled on 2026-04-28.

Closes #363

## Test plan

- [ ] `npm test` passes (1049/1050; the 1 failure is a pre-existing live-network integration test that fails in the sandbox and is unrelated to this change — identical failure on `main`)
- [ ] `npm run typecheck` passes (zero errors)
- [ ] `curl -I https://mta-sts.dmarc.mx/` returns `HTTP/2 301` with `location: https://dmarc.mx/`
- [ ] `curl -I https://mta-sts.dmarc.mx/some/random/path` also returns `301 → https://dmarc.mx/`
- [ ] `curl -s https://mta-sts.dmarc.mx/.well-known/mta-sts.txt` still returns `200` with the STSv1 policy body unchanged

https://claude.ai/code/session_01CnbNthXu35yeCa6PrvcVM2

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnbNthXu35yeCa6PrvcVM2)_