### PR TITLE
feat(seo): add /mx/<provider> pages for MX hostname identification

### DIFF
--- a/src/data/mx-providers.ts
+++ b/src/data/mx-providers.ts
@@ -1,0 +1,455 @@
+// MX provider catalog. Powers two surfaces:
+//   1. The /mx/<slug> SEO pages (one ranking target per common MX host) —
+//      see src/views/mx.ts and src/views/markdown.ts.
+//   2. The MX card on /check?domain=... — components.ts looks up the provider
+//      for each MX record and links the badge to /mx/<slug> when matched.
+//
+// The MX analyzer's own PROVIDER_SIGNATURES (src/analyzers/mx.ts) is tuned for
+// detection labels and is intentionally not the source for these patterns —
+// some entries here are more specific (e.g. messagingengine.com, not
+// fastmail.com, is the real Fastmail inbound MX).
+
+export interface MxProviderSection {
+  title: string;
+  paragraphs: string[];
+  list?: string[];
+}
+
+export interface MxProvider {
+  slug: string;
+  /** Long form used in <title> and meta og:title. */
+  displayName: string;
+  /** Short form used in breadcrumbs and badge link text. */
+  shortName: string;
+  /** Vendor that operates the service (publisher in JSON-LD). */
+  operator: string;
+  /** Patterns matched case-insensitively against the MX exchange (after
+   * lowercasing and stripping the trailing dot). Order matters only for
+   * collisions — the first match wins. */
+  hostnames: RegExp[];
+  /** Verbatim hostname strings to show on the page ("how it appears in DNS"). */
+  hostnameExamples: string[];
+  /** Common parent domains using this provider. Rendered as scan-link CTAs. */
+  parentExamples: string[];
+  /** Meta description — must be unique per provider per the SEO contract. */
+  description: string;
+  /** H1 / og:title body — must be unique per provider. */
+  headline: string;
+  /** First paragraph rendered as the page intro. */
+  intro: string;
+  /** Body sections rendered as bd-cards (HTML) or H2s (markdown). */
+  sections: MxProviderSection[];
+}
+
+const OUTLOOK_DESCRIPTION =
+  "Microsoft 365 (formerly Office 365) routes inbound mail through *.mail.protection.outlook.com. Here's what that MX hostname is, who runs it, and which large domains use it.";
+
+const GOOGLE_DESCRIPTION =
+  "Google Workspace receives mail at aspmx.l.google.com and four alt MX hosts. Here's what those hostnames mean, who runs them, and how to spot a Workspace tenant.";
+
+const MIMECAST_DESCRIPTION =
+  "Mimecast is a perimeter security gateway, not a mailbox host — *.mimecast.com MX hostnames sit in front of Microsoft 365 or Google Workspace. Here's how to read them.";
+
+const PROOFPOINT_DESCRIPTION =
+  "Proofpoint runs *.pphosted.com (enterprise) and *.ppe-hosted.com (Essentials/SMB) as MX-front-ends in front of customer mailbox tenants. Here's how to identify each.";
+
+const FASTMAIL_DESCRIPTION =
+  "Fastmail's inbound MX hosts are in1-smtp.messagingengine.com and in2-smtp.messagingengine.com — not fastmail.com. The MessagingEngine name trips up most lookup tools.";
+
+const ZOHO_DESCRIPTION =
+  "Zoho Mail's inbound MX hosts are mx.zoho.com / mx2.zoho.com (or mx.zoho.eu / mx.zoho.in for regional plans). Here's what those mean and which businesses use them.";
+
+const SES_DESCRIPTION =
+  "Amazon SES receives mail at inbound-smtp.<region>.amazonaws.com. The region in the hostname tells you which AWS region the receiving account uses.";
+
+const CLOUDFLARE_DESCRIPTION =
+  "Cloudflare Email Routing uses route1-3.mx.cloudflare.net as inbound MX hosts. It's a free forwarding service — useful for catch-alls, not a full mailbox.";
+
+export const MX_PROVIDERS: readonly MxProvider[] = [
+  {
+    slug: "outlook",
+    displayName: "Microsoft 365 / Exchange Online",
+    shortName: "Microsoft 365",
+    operator: "Microsoft",
+    hostnames: [
+      /\.mail\.protection\.outlook\.com$/,
+      /\.olc\.protection\.outlook\.com$/,
+    ],
+    hostnameExamples: [
+      "<tenant>.mail.protection.outlook.com",
+      "<tenant>-com.mail.protection.outlook.com",
+      "<tenant>.olc.protection.outlook.com",
+    ],
+    parentExamples: ["github.com", "microsoft.com", "linkedin.com"],
+    description: OUTLOOK_DESCRIPTION,
+    headline:
+      "What is *.mail.protection.outlook.com? Microsoft 365 inbound MX explained",
+    intro:
+      "An MX record that ends in <code>mail.protection.outlook.com</code> means the domain receives mail through Microsoft 365 — formerly Office 365, and the same service that powers Exchange Online tenants. The slug before <code>mail.protection.outlook.com</code> is the tenant identifier, derived from the primary domain with dots replaced by dashes.",
+    sections: [
+      {
+        title: "How it appears in DNS",
+        paragraphs: [
+          "Microsoft 365 publishes a single MX target per tenant. The hostname is generated from the domain name itself, so it's easy to recognise once you've seen the pattern.",
+        ],
+        list: [
+          "<code>github.com</code> &rarr; <code>github-com.mail.protection.outlook.com</code>",
+          "<code>microsoft.com</code> &rarr; <code>microsoft-com.mail.protection.outlook.com</code>",
+          "Government Community Cloud (GCC) tenants use <code>*.olc.protection.outlook.com</code> instead — same operator, different ring.",
+        ],
+      },
+      {
+        title: "Who runs it",
+        paragraphs: [
+          "Microsoft 365 is operated by Microsoft. The MX endpoint is part of Exchange Online Protection (EOP), which performs anti-spam and anti-malware filtering before mail lands in the tenant's mailbox. Customers can layer a third-party gateway (Mimecast, Proofpoint, etc.) in front of EOP, in which case EOP becomes the secondary destination and the gateway's MX is what you'll see externally.",
+        ],
+      },
+      {
+        title: "How to tell it's actually Microsoft 365",
+        paragraphs: [
+          "The MX hostname alone is enough — only Microsoft can serve that domain. If you want a second signal, look at the SPF record: a Microsoft 365 tenant will <code>include:spf.protection.outlook.com</code>. The DKIM keys live at <code>selector1._domainkey</code> and <code>selector2._domainkey</code> and point at <code>selector*-&lt;tenant&gt;._domainkey.&lt;tenant&gt;.onmicrosoft.com</code>.",
+        ],
+      },
+    ],
+  },
+  {
+    slug: "google",
+    displayName: "Google Workspace (Gmail)",
+    shortName: "Google Workspace",
+    operator: "Google",
+    hostnames: [
+      /^aspmx\.l\.google\.com$/,
+      /^alt[1-4]\.aspmx\.l\.google\.com$/,
+      /^aspmx[2-5]\.googlemail\.com$/,
+      /\.googlemail\.com$/,
+    ],
+    hostnameExamples: [
+      "aspmx.l.google.com",
+      "alt1.aspmx.l.google.com",
+      "alt2.aspmx.l.google.com",
+      "alt3.aspmx.l.google.com",
+      "alt4.aspmx.l.google.com",
+    ],
+    parentExamples: ["google.com", "stripe.com", "ycombinator.com"],
+    description: GOOGLE_DESCRIPTION,
+    headline:
+      "What is aspmx.l.google.com? Google Workspace inbound MX explained",
+    intro:
+      "An MX record set that lists <code>aspmx.l.google.com</code> as the primary plus four <code>alt[1-4].aspmx.l.google.com</code> hosts is Google Workspace — the business mail service formerly known as G Suite and, before that, Google Apps. Every Workspace tenant uses the same five hostnames, regardless of which domain they're for.",
+    sections: [
+      {
+        title: "How it appears in DNS",
+        paragraphs: [
+          "Workspace's recommended MX configuration is five records with different priorities. The primary is the lowest priority value; the alt hosts are stand-bys for when the primary is at capacity or unreachable.",
+        ],
+        list: [
+          "<code>1 aspmx.l.google.com</code>",
+          "<code>5 alt1.aspmx.l.google.com</code>",
+          "<code>5 alt2.aspmx.l.google.com</code>",
+          "<code>10 alt3.aspmx.l.google.com</code>",
+          "<code>10 alt4.aspmx.l.google.com</code>",
+        ],
+      },
+      {
+        title: "Who runs it",
+        paragraphs: [
+          "Google Workspace is operated by Google. The MX endpoints terminate at Gmail's anti-spam and anti-malware infrastructure — the same engine that handles consumer Gmail, configured for the tenant's domain.",
+        ],
+      },
+      {
+        title: "Identifying a Workspace tenant",
+        paragraphs: [
+          "Unlike Microsoft 365's per-tenant hostname, every Workspace customer shares the same MX hosts — so the MX alone doesn't reveal the tenant. The tenant identifier shows up elsewhere: the SPF record includes <code>_spf.google.com</code>, and DKIM uses <code>google._domainkey</code> by default. If the domain publishes DMARC with a <code>rua</code> mailto pointing at <code>*.google.com</code>, that's another tell.",
+        ],
+      },
+    ],
+  },
+  {
+    slug: "mimecast",
+    displayName: "Mimecast Secure Email Gateway",
+    shortName: "Mimecast",
+    operator: "Mimecast",
+    hostnames: [/\.mimecast\.com$/, /\.mimecast\.co\.za$/],
+    hostnameExamples: [
+      "<tenant>-com.mail.eu.mimecast.com",
+      "<tenant>-com.mail.us.mimecast.com",
+      "<tenant>-com.mail.za.mimecast.com",
+    ],
+    parentExamples: ["barclays.com", "publix.com"],
+    description: MIMECAST_DESCRIPTION,
+    headline:
+      "What is *.mimecast.com? Mimecast secure email gateway, explained",
+    intro:
+      "Mimecast is a security gateway, not a mailbox provider. When a domain's MX points at <code>*.mimecast.com</code>, inbound mail lands at Mimecast first — Mimecast performs anti-spam, anti-phishing, sandboxing and policy enforcement, and then relays the cleaned mail to the customer's actual mailbox host (most commonly Microsoft 365 or Google Workspace).",
+    sections: [
+      {
+        title: "How it appears in DNS",
+        paragraphs: [
+          "Mimecast hostnames embed a region segment that tells you which data centre the tenant is provisioned in.",
+        ],
+        list: [
+          "<code>*.mail.eu.mimecast.com</code> — Europe",
+          "<code>*.mail.us.mimecast.com</code> — North America",
+          "<code>*.mail.za.mimecast.com</code> — South Africa",
+          "<code>*.mail.au.mimecast.com</code> — Australia/Pacific",
+        ],
+      },
+      {
+        title: "Gateway vs platform",
+        paragraphs: [
+          "If you see a Mimecast MX hostname externally and a Microsoft 365 or Google Workspace fingerprint internally (in SPF, DKIM, or auto-discover), that's expected — the gateway is the inbound front-door, not the mailbox. From an attacker's perspective the surface is still the upstream platform; the gateway is a filter, not an authoritative MTA for the tenant.",
+        ],
+      },
+      {
+        title: "Who runs it",
+        paragraphs: [
+          "Mimecast Limited, headquartered in the UK, runs the service. It's a publicly-known enterprise email security vendor used by tens of thousands of organisations, often in regulated industries where a separate filtering perimeter is a compliance requirement.",
+        ],
+      },
+    ],
+  },
+  {
+    slug: "proofpoint",
+    displayName: "Proofpoint email protection",
+    shortName: "Proofpoint",
+    operator: "Proofpoint",
+    hostnames: [/\.pphosted\.com$/, /\.ppe-hosted\.com$/],
+    hostnameExamples: [
+      "mx0a-<tenant>.pphosted.com",
+      "mx0b-<tenant>.pphosted.com",
+      "mx1-<region>.ppe-hosted.com",
+    ],
+    parentExamples: ["uber.com", "intuit.com"],
+    description: PROOFPOINT_DESCRIPTION,
+    headline:
+      "What is *.pphosted.com and *.ppe-hosted.com? Proofpoint MX explained",
+    intro:
+      "Two MX hostname families both belong to Proofpoint. <code>*.pphosted.com</code> is the enterprise tier — large organisations on Proofpoint's flagship Enterprise Protection product. <code>*.ppe-hosted.com</code> is Proofpoint Essentials, the SMB tier sold through partner MSPs. Both are perimeter filtering gateways in front of the customer's real mailbox host.",
+    sections: [
+      {
+        title: "How it appears in DNS",
+        paragraphs: [
+          "Enterprise Protection publishes a pair of MX records with <code>mx0a-</code> and <code>mx0b-</code> prefixes for high availability. The slug after the prefix is a tenant identifier.",
+        ],
+        list: [
+          "<code>10 mx0a-&lt;tenant&gt;.pphosted.com</code>",
+          "<code>10 mx0b-&lt;tenant&gt;.pphosted.com</code>",
+          "Essentials customers see <code>mx1-&lt;region&gt;.ppe-hosted.com</code> and <code>mx2-&lt;region&gt;.ppe-hosted.com</code>.",
+        ],
+      },
+      {
+        title: "Enterprise vs Essentials",
+        paragraphs: [
+          "The two product lines have different feature sets, different administrative consoles, and different SLAs, but they share the Proofpoint detection engine. From a recipient's perspective the difference matters mostly for who to contact about a false-positive — Essentials is partner-supported, Enterprise is direct.",
+        ],
+      },
+      {
+        title: "Who runs it",
+        paragraphs: [
+          "Proofpoint, Inc. is a US-based security vendor (now owned by Thoma Bravo since 2021). It's one of the largest commercial email security providers, particularly common in financial services, healthcare and government supply chains.",
+        ],
+      },
+    ],
+  },
+  {
+    slug: "fastmail",
+    displayName: "Fastmail",
+    shortName: "Fastmail",
+    operator: "Fastmail Pty Ltd",
+    hostnames: [
+      /^in1-smtp\.messagingengine\.com$/,
+      /^in2-smtp\.messagingengine\.com$/,
+      /\.messagingengine\.com$/,
+    ],
+    hostnameExamples: [
+      "in1-smtp.messagingengine.com",
+      "in2-smtp.messagingengine.com",
+    ],
+    parentExamples: ["fastmail.com", "fastmail.fm"],
+    description: FASTMAIL_DESCRIPTION,
+    headline:
+      "What is in1-smtp.messagingengine.com? Fastmail inbound MX explained",
+    intro:
+      "Fastmail's inbound MX hosts are <code>in1-smtp.messagingengine.com</code> and <code>in2-smtp.messagingengine.com</code>. The <code>messagingengine.com</code> domain — not <code>fastmail.com</code> — is what trips up most reverse-lookup tools: <code>messagingengine.com</code> is Fastmail's infrastructure brand, used for SMTP, IMAP, and SPF includes as well.",
+    sections: [
+      {
+        title: "How it appears in DNS",
+        paragraphs: [
+          "Fastmail publishes two MX records with equal priority for round-robin delivery.",
+        ],
+        list: [
+          "<code>10 in1-smtp.messagingengine.com</code>",
+          "<code>20 in2-smtp.messagingengine.com</code>",
+        ],
+      },
+      {
+        title: "Why it's called messagingengine.com",
+        paragraphs: [
+          "MessagingEngine is the operational arm of Fastmail Pty Ltd. The split between the consumer brand and the infrastructure brand goes back to Fastmail's days as Opera Software's mail division — keeping infrastructure under a separate name made it portable when Fastmail spun out in 2013. Today the two are the same company, but the DNS naming has stuck.",
+        ],
+      },
+      {
+        title: "Who runs it",
+        paragraphs: [
+          "Fastmail Pty Ltd is an Australian, privately-held mailbox provider. It's a popular choice for technical users and small businesses that want a paid alternative to Gmail or Outlook with strong CalDAV/CardDAV support and no advertising.",
+        ],
+      },
+    ],
+  },
+  {
+    slug: "zoho",
+    displayName: "Zoho Mail",
+    shortName: "Zoho Mail",
+    operator: "Zoho Corporation",
+    hostnames: [
+      /\.zoho\.com$/,
+      /\.zoho\.eu$/,
+      /\.zoho\.in$/,
+      /\.zoho\.com\.au$/,
+      /\.zohomail\.com$/,
+    ],
+    hostnameExamples: [
+      "mx.zoho.com",
+      "mx2.zoho.com",
+      "mx3.zoho.com",
+      "mx.zoho.eu",
+      "mx.zoho.in",
+    ],
+    parentExamples: ["zoho.com"],
+    description: ZOHO_DESCRIPTION,
+    headline: "What is mx.zoho.com? Zoho Mail inbound MX explained",
+    intro:
+      "Zoho Mail is the business email service from Zoho Corporation, bundled with the broader Zoho CRM/Workplace suite. Customers point their MX records at <code>mx.zoho.com</code>, <code>mx2.zoho.com</code>, and <code>mx3.zoho.com</code> — or the regional equivalents <code>mx.zoho.eu</code>, <code>mx.zoho.in</code>, and <code>mx.zoho.com.au</code> depending on the data residency tier they chose at signup.",
+    sections: [
+      {
+        title: "How it appears in DNS",
+        paragraphs: [
+          "Zoho's recommended setup is three MX records with ascending priorities. Regional plans swap the TLD on every host — once you pick a region you're committed to it for the lifetime of the account.",
+        ],
+        list: [
+          "<code>10 mx.zoho.com</code>",
+          "<code>20 mx2.zoho.com</code>",
+          "<code>50 mx3.zoho.com</code>",
+          "European tenants substitute <code>mx.zoho.eu</code> / <code>mx2.zoho.eu</code>.",
+          "Indian tenants substitute <code>mx.zoho.in</code> / <code>mx2.zoho.in</code>.",
+        ],
+      },
+      {
+        title: "Who runs it",
+        paragraphs: [
+          "Zoho Corporation is a privately-held software vendor headquartered in Chennai, India, with major US and EU offices. Zoho Mail is most often seen on small-business and freelance domains, plus international branches of larger companies that pick it for the bundled CRM rather than the mail product itself.",
+        ],
+      },
+      {
+        title: "Identifying a Zoho tenant",
+        paragraphs: [
+          "The MX hostname is unambiguous — only Zoho can serve those. The SPF record will <code>include:zoho.com</code> (or the regional equivalent). DKIM selectors are named <code>zoho._domainkey</code> by default but can be renamed.",
+        ],
+      },
+    ],
+  },
+  {
+    slug: "amazon-ses",
+    displayName: "Amazon SES (inbound)",
+    shortName: "Amazon SES",
+    operator: "Amazon Web Services",
+    hostnames: [/^inbound-smtp\.[a-z0-9-]+\.amazonaws\.com$/],
+    hostnameExamples: [
+      "inbound-smtp.us-east-1.amazonaws.com",
+      "inbound-smtp.eu-west-1.amazonaws.com",
+      "inbound-smtp.ap-southeast-2.amazonaws.com",
+    ],
+    parentExamples: [],
+    description: SES_DESCRIPTION,
+    headline:
+      "What is inbound-smtp.amazonaws.com? Amazon SES inbound MX explained",
+    intro:
+      "Amazon SES (Simple Email Service) is a transactional email API. Its inbound side — receiving mail at a domain — uses MX hostnames of the form <code>inbound-smtp.&lt;region&gt;.amazonaws.com</code>. The region segment tells you which AWS region the receiving SES configuration lives in.",
+    sections: [
+      {
+        title: "How it appears in DNS",
+        paragraphs: [
+          "Only the regions that have SES inbound enabled get an inbound-smtp hostname. The available regions are a moving target but at time of writing include us-east-1, us-west-2, eu-west-1, eu-central-1, and ap-southeast-2.",
+        ],
+        list: [
+          "<code>10 inbound-smtp.us-east-1.amazonaws.com</code> — N. Virginia",
+          "<code>10 inbound-smtp.us-west-2.amazonaws.com</code> — Oregon",
+          "<code>10 inbound-smtp.eu-west-1.amazonaws.com</code> — Ireland",
+          "<code>10 inbound-smtp.eu-central-1.amazonaws.com</code> — Frankfurt",
+        ],
+      },
+      {
+        title: "Inbound vs outbound SES",
+        paragraphs: [
+          "Most domains use SES outbound (sending email programmatically) without using SES inbound. If a domain only sends via SES, you won't see <code>inbound-smtp</code> in its MX — the MX will point elsewhere. <code>inbound-smtp</code> means the operators are routing received mail into an S3 bucket, Lambda function, or SNS topic for processing.",
+        ],
+      },
+      {
+        title: "Who runs it",
+        paragraphs: [
+          "Amazon Web Services. SES inbound is a developer-facing service — its presence usually indicates an application is processing received mail programmatically, not a human reading an inbox.",
+        ],
+      },
+    ],
+  },
+  {
+    slug: "cloudflare",
+    displayName: "Cloudflare Email Routing",
+    shortName: "Cloudflare",
+    operator: "Cloudflare",
+    hostnames: [/^route[1-3]\.mx\.cloudflare\.net$/, /\.mx\.cloudflare\.net$/],
+    hostnameExamples: [
+      "route1.mx.cloudflare.net",
+      "route2.mx.cloudflare.net",
+      "route3.mx.cloudflare.net",
+    ],
+    parentExamples: [],
+    description: CLOUDFLARE_DESCRIPTION,
+    headline:
+      "What is route1.mx.cloudflare.net? Cloudflare Email Routing explained",
+    intro:
+      "Cloudflare Email Routing is a free email-forwarding service for domains whose DNS is managed by Cloudflare. It doesn't host mailboxes — it accepts mail at <code>route1-3.mx.cloudflare.net</code> and forwards it to a destination address the domain owner specified (a Gmail account, a Fastmail account, anything that accepts SMTP).",
+    sections: [
+      {
+        title: "How it appears in DNS",
+        paragraphs: [
+          "Email Routing publishes three MX records, all at equal priority, so any of Cloudflare's edge can accept inbound mail.",
+        ],
+        list: [
+          "<code>2 route1.mx.cloudflare.net</code>",
+          "<code>3 route2.mx.cloudflare.net</code>",
+          "<code>15 route3.mx.cloudflare.net</code>",
+        ],
+      },
+      {
+        title: "Forwarder, not a mailbox",
+        paragraphs: [
+          "Email Routing is one-way — it accepts mail and forwards it; the destination mailbox is the real authoritative MTA. That means a domain using Email Routing won't have meaningful DKIM keys at its own selectors and may have SPF set up only for forwarding. It also means Cloudflare can't reply to bounces; non-deliverable mail gets dropped at the destination.",
+        ],
+      },
+      {
+        title: "Who runs it",
+        paragraphs: [
+          "Cloudflare, Inc. The service launched in 2021 and is free for domains using Cloudflare DNS. It's a popular choice for personal domains, side projects, and aliases that don't justify a full mailbox plan.",
+        ],
+      },
+    ],
+  },
+];
+
+/** Lookup a provider by an MX exchange hostname. Returns undefined when no
+ * provider in the catalog matches. Case-insensitive; tolerates a trailing dot. */
+export function lookupMxProvider(exchange: string): MxProvider | undefined {
+  const normalized = exchange.toLowerCase().replace(/\.$/, "");
+  for (const provider of MX_PROVIDERS) {
+    for (const pattern of provider.hostnames) {
+      if (pattern.test(normalized)) return provider;
+    }
+  }
+  return undefined;
+}
+
+/** Lookup a provider by its slug. Returns undefined for unknown slugs. */
+export function getMxProvider(slug: string): MxProvider | undefined {
+  return MX_PROVIDERS.find((p) => p.slug === slug);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,11 +98,14 @@ import {
   renderErrorMarkdown,
   renderLandingMarkdown,
   renderLearnHubMarkdown,
+  renderMxHubMarkdown,
+  renderMxProviderMarkdown,
   renderPricingMarkdown,
   renderPrivacyMarkdown,
   renderReportMarkdown,
   renderScoringRubricMarkdown,
 } from "./views/markdown.js";
+import { renderMxHub, renderMxProviderPage } from "./views/mx.js";
 import { renderPricingPage } from "./views/pricing.js";
 import { JS } from "./views/scripts.js";
 import { CSS } from "./views/styles.js";
@@ -918,9 +921,18 @@ const STATIC_SITEMAP_URLS: Array<{ loc: string; priority: string }> = [
   { loc: "https://dmarc.mx/learn/dkim", priority: "0.7" },
   { loc: "https://dmarc.mx/learn/bimi", priority: "0.6" },
   { loc: "https://dmarc.mx/learn/mta-sts", priority: "0.7" },
+  { loc: "https://dmarc.mx/mx", priority: "0.7" },
+  { loc: "https://dmarc.mx/mx/outlook", priority: "0.8" },
+  { loc: "https://dmarc.mx/mx/google", priority: "0.8" },
+  { loc: "https://dmarc.mx/mx/mimecast", priority: "0.7" },
+  { loc: "https://dmarc.mx/mx/proofpoint", priority: "0.7" },
+  { loc: "https://dmarc.mx/mx/fastmail", priority: "0.6" },
+  { loc: "https://dmarc.mx/mx/zoho", priority: "0.6" },
+  { loc: "https://dmarc.mx/mx/amazon-ses", priority: "0.6" },
+  { loc: "https://dmarc.mx/mx/cloudflare", priority: "0.6" },
   { loc: "https://dmarc.mx/llms.txt", priority: "0.2" },
 ];
-const SITEMAP_LASTMOD = "2026-04-26";
+const SITEMAP_LASTMOD = "2026-05-24";
 
 function buildSitemapUrls(): Array<{ loc: string; priority: string }> {
   const scanUrls = listIndexableScanDomains().map((domain) => ({
@@ -968,6 +980,22 @@ app.get("/learn/spf", (c) => c.html(renderLearnSpf()));
 app.get("/learn/dkim", (c) => c.html(renderLearnDkim()));
 app.get("/learn/bimi", (c) => c.html(renderLearnBimi()));
 app.get("/learn/mta-sts", (c) => c.html(renderLearnMtaSts()));
+
+app.get("/mx", (c) => {
+  if (wantsMarkdown(c)) return markdownResponse(c, renderMxHubMarkdown());
+  return c.html(renderMxHub());
+});
+app.get("/mx/:slug", (c) => {
+  const slug = c.req.param("slug");
+  if (wantsMarkdown(c)) {
+    const md = renderMxProviderMarkdown(slug);
+    if (!md) return c.notFound();
+    return markdownResponse(c, md);
+  }
+  const html = renderMxProviderPage(slug);
+  if (!html) return c.notFound();
+  return c.html(html);
+});
 
 app.get("/pricing", (c) => {
   if (wantsMarkdown(c)) return markdownResponse(c, renderPricingMarkdown());

--- a/src/views/components.ts
+++ b/src/views/components.ts
@@ -8,6 +8,7 @@ import type {
   Status,
   Validation,
 } from "../analyzers/types.js";
+import { lookupMxProvider } from "../data/mx-providers.js";
 import type { Recommendation, ScoringFactor } from "../shared/scoring.js";
 
 const DMARC_TOOLTIPS: Record<string, string> = {
@@ -433,7 +434,20 @@ export function mxTable(records: MxRecord[]): string {
   // Reduces GC pressure on a hot rendering path by avoiding array allocations
   let rows = "";
   for (const r of records) {
-    const providerCell = r.provider ? providerBadge(r.provider) : "";
+    // The analyzer's PROVIDER_SIGNATURES (used for r.provider) is intentionally
+    // stricter than this view's MX catalog — the catalog covers hostnames the
+    // analyzer doesn't label (e.g. route*.mx.cloudflare.net, *.messagingengine.com).
+    // Render a link whenever the catalog matches, regardless of analyzer label.
+    const catalogged = lookupMxProvider(r.exchange);
+    let providerCell = "";
+    if (r.provider) {
+      const badge = providerBadge(r.provider);
+      providerCell = catalogged
+        ? `<a class="mx-provider-link" href="/mx/${catalogged.slug}" title="What is ${esc(catalogged.shortName)}?">${badge}</a>`
+        : badge;
+    } else if (catalogged) {
+      providerCell = `<a class="mx-provider-link" href="/mx/${catalogged.slug}" title="What is ${esc(catalogged.shortName)}?">${esc(catalogged.shortName)}</a>`;
+    }
     rows += `<tr class="mx-row"><td class="mx-priority">${r.priority}</td><td class="mx-exchange">${esc(r.exchange)}</td><td class="mx-provider">${providerCell}</td></tr>`;
   }
 

--- a/src/views/markdown.ts
+++ b/src/views/markdown.ts
@@ -4,6 +4,11 @@ import type {
   TlsRptResult,
   Validation,
 } from "../analyzers/types.js";
+import {
+  getMxProvider,
+  MX_PROVIDERS,
+  type MxProvider,
+} from "../data/mx-providers.js";
 
 // Markdown renderings for agent consumers that send `Accept: text/markdown`.
 // Output is plain markdown with no HTML fragments — agents are expected to
@@ -438,6 +443,81 @@ If I change how I handle your data in a way that affects you materially, I'll em
 ## Contact
 
 support@dmarc.mx
+`;
+}
+
+function mdStripHtml(html: string): string {
+  // Page prose stores light HTML (<code>, <a>, etc.) for the HTML renderer.
+  // For markdown we convert <code>x</code> to backticked `x`, strip remaining
+  // tags, and decode the handful of HTML entities used in the catalog.
+  return html
+    .replace(/<code>([^<]*)<\/code>/g, (_, inner) => `\`${inner}\``)
+    .replace(/<[^>]+>/g, "")
+    .replace(/&rarr;/g, "→")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"');
+}
+
+function renderMxProviderBodyMarkdown(provider: MxProvider): string {
+  const sections = provider.sections
+    .map((section) => {
+      const paragraphs = section.paragraphs.map(mdStripHtml).join("\n\n");
+      const list = section.list
+        ? `\n\n${section.list.map((item) => `- ${mdStripHtml(item)}`).join("\n")}`
+        : "";
+      return `## ${section.title}\n\n${paragraphs}${list}`;
+    })
+    .join("\n\n");
+  const hostnames = provider.hostnameExamples
+    .map((h) => `- \`${h}\``)
+    .join("\n");
+  const examples =
+    provider.parentExamples.length > 0
+      ? `## Scan an example tenant\n\n${provider.parentExamples
+          .map(
+            (d) =>
+              `- [Scan ${d}](${MD_SITE}/check?domain=${encodeURIComponent(d)})`,
+          )
+          .join("\n")}\n\n`
+      : "";
+  return `# ${provider.headline}
+
+${mdStripHtml(provider.intro)}
+
+**Operator:** ${provider.operator}
+
+## Hostnames in the catalog
+
+${hostnames}
+
+${sections}
+
+${examples}---
+
+More MX providers: <${MD_SITE}/mx>. Scan a domain: <${MD_SITE}/check?domain=example.com>.
+`;
+}
+
+export function renderMxProviderMarkdown(slug: string): string | null {
+  const provider = getMxProvider(slug);
+  if (!provider) return null;
+  return renderMxProviderBodyMarkdown(provider);
+}
+
+export function renderMxHubMarkdown(): string {
+  const items = MX_PROVIDERS.map(
+    (p) =>
+      `- [${p.shortName}](${MD_SITE}/mx/${p.slug}) — \`${p.hostnameExamples[0] ?? ""}\``,
+  ).join("\n");
+  return `# MX provider reference — identify an MX hostname
+
+If you've spotted an MX hostname in a DNS lookup or message header and want to know what runs it, start here. Each page covers what the service is, who operates it, how the MX hostname is structured, and which kinds of organisations use it.
+
+${items}
+
+Scan a domain: <${MD_SITE}/check?domain=example.com>.
 `;
 }
 

--- a/src/views/mx.ts
+++ b/src/views/mx.ts
@@ -1,0 +1,245 @@
+import {
+  getMxProvider,
+  MX_PROVIDERS,
+  type MxProvider,
+  type MxProviderSection,
+} from "../data/mx-providers.js";
+import { esc, generateCreature } from "./components.js";
+import { page, SITE_ORIGIN } from "./html.js";
+
+// /mx — hub + per-provider pages. Modelled on /learn for visual parity (same
+// .breakdown.learn CSS shell, same bd-card body cards) but the JSON-LD,
+// breadcrumbs, and sibling lists are scoped to the /mx hub, not /learn.
+
+const MX_PUBLISHED = "2026-05-24";
+
+const MX_FOOTER = `<div class="foss-callout">
+    <a href="https://github.com/schmug/dmarcheck" class="foss-link">
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+      Free and open source &mdash; MIT License
+    </a>
+  </div>`;
+
+function renderSectionsHtml(sections: MxProviderSection[]): string {
+  return sections
+    .map((section) => {
+      const paragraphs = section.paragraphs
+        .map((p) => `<p class="tier-text">${p}</p>`)
+        .join("");
+      const list = section.list
+        ? `<ul class="learn-pitfalls">${section.list
+            .map((item) => `<li>${item}</li>`)
+            .join("")}</ul>`
+        : "";
+      return `<div class="bd-card">
+    <div class="bd-card-title">${esc(section.title)}</div>
+    <div class="bd-card-body">
+      ${paragraphs}
+      ${list}
+    </div>
+  </div>`;
+    })
+    .join("");
+}
+
+function hostnameList(examples: string[]): string {
+  return `<ul class="learn-pitfalls">${examples
+    .map((h) => `<li><code>${esc(h)}</code></li>`)
+    .join("")}</ul>`;
+}
+
+function scanLinks(domains: string[]): string {
+  if (domains.length === 0) return "";
+  const items = domains
+    .map(
+      (d) =>
+        `<li><a href="/check?domain=${encodeURIComponent(d)}">Scan ${esc(d)} &rarr;</a></li>`,
+    )
+    .join("");
+  return `<div class="bd-card">
+    <div class="bd-card-title">Scan an example tenant</div>
+    <div class="bd-card-body">
+      <ul class="learn-pitfalls">${items}</ul>
+    </div>
+  </div>`;
+}
+
+function siblingLinks(currentSlug: string): string {
+  const items = MX_PROVIDERS.filter((p) => p.slug !== currentSlug)
+    .map(
+      (p) =>
+        `<li><a href="/mx/${p.slug}"><strong>${esc(p.shortName)}</strong> &mdash; ${esc(p.hostnameExamples[0] ?? "")}</a></li>`,
+    )
+    .join("");
+  return `<ul class="learn-siblings">${items}</ul>`;
+}
+
+function providerJsonLd(provider: MxProvider): string {
+  return JSON.stringify({
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "TechArticle",
+        headline: provider.headline,
+        description: provider.description,
+        datePublished: MX_PUBLISHED,
+        dateModified: MX_PUBLISHED,
+        author: {
+          "@type": "Organization",
+          name: "dmarcheck",
+          url: `${SITE_ORIGIN}/`,
+        },
+        publisher: {
+          "@type": "Organization",
+          name: "dmarcheck",
+          url: `${SITE_ORIGIN}/`,
+          logo: {
+            "@type": "ImageObject",
+            url: `${SITE_ORIGIN}/logo.svg`,
+          },
+        },
+        about: {
+          "@type": "Thing",
+          name: provider.displayName,
+        },
+        image: `${SITE_ORIGIN}/og-image.png`,
+        mainEntityOfPage: `${SITE_ORIGIN}/mx/${provider.slug}`,
+      },
+      {
+        "@type": "BreadcrumbList",
+        itemListElement: [
+          {
+            "@type": "ListItem",
+            position: 1,
+            name: "dmarcheck",
+            item: `${SITE_ORIGIN}/`,
+          },
+          {
+            "@type": "ListItem",
+            position: 2,
+            name: "MX providers",
+            item: `${SITE_ORIGIN}/mx`,
+          },
+          {
+            "@type": "ListItem",
+            position: 3,
+            name: provider.shortName,
+            item: `${SITE_ORIGIN}/mx/${provider.slug}`,
+          },
+        ],
+      },
+    ],
+  });
+}
+
+export function renderMxProviderPage(slug: string): string | null {
+  const provider = getMxProvider(slug);
+  if (!provider) return null;
+
+  const body = `<main class="breakdown learn">
+  <nav class="report-nav" aria-label="Breadcrumb">
+    <a href="/">${generateCreature("sm")} Home</a>
+    <span class="breadcrumb-sep" aria-hidden="true">&rsaquo;</span>
+    <a href="/mx">MX providers</a>
+    <span class="breadcrumb-sep" aria-hidden="true">&rsaquo;</span>
+    <span class="breadcrumb-current">${esc(provider.shortName)}</span>
+  </nav>
+  <h1 class="rubric-title">${esc(provider.headline)}</h1>
+  <p class="rubric-intro">${provider.intro}</p>
+  <div class="bd-card">
+    <div class="bd-card-title">Hostnames in the catalog</div>
+    <div class="bd-card-body">
+      <p class="tier-text">Operated by ${esc(provider.operator)}. These are the MX hostnames you'll see in DNS:</p>
+      ${hostnameList(provider.hostnameExamples)}
+    </div>
+  </div>
+  ${renderSectionsHtml(provider.sections)}
+  ${scanLinks(provider.parentExamples)}
+  <div class="bd-card">
+    <div class="bd-card-title">More MX providers</div>
+    <div class="bd-card-body">
+      ${siblingLinks(provider.slug)}
+      <p class="tier-text" style="margin-top:12px">Want the full grading rubric? See <a href="/scoring">how dmarcheck calculates your score</a>.</p>
+    </div>
+  </div>
+  ${MX_FOOTER}
+</main>`;
+
+  return page({
+    title: `${provider.headline} — dmarcheck`,
+    path: `/mx/${provider.slug}`,
+    description: provider.description,
+    jsonLd: providerJsonLd(provider),
+    body,
+  });
+}
+
+export function renderMxHub(): string {
+  const hubJsonLd = JSON.stringify({
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "CollectionPage",
+        name: "MX provider reference — dmarcheck",
+        description:
+          "Identify an inbound MX hostname: what it is, who runs it, and which domains use it. Covers Microsoft 365, Google Workspace, Mimecast, Proofpoint, Fastmail, Zoho, Amazon SES, and Cloudflare Email Routing.",
+        url: `${SITE_ORIGIN}/mx`,
+        mainEntity: {
+          "@type": "ItemList",
+          itemListElement: MX_PROVIDERS.map((p, i) => ({
+            "@type": "ListItem",
+            position: i + 1,
+            url: `${SITE_ORIGIN}/mx/${p.slug}`,
+            name: p.shortName,
+          })),
+        },
+      },
+      {
+        "@type": "BreadcrumbList",
+        itemListElement: [
+          {
+            "@type": "ListItem",
+            position: 1,
+            name: "dmarcheck",
+            item: `${SITE_ORIGIN}/`,
+          },
+          {
+            "@type": "ListItem",
+            position: 2,
+            name: "MX providers",
+            item: `${SITE_ORIGIN}/mx`,
+          },
+        ],
+      },
+    ],
+  });
+
+  const cards = MX_PROVIDERS.map(
+    (p) =>
+      `<li><a href="/mx/${p.slug}" class="learn-hub-card">
+        <h2>${esc(p.shortName)}</h2>
+        <p><code>${esc(p.hostnameExamples[0] ?? "")}</code></p>
+      </a></li>`,
+  ).join("");
+
+  const body = `<main class="breakdown learn">
+  <nav class="report-nav" aria-label="Breadcrumb">
+    <a href="/">${generateCreature("sm")} Home</a>
+    <span class="breadcrumb-sep" aria-hidden="true">&rsaquo;</span>
+    <span class="breadcrumb-current">MX providers</span>
+  </nav>
+  <h1 class="rubric-title">Identify an MX hostname</h1>
+  <p class="rubric-intro">If you've spotted an MX hostname in a DNS lookup or message header and want to know what runs it, start here. Each page covers what the service is, who operates it, how the MX hostname is structured, and which kinds of organisations use it.</p>
+  <ul class="learn-hub-grid">${cards}</ul>
+  ${MX_FOOTER}
+</main>`;
+
+  return page({
+    title: "MX provider reference — identify an MX hostname | dmarcheck",
+    path: "/mx",
+    description:
+      "Identify an inbound MX hostname: what it is, who runs it, and which domains use it. Microsoft 365, Google Workspace, Mimecast, Proofpoint, Fastmail, Zoho, Amazon SES, Cloudflare.",
+    jsonLd: hubJsonLd,
+    body,
+  });
+}

--- a/test/mx-providers.test.ts
+++ b/test/mx-providers.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import {
+  getMxProvider,
+  lookupMxProvider,
+  MX_PROVIDERS,
+} from "../src/data/mx-providers.js";
+
+describe("lookupMxProvider", () => {
+  it("matches Microsoft 365 MX hostnames", () => {
+    expect(
+      lookupMxProvider("github-com.mail.protection.outlook.com")?.slug,
+    ).toBe("outlook");
+    expect(
+      lookupMxProvider("contoso-onmicrosoft-com.mail.protection.outlook.com")
+        ?.slug,
+    ).toBe("outlook");
+  });
+
+  it("matches Google Workspace MX hostnames", () => {
+    expect(lookupMxProvider("aspmx.l.google.com")?.slug).toBe("google");
+    expect(lookupMxProvider("alt1.aspmx.l.google.com")?.slug).toBe("google");
+    expect(lookupMxProvider("alt4.aspmx.l.google.com")?.slug).toBe("google");
+  });
+
+  it("matches Mimecast", () => {
+    expect(lookupMxProvider("us-smtp-inbound-1.mimecast.com")?.slug).toBe(
+      "mimecast",
+    );
+  });
+
+  it("distinguishes Proofpoint Enterprise (pphosted) from Essentials (ppe-hosted)", () => {
+    // Both currently map to the same /mx/proofpoint page, but the lookup must
+    // succeed for either family — the distinction is documented on the page,
+    // not in the catalog routing.
+    expect(lookupMxProvider("mx0a-001a8b01.pphosted.com")?.slug).toBe(
+      "proofpoint",
+    );
+    expect(lookupMxProvider("mx1-us1.ppe-hosted.com")?.slug).toBe("proofpoint");
+  });
+
+  it("matches Fastmail by messagingengine.com, not fastmail.com", () => {
+    expect(lookupMxProvider("in1-smtp.messagingengine.com")?.slug).toBe(
+      "fastmail",
+    );
+    expect(lookupMxProvider("in2-smtp.messagingengine.com")?.slug).toBe(
+      "fastmail",
+    );
+  });
+
+  it("matches Zoho Mail across regions", () => {
+    expect(lookupMxProvider("mx.zoho.com")?.slug).toBe("zoho");
+    expect(lookupMxProvider("mx2.zoho.eu")?.slug).toBe("zoho");
+    expect(lookupMxProvider("mx.zoho.in")?.slug).toBe("zoho");
+  });
+
+  it("matches Amazon SES across regions", () => {
+    expect(lookupMxProvider("inbound-smtp.us-east-1.amazonaws.com")?.slug).toBe(
+      "amazon-ses",
+    );
+    expect(lookupMxProvider("inbound-smtp.eu-west-1.amazonaws.com")?.slug).toBe(
+      "amazon-ses",
+    );
+    expect(
+      lookupMxProvider("inbound-smtp.ap-southeast-2.amazonaws.com")?.slug,
+    ).toBe("amazon-ses");
+  });
+
+  it("matches Cloudflare Email Routing", () => {
+    expect(lookupMxProvider("route1.mx.cloudflare.net")?.slug).toBe(
+      "cloudflare",
+    );
+    expect(lookupMxProvider("route3.mx.cloudflare.net")?.slug).toBe(
+      "cloudflare",
+    );
+  });
+
+  it("is case-insensitive", () => {
+    expect(lookupMxProvider("ASPMX.L.GOOGLE.COM")?.slug).toBe("google");
+    expect(
+      lookupMxProvider("Github-Com.Mail.Protection.Outlook.Com")?.slug,
+    ).toBe("outlook");
+  });
+
+  it("tolerates trailing dot from DNS resolvers", () => {
+    expect(lookupMxProvider("aspmx.l.google.com.")?.slug).toBe("google");
+    expect(lookupMxProvider("in1-smtp.messagingengine.com.")?.slug).toBe(
+      "fastmail",
+    );
+  });
+
+  it("returns undefined for unknown hostnames", () => {
+    expect(lookupMxProvider("mail.custom-server.example.org")).toBeUndefined();
+    expect(lookupMxProvider("smtp.acme.invalid")).toBeUndefined();
+    expect(lookupMxProvider("")).toBeUndefined();
+  });
+
+  it("does not match arbitrary amazonaws.com hostnames (only inbound-smtp)", () => {
+    expect(
+      lookupMxProvider("email-smtp.us-east-1.amazonaws.com"),
+    ).toBeUndefined();
+    expect(lookupMxProvider("ec2.us-east-1.amazonaws.com")).toBeUndefined();
+  });
+});
+
+describe("getMxProvider", () => {
+  it("returns a provider by slug", () => {
+    expect(getMxProvider("outlook")?.shortName).toBe("Microsoft 365");
+    expect(getMxProvider("google")?.shortName).toBe("Google Workspace");
+  });
+
+  it("returns undefined for unknown slugs", () => {
+    expect(getMxProvider("does-not-exist")).toBeUndefined();
+    expect(getMxProvider("")).toBeUndefined();
+  });
+});
+
+describe("MX_PROVIDERS catalog", () => {
+  it("has 8 entries with unique slugs", () => {
+    expect(MX_PROVIDERS).toHaveLength(8);
+    const slugs = MX_PROVIDERS.map((p) => p.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it("requires every provider to have unique meta description and headline", () => {
+    // Google demotes near-duplicate pages — keep this invariant tight.
+    const descriptions = MX_PROVIDERS.map((p) => p.description);
+    expect(new Set(descriptions).size).toBe(descriptions.length);
+    const headlines = MX_PROVIDERS.map((p) => p.headline);
+    expect(new Set(headlines).size).toBe(headlines.length);
+  });
+
+  it("requires every provider to declare at least one hostname pattern and example", () => {
+    for (const p of MX_PROVIDERS) {
+      expect(p.hostnames.length).toBeGreaterThan(0);
+      expect(p.hostnameExamples.length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #364.

GSC review surfaced that >50% of impressions come from operator-style queries with MX hostnames in quotes (e.g. `"github-com.mail.protection.outlook.com" github.com mx`). The existing `/check` page surfaces because the hostname is in the body text, but the page isn't *about* answering that question. This PR builds a small indexable surface that directly does.

- **Hub** at `/mx` listing eight providers.
- **Per-provider pages** at `/mx/outlook`, `/mx/google`, `/mx/mimecast`, `/mx/proofpoint`, `/mx/fastmail`, `/mx/zoho`, `/mx/amazon-ses`, `/mx/cloudflare`. Each page has a unique H1 and meta description.
- **Typed catalog** in [src/data/mx-providers.ts](src/data/mx-providers.ts) with `lookupMxProvider(hostname)` and `getMxProvider(slug)`. Patterns are independent of the MX analyzer's `PROVIDER_SIGNATURES` — fixes e.g. Fastmail's real MX (`messagingengine.com`, not `fastmail.com`).
- **MX card cross-links** in [src/views/components.ts](src/views/components.ts): when an exchange matches the catalog, the badge becomes a link to `/mx/<slug>`. Catalog match without analyzer label (Cloudflare, Fastmail) now renders a link too, so `/check?domain=dmarc.mx` connects to `/mx/cloudflare`.
- **`Accept: text/markdown`** rendering on both the hub and each provider page, generated from the same data so they can't drift.
- **JSON-LD** `TechArticle` + `BreadcrumbList` on every provider page, `CollectionPage` + `BreadcrumbList` on the hub.
- **Sitemap** gets 9 new URLs; `SITEMAP_LASTMOD` bumped to 2026-05-24.

Verified manually: `/check?domain=microsoft.com` MX card now links to `/mx/outlook`; `/check?domain=dmarc.mx` links to `/mx/cloudflare`.

## Test plan

- [x] `npm test` — 1067 passing, 0 failing (added [test/mx-providers.test.ts](test/mx-providers.test.ts) covering known hostnames, case-insensitive match, trailing-dot tolerance, region templating for SES, no false positives on arbitrary `*.amazonaws.com`, slug-uniqueness invariants).
- [x] `npm run lint` — clean.
- [x] `npm run typecheck` — clean.
- [x] Browser smoke: `/mx`, `/mx/outlook`, `/mx/google` all 200, canonical/Link header/JSON-LD/breadcrumb render correctly.
- [x] `curl -H "Accept: text/markdown" /mx/outlook` returns markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)