### PR TITLE
fix(seo): drop regex HTML-strip in /mx markdown renderer

### DIFF
--- a/src/data/mx-providers.ts
+++ b/src/data/mx-providers.ts
@@ -4,6 +4,11 @@
 //   2. The MX card on /check?domain=... — components.ts looks up the provider
 //      for each MX record and links the badge to /mx/<slug> when matched.
 //
+// Prose is stored as plain text with backticks for inline code (markdown
+// convention). The HTML renderer escapes the text and then promotes backticks
+// to <code>; the markdown renderer passes the text through. This avoids any
+// HTML-stripping regex (and the double-escape footguns that come with one).
+//
 // The MX analyzer's own PROVIDER_SIGNATURES (src/analyzers/mx.ts) is tuned for
 // detection labels and is intentionally not the source for these patterns —
 // some entries here are more specific (e.g. messagingengine.com, not
@@ -85,7 +90,7 @@ export const MX_PROVIDERS: readonly MxProvider[] = [
     headline:
       "What is *.mail.protection.outlook.com? Microsoft 365 inbound MX explained",
     intro:
-      "An MX record that ends in <code>mail.protection.outlook.com</code> means the domain receives mail through Microsoft 365 — formerly Office 365, and the same service that powers Exchange Online tenants. The slug before <code>mail.protection.outlook.com</code> is the tenant identifier, derived from the primary domain with dots replaced by dashes.",
+      "An MX record that ends in `mail.protection.outlook.com` means the domain receives mail through Microsoft 365 — formerly Office 365, and the same service that powers Exchange Online tenants. The slug before `mail.protection.outlook.com` is the tenant identifier, derived from the primary domain with dots replaced by dashes.",
     sections: [
       {
         title: "How it appears in DNS",
@@ -93,9 +98,9 @@ export const MX_PROVIDERS: readonly MxProvider[] = [
           "Microsoft 365 publishes a single MX target per tenant. The hostname is generated from the domain name itself, so it's easy to recognise once you've seen the pattern.",
         ],
         list: [
-          "<code>github.com</code> &rarr; <code>github-com.mail.protection.outlook.com</code>",
-          "<code>microsoft.com</code> &rarr; <code>microsoft-com.mail.protection.outlook.com</code>",
-          "Government Community Cloud (GCC) tenants use <code>*.olc.protection.outlook.com</code> instead — same operator, different ring.",
+          "`github.com` → `github-com.mail.protection.outlook.com`",
+          "`microsoft.com` → `microsoft-com.mail.protection.outlook.com`",
+          "Government Community Cloud (GCC) tenants use `*.olc.protection.outlook.com` instead — same operator, different ring.",
         ],
       },
       {
@@ -107,7 +112,7 @@ export const MX_PROVIDERS: readonly MxProvider[] = [
       {
         title: "How to tell it's actually Microsoft 365",
         paragraphs: [
-          "The MX hostname alone is enough — only Microsoft can serve that domain. If you want a second signal, look at the SPF record: a Microsoft 365 tenant will <code>include:spf.protection.outlook.com</code>. The DKIM keys live at <code>selector1._domainkey</code> and <code>selector2._domainkey</code> and point at <code>selector*-&lt;tenant&gt;._domainkey.&lt;tenant&gt;.onmicrosoft.com</code>.",
+          "The MX hostname alone is enough — only Microsoft can serve that domain. If you want a second signal, look at the SPF record: a Microsoft 365 tenant will `include:spf.protection.outlook.com`. The DKIM keys live at `selector1._domainkey` and `selector2._domainkey` and point at `selector*-<tenant>._domainkey.<tenant>.onmicrosoft.com`.",
         ],
       },
     ],
@@ -135,7 +140,7 @@ export const MX_PROVIDERS: readonly MxProvider[] = [
     headline:
       "What is aspmx.l.google.com? Google Workspace inbound MX explained",
     intro:
-      "An MX record set that lists <code>aspmx.l.google.com</code> as the primary plus four <code>alt[1-4].aspmx.l.google.com</code> hosts is Google Workspace — the business mail service formerly known as G Suite and, before that, Google Apps. Every Workspace tenant uses the same five hostnames, regardless of which domain they're for.",
+      "An MX record set that lists `aspmx.l.google.com` as the primary plus four `alt[1-4].aspmx.l.google.com` hosts is Google Workspace — the business mail service formerly known as G Suite and, before that, Google Apps. Every Workspace tenant uses the same five hostnames, regardless of which domain they're for.",
     sections: [
       {
         title: "How it appears in DNS",
@@ -143,11 +148,11 @@ export const MX_PROVIDERS: readonly MxProvider[] = [
           "Workspace's recommended MX configuration is five records with different priorities. The primary is the lowest priority value; the alt hosts are stand-bys for when the primary is at capacity or unreachable.",
         ],
         list: [
-          "<code>1 aspmx.l.google.com</code>",
-          "<code>5 alt1.aspmx.l.google.com</code>",
-          "<code>5 alt2.aspmx.l.google.com</code>",
-          "<code>10 alt3.aspmx.l.google.com</code>",
-          "<code>10 alt4.aspmx.l.google.com</code>",
+          "`1 aspmx.l.google.com`",
+          "`5 alt1.aspmx.l.google.com`",
+          "`5 alt2.aspmx.l.google.com`",
+          "`10 alt3.aspmx.l.google.com`",
+          "`10 alt4.aspmx.l.google.com`",
         ],
       },
       {
@@ -159,7 +164,7 @@ export const MX_PROVIDERS: readonly MxProvider[] = [
       {
         title: "Identifying a Workspace tenant",
         paragraphs: [
-          "Unlike Microsoft 365's per-tenant hostname, every Workspace customer shares the same MX hosts — so the MX alone doesn't reveal the tenant. The tenant identifier shows up elsewhere: the SPF record includes <code>_spf.google.com</code>, and DKIM uses <code>google._domainkey</code> by default. If the domain publishes DMARC with a <code>rua</code> mailto pointing at <code>*.google.com</code>, that's another tell.",
+          "Unlike Microsoft 365's per-tenant hostname, every Workspace customer shares the same MX hosts — so the MX alone doesn't reveal the tenant. The tenant identifier shows up elsewhere: the SPF record includes `_spf.google.com`, and DKIM uses `google._domainkey` by default. If the domain publishes DMARC with a `rua` mailto pointing at `*.google.com`, that's another tell.",
         ],
       },
     ],
@@ -180,7 +185,7 @@ export const MX_PROVIDERS: readonly MxProvider[] = [
     headline:
       "What is *.mimecast.com? Mimecast secure email gateway, explained",
     intro:
-      "Mimecast is a security gateway, not a mailbox provider. When a domain's MX points at <code>*.mimecast.com</code>, inbound mail lands at Mimecast first — Mimecast performs anti-spam, anti-phishing, sandboxing and policy enforcement, and then relays the cleaned mail to the customer's actual mailbox host (most commonly Microsoft 365 or Google Workspace).",
+      "Mimecast is a security gateway, not a mailbox provider. When a domain's MX points at `*.mimecast.com`, inbound mail lands at Mimecast first — Mimecast performs anti-spam, anti-phishing, sandboxing and policy enforcement, and then relays the cleaned mail to the customer's actual mailbox host (most commonly Microsoft 365 or Google Workspace).",
     sections: [
       {
         title: "How it appears in DNS",
@@ -188,10 +193,10 @@ export const MX_PROVIDERS: readonly MxProvider[] = [
           "Mimecast hostnames embed a region segment that tells you which data centre the tenant is provisioned in.",
         ],
         list: [
-          "<code>*.mail.eu.mimecast.com</code> — Europe",
-          "<code>*.mail.us.mimecast.com</code> — North America",
-          "<code>*.mail.za.mimecast.com</code> — South Africa",
-          "<code>*.mail.au.mimecast.com</code> — Australia/Pacific",
+          "`*.mail.eu.mimecast.com` — Europe",
+          "`*.mail.us.mimecast.com` — North America",
+          "`*.mail.za.mimecast.com` — South Africa",
+          "`*.mail.au.mimecast.com` — Australia/Pacific",
         ],
       },
       {
@@ -224,17 +229,17 @@ export const MX_PROVIDERS: readonly MxProvider[] = [
     headline:
       "What is *.pphosted.com and *.ppe-hosted.com? Proofpoint MX explained",
     intro:
-      "Two MX hostname families both belong to Proofpoint. <code>*.pphosted.com</code> is the enterprise tier — large organisations on Proofpoint's flagship Enterprise Protection product. <code>*.ppe-hosted.com</code> is Proofpoint Essentials, the SMB tier sold through partner MSPs. Both are perimeter filtering gateways in front of the customer's real mailbox host.",
+      "Two MX hostname families both belong to Proofpoint. `*.pphosted.com` is the enterprise tier — large organisations on Proofpoint's flagship Enterprise Protection product. `*.ppe-hosted.com` is Proofpoint Essentials, the SMB tier sold through partner MSPs. Both are perimeter filtering gateways in front of the customer's real mailbox host.",
     sections: [
       {
         title: "How it appears in DNS",
         paragraphs: [
-          "Enterprise Protection publishes a pair of MX records with <code>mx0a-</code> and <code>mx0b-</code> prefixes for high availability. The slug after the prefix is a tenant identifier.",
+          "Enterprise Protection publishes a pair of MX records with `mx0a-` and `mx0b-` prefixes for high availability. The slug after the prefix is a tenant identifier.",
         ],
         list: [
-          "<code>10 mx0a-&lt;tenant&gt;.pphosted.com</code>",
-          "<code>10 mx0b-&lt;tenant&gt;.pphosted.com</code>",
-          "Essentials customers see <code>mx1-&lt;region&gt;.ppe-hosted.com</code> and <code>mx2-&lt;region&gt;.ppe-hosted.com</code>.",
+          "`10 mx0a-<tenant>.pphosted.com`",
+          "`10 mx0b-<tenant>.pphosted.com`",
+          "Essentials customers see `mx1-<region>.ppe-hosted.com` and `mx2-<region>.ppe-hosted.com`.",
         ],
       },
       {
@@ -270,7 +275,7 @@ export const MX_PROVIDERS: readonly MxProvider[] = [
     headline:
       "What is in1-smtp.messagingengine.com? Fastmail inbound MX explained",
     intro:
-      "Fastmail's inbound MX hosts are <code>in1-smtp.messagingengine.com</code> and <code>in2-smtp.messagingengine.com</code>. The <code>messagingengine.com</code> domain — not <code>fastmail.com</code> — is what trips up most reverse-lookup tools: <code>messagingengine.com</code> is Fastmail's infrastructure brand, used for SMTP, IMAP, and SPF includes as well.",
+      "Fastmail's inbound MX hosts are `in1-smtp.messagingengine.com` and `in2-smtp.messagingengine.com`. The `messagingengine.com` domain — not `fastmail.com` — is what trips up most reverse-lookup tools: `messagingengine.com` is Fastmail's infrastructure brand, used for SMTP, IMAP, and SPF includes as well.",
     sections: [
       {
         title: "How it appears in DNS",
@@ -278,8 +283,8 @@ export const MX_PROVIDERS: readonly MxProvider[] = [
           "Fastmail publishes two MX records with equal priority for round-robin delivery.",
         ],
         list: [
-          "<code>10 in1-smtp.messagingengine.com</code>",
-          "<code>20 in2-smtp.messagingengine.com</code>",
+          "`10 in1-smtp.messagingengine.com`",
+          "`20 in2-smtp.messagingengine.com`",
         ],
       },
       {
@@ -319,7 +324,7 @@ export const MX_PROVIDERS: readonly MxProvider[] = [
     description: ZOHO_DESCRIPTION,
     headline: "What is mx.zoho.com? Zoho Mail inbound MX explained",
     intro:
-      "Zoho Mail is the business email service from Zoho Corporation, bundled with the broader Zoho CRM/Workplace suite. Customers point their MX records at <code>mx.zoho.com</code>, <code>mx2.zoho.com</code>, and <code>mx3.zoho.com</code> — or the regional equivalents <code>mx.zoho.eu</code>, <code>mx.zoho.in</code>, and <code>mx.zoho.com.au</code> depending on the data residency tier they chose at signup.",
+      "Zoho Mail is the business email service from Zoho Corporation, bundled with the broader Zoho CRM/Workplace suite. Customers point their MX records at `mx.zoho.com`, `mx2.zoho.com`, and `mx3.zoho.com` — or the regional equivalents `mx.zoho.eu`, `mx.zoho.in`, and `mx.zoho.com.au` depending on the data residency tier they chose at signup.",
     sections: [
       {
         title: "How it appears in DNS",
@@ -327,11 +332,11 @@ export const MX_PROVIDERS: readonly MxProvider[] = [
           "Zoho's recommended setup is three MX records with ascending priorities. Regional plans swap the TLD on every host — once you pick a region you're committed to it for the lifetime of the account.",
         ],
         list: [
-          "<code>10 mx.zoho.com</code>",
-          "<code>20 mx2.zoho.com</code>",
-          "<code>50 mx3.zoho.com</code>",
-          "European tenants substitute <code>mx.zoho.eu</code> / <code>mx2.zoho.eu</code>.",
-          "Indian tenants substitute <code>mx.zoho.in</code> / <code>mx2.zoho.in</code>.",
+          "`10 mx.zoho.com`",
+          "`20 mx2.zoho.com`",
+          "`50 mx3.zoho.com`",
+          "European tenants substitute `mx.zoho.eu` / `mx2.zoho.eu`.",
+          "Indian tenants substitute `mx.zoho.in` / `mx2.zoho.in`.",
         ],
       },
       {
@@ -343,7 +348,7 @@ export const MX_PROVIDERS: readonly MxProvider[] = [
       {
         title: "Identifying a Zoho tenant",
         paragraphs: [
-          "The MX hostname is unambiguous — only Zoho can serve those. The SPF record will <code>include:zoho.com</code> (or the regional equivalent). DKIM selectors are named <code>zoho._domainkey</code> by default but can be renamed.",
+          "The MX hostname is unambiguous — only Zoho can serve those. The SPF record will `include:zoho.com` (or the regional equivalent). DKIM selectors are named `zoho._domainkey` by default but can be renamed.",
         ],
       },
     ],
@@ -364,7 +369,7 @@ export const MX_PROVIDERS: readonly MxProvider[] = [
     headline:
       "What is inbound-smtp.amazonaws.com? Amazon SES inbound MX explained",
     intro:
-      "Amazon SES (Simple Email Service) is a transactional email API. Its inbound side — receiving mail at a domain — uses MX hostnames of the form <code>inbound-smtp.&lt;region&gt;.amazonaws.com</code>. The region segment tells you which AWS region the receiving SES configuration lives in.",
+      "Amazon SES (Simple Email Service) is a transactional email API. Its inbound side — receiving mail at a domain — uses MX hostnames of the form `inbound-smtp.<region>.amazonaws.com`. The region segment tells you which AWS region the receiving SES configuration lives in.",
     sections: [
       {
         title: "How it appears in DNS",
@@ -372,16 +377,16 @@ export const MX_PROVIDERS: readonly MxProvider[] = [
           "Only the regions that have SES inbound enabled get an inbound-smtp hostname. The available regions are a moving target but at time of writing include us-east-1, us-west-2, eu-west-1, eu-central-1, and ap-southeast-2.",
         ],
         list: [
-          "<code>10 inbound-smtp.us-east-1.amazonaws.com</code> — N. Virginia",
-          "<code>10 inbound-smtp.us-west-2.amazonaws.com</code> — Oregon",
-          "<code>10 inbound-smtp.eu-west-1.amazonaws.com</code> — Ireland",
-          "<code>10 inbound-smtp.eu-central-1.amazonaws.com</code> — Frankfurt",
+          "`10 inbound-smtp.us-east-1.amazonaws.com` — N. Virginia",
+          "`10 inbound-smtp.us-west-2.amazonaws.com` — Oregon",
+          "`10 inbound-smtp.eu-west-1.amazonaws.com` — Ireland",
+          "`10 inbound-smtp.eu-central-1.amazonaws.com` — Frankfurt",
         ],
       },
       {
         title: "Inbound vs outbound SES",
         paragraphs: [
-          "Most domains use SES outbound (sending email programmatically) without using SES inbound. If a domain only sends via SES, you won't see <code>inbound-smtp</code> in its MX — the MX will point elsewhere. <code>inbound-smtp</code> means the operators are routing received mail into an S3 bucket, Lambda function, or SNS topic for processing.",
+          "Most domains use SES outbound (sending email programmatically) without using SES inbound. If a domain only sends via SES, you won't see `inbound-smtp` in its MX — the MX will point elsewhere. `inbound-smtp` means the operators are routing received mail into an S3 bucket, Lambda function, or SNS topic for processing.",
         ],
       },
       {
@@ -408,7 +413,7 @@ export const MX_PROVIDERS: readonly MxProvider[] = [
     headline:
       "What is route1.mx.cloudflare.net? Cloudflare Email Routing explained",
     intro:
-      "Cloudflare Email Routing is a free email-forwarding service for domains whose DNS is managed by Cloudflare. It doesn't host mailboxes — it accepts mail at <code>route1-3.mx.cloudflare.net</code> and forwards it to a destination address the domain owner specified (a Gmail account, a Fastmail account, anything that accepts SMTP).",
+      "Cloudflare Email Routing is a free email-forwarding service for domains whose DNS is managed by Cloudflare. It doesn't host mailboxes — it accepts mail at `route1-3.mx.cloudflare.net` and forwards it to a destination address the domain owner specified (a Gmail account, a Fastmail account, anything that accepts SMTP).",
     sections: [
       {
         title: "How it appears in DNS",
@@ -416,9 +421,9 @@ export const MX_PROVIDERS: readonly MxProvider[] = [
           "Email Routing publishes three MX records, all at equal priority, so any of Cloudflare's edge can accept inbound mail.",
         ],
         list: [
-          "<code>2 route1.mx.cloudflare.net</code>",
-          "<code>3 route2.mx.cloudflare.net</code>",
-          "<code>15 route3.mx.cloudflare.net</code>",
+          "`2 route1.mx.cloudflare.net`",
+          "`3 route2.mx.cloudflare.net`",
+          "`15 route3.mx.cloudflare.net`",
         ],
       },
       {

--- a/src/views/markdown.ts
+++ b/src/views/markdown.ts
@@ -446,26 +446,15 @@ support@dmarc.mx
 `;
 }
 
-function mdStripHtml(html: string): string {
-  // Page prose stores light HTML (<code>, <a>, etc.) for the HTML renderer.
-  // For markdown we convert <code>x</code> to backticked `x`, strip remaining
-  // tags, and decode the handful of HTML entities used in the catalog.
-  return html
-    .replace(/<code>([^<]*)<\/code>/g, (_, inner) => `\`${inner}\``)
-    .replace(/<[^>]+>/g, "")
-    .replace(/&rarr;/g, "→")
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"');
-}
-
 function renderMxProviderBodyMarkdown(provider: MxProvider): string {
+  // The catalog stores prose as plain text with backticks for inline code
+  // (the markdown convention), so the markdown renderer passes section
+  // content through verbatim — no HTML stripping, no entity decoding.
   const sections = provider.sections
     .map((section) => {
-      const paragraphs = section.paragraphs.map(mdStripHtml).join("\n\n");
+      const paragraphs = section.paragraphs.join("\n\n");
       const list = section.list
-        ? `\n\n${section.list.map((item) => `- ${mdStripHtml(item)}`).join("\n")}`
+        ? `\n\n${section.list.map((item) => `- ${item}`).join("\n")}`
         : "";
       return `## ${section.title}\n\n${paragraphs}${list}`;
     })
@@ -484,7 +473,7 @@ function renderMxProviderBodyMarkdown(provider: MxProvider): string {
       : "";
   return `# ${provider.headline}
 
-${mdStripHtml(provider.intro)}
+${provider.intro}
 
 **Operator:** ${provider.operator}
 

--- a/src/views/mx.ts
+++ b/src/views/mx.ts
@@ -20,15 +20,23 @@ const MX_FOOTER = `<div class="foss-callout">
     </a>
   </div>`;
 
+// Promote markdown-style backticks to <code> tags. Input is escaped first so
+// any literal `<` or `&` in the prose is rendered as text, not as HTML.
+// Backticks themselves survive escaping unchanged, so the regex pass that
+// follows operates on already-safe text — no double-escape, no HTML injection.
+function proseToHtml(text: string): string {
+  return esc(text).replace(/`([^`]+)`/g, "<code>$1</code>");
+}
+
 function renderSectionsHtml(sections: MxProviderSection[]): string {
   return sections
     .map((section) => {
       const paragraphs = section.paragraphs
-        .map((p) => `<p class="tier-text">${p}</p>`)
+        .map((p) => `<p class="tier-text">${proseToHtml(p)}</p>`)
         .join("");
       const list = section.list
         ? `<ul class="learn-pitfalls">${section.list
-            .map((item) => `<li>${item}</li>`)
+            .map((item) => `<li>${proseToHtml(item)}</li>`)
             .join("")}</ul>`
         : "";
       return `<div class="bd-card">
@@ -145,7 +153,7 @@ export function renderMxProviderPage(slug: string): string | null {
     <span class="breadcrumb-current">${esc(provider.shortName)}</span>
   </nav>
   <h1 class="rubric-title">${esc(provider.headline)}</h1>
-  <p class="rubric-intro">${provider.intro}</p>
+  <p class="rubric-intro">${proseToHtml(provider.intro)}</p>
   <div class="bd-card">
     <div class="bd-card-title">Hostnames in the catalog</div>
     <div class="bd-card-body">


### PR DESCRIPTION
## Summary

Follow-up to [#367](https://github.com/schmug/dmarcheck/pull/367) which was auto-merged before the CodeQL alerts could land. Two inline alerts on the `mdStripHtml` helper:

- [security/code-scanning/14](https://github.com/schmug/dmarcheck/security/code-scanning/14): Double escaping / unescaping — the chained `.replace(/&amp;/g, "&")` and friends could double-decode entities.
- [security/code-scanning/15](https://github.com/schmug/dmarcheck/security/code-scanning/15): Incomplete multi-character sanitization — a `<` followed by `<script` in input could slip past the single-pass tag strip.

The helper was operating on trusted catalog prose, but regex-stripping HTML + entity decoding is the kind of pattern that shouldn't be in the codebase regardless.

## Fix

Reshape the catalog so prose is stored as plain text with markdown-style backticks for inline code (e.g. ``` `aspmx.l.google.com` ```), not HTML fragments.

- [src/views/mx.ts](src/views/mx.ts): new `proseToHtml(text)` helper — `esc(text)` then promote backticks to `<code>`. Single forward pass on already-escaped (safe) text, no entities to decode, no tags to strip.
- [src/views/markdown.ts](src/views/markdown.ts): `mdStripHtml` is removed; the markdown renderer passes catalog prose through verbatim (backticks are already markdown).
- [src/data/mx-providers.ts](src/data/mx-providers.ts): prose rewritten in the new shape — no behavior change for either rendering path.

## Test plan

- [x] `npm test` — 1067 passing, 0 failing
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] Browser smoke: `/mx/outlook` HTML renders identically to before (escaped `<tenant>` placeholders, inline `<code>` for hostnames). `curl -H "Accept: text/markdown" /mx/outlook` returns clean markdown with raw `<tenant>` and backticked code spans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)