### PR TITLE
feat: add /mx/ provider pages for 8 MX hosts (Microsoft 365, Google Workspace, and more)

### DIFF
--- a/src/data/mx-providers.ts
+++ b/src/data/mx-providers.ts
@@ -1,0 +1,164 @@
+export interface MxProviderData {
+  slug: string;
+  name: string;
+  operator: string;
+  category: "email-platform" | "security-gateway" | "cdn";
+  patterns: RegExp[];
+  mxExamples: string[];
+  description: string;
+  headline: string;
+  metaDescription: string;
+}
+
+export const MX_PROVIDERS: MxProviderData[] = [
+  {
+    slug: "outlook",
+    name: "Microsoft 365",
+    operator: "Microsoft",
+    category: "email-platform",
+    patterns: [
+      /\.protection\.outlook\.com$/i,
+      /\.olc\.protection\.outlook\.com$/i,
+    ],
+    mxExamples: [
+      "yourdomain-com.mail.protection.outlook.com",
+      "yourdomain-com.olc.protection.outlook.com",
+    ],
+    description:
+      "Microsoft 365 / Exchange Online MX records — what the protection.outlook.com hostname means, how tenant routing works, and how to verify DMARC alignment.",
+    headline: "Microsoft 365 MX records (protection.outlook.com)",
+    metaDescription:
+      "What does *.mail.protection.outlook.com mean in a DNS MX record? Microsoft 365 / Exchange Online routes inbound mail through these hostnames. Learn how tenant routing works and how to check DMARC alignment.",
+  },
+  {
+    slug: "google",
+    name: "Google Workspace",
+    operator: "Google",
+    category: "email-platform",
+    patterns: [/\.google\.com$/i, /\.googlemail\.com$/i],
+    mxExamples: [
+      "aspmx.l.google.com",
+      "alt1.aspmx.l.google.com",
+      "alt2.aspmx.l.google.com",
+      "alt3.aspmx.l.google.com",
+      "alt4.aspmx.l.google.com",
+    ],
+    description:
+      "Google Workspace MX records — what aspmx.l.google.com and the alt hostnames mean, MX priority setup, and how Google enforces DMARC for Workspace.",
+    headline: "Google Workspace MX records (aspmx.l.google.com)",
+    metaDescription:
+      "What does aspmx.l.google.com mean in a DNS MX record? Google Workspace routes inbound mail through these five hostnames with specific priorities. Learn how to set them up and verify DMARC alignment.",
+  },
+  {
+    slug: "mimecast",
+    name: "Mimecast",
+    operator: "Mimecast",
+    category: "security-gateway",
+    patterns: [/\.mimecast\.com$/i],
+    mxExamples: [
+      "us-smtp-inbound-1.mimecast.com",
+      "us-smtp-inbound-2.mimecast.com",
+      "eu-smtp-inbound-1.mimecast.com",
+    ],
+    description:
+      "Mimecast MX records — how the mimecast.com gateway sits in front of Microsoft 365 or Google Workspace, what the regional hostnames mean, and DMARC considerations.",
+    headline: "Mimecast MX records (*.mimecast.com)",
+    metaDescription:
+      "What does *.mimecast.com mean in a DNS MX record? Mimecast is an email security gateway that sits in front of Microsoft 365 or Google Workspace. Learn how it routes mail and what DMARC policies apply.",
+  },
+  {
+    slug: "proofpoint",
+    name: "Proofpoint",
+    operator: "Proofpoint",
+    category: "security-gateway",
+    patterns: [/\.pphosted\.com$/i, /\.ppe-hosted\.com$/i],
+    mxExamples: [
+      "mail.pphosted.com",
+      "mx-eu.pphosted.com",
+      "inbound.ppe-hosted.com",
+    ],
+    description:
+      "Proofpoint MX records — what pphosted.com and ppe-hosted.com mean, how Proofpoint Essentials differs from the enterprise product, and DMARC alignment with a gateway.",
+    headline: "Proofpoint MX records (pphosted.com / ppe-hosted.com)",
+    metaDescription:
+      "What does pphosted.com or ppe-hosted.com mean in a DNS MX record? Proofpoint is an enterprise email security gateway. Learn how it routes inbound mail and how DMARC reporting flows through a gateway.",
+  },
+  {
+    slug: "fastmail",
+    name: "Fastmail",
+    operator: "Fastmail",
+    category: "email-platform",
+    patterns: [/\.messagingengine\.com$/i, /\.fastmail\.com$/i],
+    mxExamples: [
+      "in1-smtp.messagingengine.com",
+      "in2-smtp.messagingengine.com",
+    ],
+    description:
+      "Fastmail MX records — what in1-smtp.messagingengine.com and in2-smtp.messagingengine.com mean, how Fastmail supports custom domains, and DMARC setup.",
+    headline: "Fastmail MX records (messagingengine.com)",
+    metaDescription:
+      "What does in1-smtp.messagingengine.com mean in a DNS MX record? Fastmail routes inbound mail through messagingengine.com hostnames. Learn how to set up a custom domain with Fastmail and configure DMARC.",
+  },
+  {
+    slug: "zoho",
+    name: "Zoho Mail",
+    operator: "Zoho",
+    category: "email-platform",
+    patterns: [/\.zoho\.com$/i, /\.zoho\.eu$/i, /\.zoho\.com\.au$/i],
+    mxExamples: ["mx.zoho.com", "mx2.zoho.com", "mx3.zoho.com"],
+    description:
+      "Zoho Mail MX records — what mx.zoho.com, mx2.zoho.com, and mx3.zoho.com mean, MX priority requirements, and DMARC alignment for Zoho-hosted custom domains.",
+    headline: "Zoho Mail MX records (mx.zoho.com)",
+    metaDescription:
+      "What does mx.zoho.com mean in a DNS MX record? Zoho Mail routes custom-domain inbound mail through three MX hostnames with specific priorities. Learn how to set them up and configure DMARC.",
+  },
+  {
+    slug: "amazon-ses",
+    name: "Amazon SES",
+    operator: "Amazon Web Services",
+    category: "email-platform",
+    patterns: [/inbound-smtp\.[a-z0-9-]+\.amazonaws\.com$/i],
+    mxExamples: [
+      "inbound-smtp.us-east-1.amazonaws.com",
+      "inbound-smtp.eu-west-1.amazonaws.com",
+    ],
+    description:
+      "Amazon SES inbound MX records — what inbound-smtp.*.amazonaws.com means, how SES inbound email processing works per region, and DMARC considerations for SES.",
+    headline: "Amazon SES inbound MX records (amazonaws.com)",
+    metaDescription:
+      "What does inbound-smtp.us-east-1.amazonaws.com mean in a DNS MX record? Amazon SES routes inbound mail through regional amazonaws.com hostnames. Learn how SES inbound processing works and how to configure DMARC.",
+  },
+  {
+    slug: "cloudflare",
+    name: "Cloudflare Email Routing",
+    operator: "Cloudflare",
+    category: "email-platform",
+    patterns: [/\.mx\.cloudflare\.net$/i],
+    mxExamples: [
+      "route1.mx.cloudflare.net",
+      "route2.mx.cloudflare.net",
+      "route3.mx.cloudflare.net",
+    ],
+    description:
+      "Cloudflare Email Routing MX records — what route1-3.mx.cloudflare.net means, how Cloudflare Email Routing forwards mail to another inbox, and DMARC behavior.",
+    headline: "Cloudflare Email Routing MX records (mx.cloudflare.net)",
+    metaDescription:
+      "What does route1.mx.cloudflare.net mean in a DNS MX record? Cloudflare Email Routing is a free forwarding service that relays custom-domain email to another inbox. Learn how it works and what DMARC posture to use.",
+  },
+];
+
+export function lookupMxSlug(exchange: string): string | undefined {
+  const normalized = exchange.toLowerCase().replace(/\.$/, "");
+  for (const provider of MX_PROVIDERS) {
+    for (const pattern of provider.patterns) {
+      if (pattern.test(normalized)) {
+        return provider.slug;
+      }
+    }
+  }
+  return undefined;
+}
+
+export function getMxProvider(slug: string): MxProviderData | undefined {
+  return MX_PROVIDERS.find((p) => p.slug === slug);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,6 +103,7 @@ import {
   renderReportMarkdown,
   renderScoringRubricMarkdown,
 } from "./views/markdown.js";
+import { renderMxHub, renderMxProviderPage } from "./views/mx.js";
 import { renderPricingPage } from "./views/pricing.js";
 import { JS } from "./views/scripts.js";
 import { CSS } from "./views/styles.js";
@@ -918,6 +919,15 @@ const STATIC_SITEMAP_URLS: Array<{ loc: string; priority: string }> = [
   { loc: "https://dmarc.mx/learn/dkim", priority: "0.7" },
   { loc: "https://dmarc.mx/learn/bimi", priority: "0.6" },
   { loc: "https://dmarc.mx/learn/mta-sts", priority: "0.7" },
+  { loc: "https://dmarc.mx/mx", priority: "0.7" },
+  { loc: "https://dmarc.mx/mx/outlook", priority: "0.8" },
+  { loc: "https://dmarc.mx/mx/google", priority: "0.8" },
+  { loc: "https://dmarc.mx/mx/mimecast", priority: "0.7" },
+  { loc: "https://dmarc.mx/mx/proofpoint", priority: "0.7" },
+  { loc: "https://dmarc.mx/mx/fastmail", priority: "0.6" },
+  { loc: "https://dmarc.mx/mx/zoho", priority: "0.6" },
+  { loc: "https://dmarc.mx/mx/amazon-ses", priority: "0.6" },
+  { loc: "https://dmarc.mx/mx/cloudflare", priority: "0.6" },
   { loc: "https://dmarc.mx/llms.txt", priority: "0.2" },
 ];
 const SITEMAP_LASTMOD = "2026-04-26";
@@ -968,6 +978,13 @@ app.get("/learn/spf", (c) => c.html(renderLearnSpf()));
 app.get("/learn/dkim", (c) => c.html(renderLearnDkim()));
 app.get("/learn/bimi", (c) => c.html(renderLearnBimi()));
 app.get("/learn/mta-sts", (c) => c.html(renderLearnMtaSts()));
+
+app.get("/mx", (c) => c.html(renderMxHub()));
+app.get("/mx/:slug", (c) => {
+  const html = renderMxProviderPage(c.req.param("slug"));
+  if (!html) return c.notFound();
+  return c.html(html);
+});
 
 app.get("/pricing", (c) => {
   if (wantsMarkdown(c)) return markdownResponse(c, renderPricingMarkdown());

--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -9,6 +9,7 @@ import type {
   SpfResult,
   TlsRptResult,
 } from "../analyzers/types.js";
+import { lookupMxSlug } from "../data/mx-providers.js";
 import { isIndexableScanDomain } from "../shared/indexable-domains.js";
 import { CSS_PATH, JS_PATH } from "./assets.js";
 import {
@@ -355,7 +356,19 @@ export function renderMxCard(mx: MxResult): string {
     mx.records.length > 0
       ? `${mx.records.length} record${mx.records.length !== 1 ? "s" : ""}${mx.providers.length > 0 ? ` · ${mx.providers.map((p) => p.name).join(", ")}` : ""}`
       : "No MX records";
-  const body = mxTable(mx.records) + validationList(mx.validations);
+
+  const slugs = new Set<string>();
+  for (const r of mx.records) {
+    const slug = lookupMxSlug(r.exchange);
+    if (slug) slugs.add(slug);
+  }
+  const providerLinks =
+    slugs.size > 0
+      ? `<p class="tier-text" style="margin-top:8px">${[...slugs].map((s) => `<a href="/mx/${esc(s)}">What is this MX? &rarr;</a>`).join(" ")}</p>`
+      : "";
+
+  const body =
+    mxTable(mx.records) + validationList(mx.validations) + providerLinks;
   return protocolCard("MX", mx.status, subtitle, body);
 }
 

--- a/src/views/mx.ts
+++ b/src/views/mx.ts
@@ -1,0 +1,407 @@
+import {
+  getMxProvider,
+  MX_PROVIDERS,
+  type MxProviderData,
+} from "../data/mx-providers.js";
+import { esc, generateCreature } from "./components.js";
+import { page, SITE_ORIGIN } from "./html.js";
+
+const MX_PUBLISHED = "2026-05-24";
+
+function mxJsonLd(provider: MxProviderData): string {
+  return JSON.stringify({
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "TechArticle",
+        headline: provider.headline,
+        description: provider.metaDescription,
+        datePublished: MX_PUBLISHED,
+        dateModified: MX_PUBLISHED,
+        author: {
+          "@type": "Organization",
+          name: "dmarcheck",
+          url: `${SITE_ORIGIN}/`,
+        },
+        publisher: {
+          "@type": "Organization",
+          name: "dmarcheck",
+          url: `${SITE_ORIGIN}/`,
+          logo: {
+            "@type": "ImageObject",
+            url: `${SITE_ORIGIN}/logo.svg`,
+          },
+        },
+        image: `${SITE_ORIGIN}/og-image.png`,
+        mainEntityOfPage: `${SITE_ORIGIN}/mx/${provider.slug}`,
+      },
+      {
+        "@type": "BreadcrumbList",
+        itemListElement: [
+          {
+            "@type": "ListItem",
+            position: 1,
+            name: "dmarcheck",
+            item: `${SITE_ORIGIN}/`,
+          },
+          {
+            "@type": "ListItem",
+            position: 2,
+            name: "MX Providers",
+            item: `${SITE_ORIGIN}/mx`,
+          },
+          {
+            "@type": "ListItem",
+            position: 3,
+            name: provider.name,
+            item: `${SITE_ORIGIN}/mx/${provider.slug}`,
+          },
+        ],
+      },
+    ],
+  });
+}
+
+function mxHubJsonLd(): string {
+  return JSON.stringify({
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "CollectionPage",
+        name: "MX record providers — dmarcheck",
+        description:
+          "What each MX hostname means: Microsoft 365, Google Workspace, Mimecast, Proofpoint, Fastmail, Zoho, Amazon SES, and Cloudflare Email Routing.",
+        url: `${SITE_ORIGIN}/mx`,
+        mainEntity: {
+          "@type": "ItemList",
+          itemListElement: MX_PROVIDERS.map((p, i) => ({
+            "@type": "ListItem",
+            position: i + 1,
+            url: `${SITE_ORIGIN}/mx/${p.slug}`,
+            name: p.name,
+          })),
+        },
+      },
+      {
+        "@type": "BreadcrumbList",
+        itemListElement: [
+          {
+            "@type": "ListItem",
+            position: 1,
+            name: "dmarcheck",
+            item: `${SITE_ORIGIN}/`,
+          },
+          {
+            "@type": "ListItem",
+            position: 2,
+            name: "MX Providers",
+            item: `${SITE_ORIGIN}/mx`,
+          },
+        ],
+      },
+    ],
+  });
+}
+
+const MX_FOOTER = `<div class="foss-callout">
+    <a href="https://github.com/schmug/dmarcheck" class="foss-link">
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+      Free and open source &mdash; MIT License
+    </a>
+  </div>`;
+
+function providerSiblingLinks(currentSlug: string): string {
+  const items = MX_PROVIDERS.filter((p) => p.slug !== currentSlug)
+    .map(
+      (p) =>
+        `<li><a href="/mx/${esc(p.slug)}"><strong>${esc(p.name)}</strong> &mdash; ${esc(p.operator)}</a></li>`,
+    )
+    .join("");
+  return `<ul class="learn-siblings">${items}</ul>`;
+}
+
+function exampleDomains(provider: MxProviderData): string {
+  const examples: Record<string, string[]> = {
+    outlook: ["github.com", "microsoft.com", "outlook.com"],
+    google: ["google.com", "alphabet.com", "youtube.com"],
+    mimecast: ["barclays.com", "hsbc.com"],
+    proofpoint: ["salesforce.com", "oracle.com"],
+    fastmail: ["fastmail.com", "fastmail.fm"],
+    zoho: ["zoho.com", "zohocrm.com"],
+    "amazon-ses": ["amazon.com", "aws.amazon.com"],
+    cloudflare: ["cloudflare.com"],
+  };
+  const domains = examples[provider.slug] ?? [];
+  if (domains.length === 0) return "";
+  const links = domains
+    .map(
+      (d) => `<a href="/check?domain=${encodeURIComponent(d)}">${esc(d)}</a>`,
+    )
+    .join(" &middot; ");
+  return `<p class="tier-text">See it live: scan ${links}</p>`;
+}
+
+function renderProviderBody(provider: MxProviderData): string {
+  return `
+  <p class="rubric-intro">${esc(provider.description)}</p>
+
+  <div class="bd-card">
+    <div class="bd-card-title">What these MX hostnames look like</div>
+    <div class="bd-card-body">
+      <p class="tier-text">When a domain uses ${esc(provider.name)}, its MX records point to hostnames like:</p>
+      <pre class="learn-example"><code>${provider.mxExamples.map(esc).join("\n")}</code></pre>
+      <p class="tier-text">You will see these in a DNS MX lookup: <code>dig MX yourdomain.com</code> or when dmarcheck scans a domain.</p>
+      ${exampleDomains(provider)}
+    </div>
+  </div>
+
+  ${providerContent(provider)}
+
+  <div class="bd-card">
+    <div class="bd-card-title">DMARC and SPF considerations</div>
+    <div class="bd-card-body">
+      ${dmarcContent(provider)}
+    </div>
+  </div>
+
+  <div class="bd-card">
+    <div class="bd-card-title">Other mail providers</div>
+    <div class="bd-card-body">
+      ${providerSiblingLinks(provider.slug)}
+    </div>
+  </div>
+
+  <div class="bd-card">
+    <div class="bd-card-title">Scan a domain using ${esc(provider.name)}</div>
+    <div class="bd-card-body">
+      <form action="/check" method="GET" class="learn-cta-form">
+        <div class="search-box">
+          <input type="text" name="domain" placeholder="Enter a domain to scan" aria-label="Enter a domain" autocapitalize="none" autocorrect="off" spellcheck="false" required>
+          <button type="submit">Scan</button>
+        </div>
+      </form>
+    </div>
+  </div>`;
+}
+
+function providerContent(provider: MxProviderData): string {
+  switch (provider.slug) {
+    case "outlook":
+      return `<div class="bd-card">
+    <div class="bd-card-title">How Microsoft 365 tenant routing works</div>
+    <div class="bd-card-body">
+      <p class="tier-text">Each Microsoft 365 tenant gets a unique MX hostname derived from its initial <code>.onmicrosoft.com</code> domain. For a tenant whose initial domain is <code>contoso.onmicrosoft.com</code>, the MX record will point to <code>contoso-com.mail.protection.outlook.com</code> — the dots in the domain name become hyphens.</p>
+      <p class="tier-text">This hostname is how Exchange Online identifies which tenant should receive the message. The MX hostname is public information — it is visible in any DNS lookup — but it does not expose mailbox names or tenant credentials.</p>
+      <p class="tier-text">Some tenants use the <code>.olc.</code> variant (<code>*.olc.protection.outlook.com</code>) when Outlook.com personal accounts share the same Exchange Online infrastructure. The routing behavior is identical.</p>
+      <p class="tier-text">Microsoft also publishes Autodiscover and SPF records for each tenant. The SPF record at <code>_spf.protection.outlook.com</code> authorizes all Exchange Online sending IPs and must appear in your domain's SPF record as <code>include:spf.protection.outlook.com</code>.</p>
+    </div>
+  </div>`;
+
+    case "google":
+      return `<div class="bd-card">
+    <div class="bd-card-title">How Google Workspace MX priorities work</div>
+    <div class="bd-card-body">
+      <p class="tier-text">Google Workspace requires five MX records with specific priority values. The standard configuration is:</p>
+      <pre class="learn-example"><code>1   ASPMX.L.GOOGLE.COM.
+5   ALT1.ASPMX.L.GOOGLE.COM.
+5   ALT2.ASPMX.L.GOOGLE.COM.
+10  ALT3.ASPMX.L.GOOGLE.COM.
+10  ALT4.ASPMX.L.GOOGLE.COM.</code></pre>
+      <p class="tier-text">The primary record (<code>aspmx.l.google.com</code>, priority 1) handles the majority of inbound traffic. The four <code>alt</code> records at priorities 5 and 10 are fallbacks — sending servers try lower-priority hosts only when higher-priority hosts are unreachable.</p>
+      <p class="tier-text">Unlike Microsoft 365, these MX hostnames are the same for every Google Workspace customer — Google identifies the destination tenant from the SMTP envelope recipient address, not the MX hostname.</p>
+      <p class="tier-text">Google's outbound SPF IP ranges are published via <code>include:_spf.google.com</code>. If you use Google Workspace to send mail, this include must appear in your domain's SPF record.</p>
+    </div>
+  </div>`;
+
+    case "mimecast":
+      return `<div class="bd-card">
+    <div class="bd-card-title">How Mimecast sits in front of your mail platform</div>
+    <div class="bd-card-body">
+      <p class="tier-text">Mimecast is a cloud email security gateway. Inbound mail arrives at Mimecast's MX hostnames first, is filtered for spam and malware, and then forwarded to the actual mailbox platform (typically Microsoft 365 or Google Workspace) on a locked-down delivery path.</p>
+      <p class="tier-text">Mimecast hostnames are regional: US customers use <code>us-smtp-inbound-*.mimecast.com</code>, EU customers use <code>eu-smtp-inbound-*.mimecast.com</code>, and so on. The specific hostname is assigned during account provisioning.</p>
+      <p class="tier-text">Because Mimecast delivers inbound mail to your downstream platform, the downstream platform's MX and SPF records should be locked down — only Mimecast's delivery IPs should be accepted. Mimecast publishes an SPF record (<code>include:spf.mimecast.com</code>) that covers its sending IPs for outbound mail processed through the gateway.</p>
+    </div>
+  </div>`;
+
+    case "proofpoint":
+      return `<div class="bd-card">
+    <div class="bd-card-title">Proofpoint Essentials vs. enterprise (pphosted.com vs. ppe-hosted.com)</div>
+    <div class="bd-card-body">
+      <p class="tier-text">Proofpoint operates two distinct products visible in MX records. The enterprise product uses <code>*.pphosted.com</code> hostnames; Proofpoint Essentials (the SMB offering) uses <code>*.ppe-hosted.com</code> hostnames. The architecture is similar — both are cloud gateways that filter inbound mail before delivering to your downstream platform — but the two product lines have separate infrastructure and support paths.</p>
+      <p class="tier-text">Like Mimecast, Proofpoint deployments route inbound mail through the gateway first. This means the downstream Microsoft 365 or Google Workspace environment typically uses a Proofpoint-provided connector to only accept delivery from Proofpoint's IP ranges — the downstream MX is not advertised publicly.</p>
+      <p class="tier-text">Proofpoint's outbound SPF range is covered by <code>include:pphosted.com</code> for enterprise and specific ranges for Essentials. Check Proofpoint's support documentation for the current include strings for your product tier.</p>
+    </div>
+  </div>`;
+
+    case "fastmail":
+      return `<div class="bd-card">
+    <div class="bd-card-title">Why Fastmail uses messagingengine.com, not fastmail.com</div>
+    <div class="bd-card-body">
+      <p class="tier-text">Fastmail's inbound MX hostnames use the <code>messagingengine.com</code> domain, which is Fastmail's infrastructure domain, not the consumer-facing brand. This is normal — many email providers use a separate operational domain for DNS infrastructure to make hostname rotation easier without affecting the brand domain.</p>
+      <p class="tier-text">A standard Fastmail custom-domain MX configuration uses two records at equal priority:</p>
+      <pre class="learn-example"><code>10  in1-smtp.messagingengine.com.
+20  in2-smtp.messagingengine.com.</code></pre>
+      <p class="tier-text">Fastmail publishes SPF records for its outbound sending infrastructure. When using a custom domain with Fastmail, your SPF record should include <code>include:spf.messagingengine.com</code>. Fastmail supports DKIM signing for custom domains from the account settings panel.</p>
+    </div>
+  </div>`;
+
+    case "zoho":
+      return `<div class="bd-card">
+    <div class="bd-card-title">Zoho Mail MX record setup</div>
+    <div class="bd-card-body">
+      <p class="tier-text">Zoho Mail requires three MX records in a specific priority order:</p>
+      <pre class="learn-example"><code>10  mx.zoho.com.
+20  mx2.zoho.com.
+50  mx3.zoho.com.</code></pre>
+      <p class="tier-text">All three hostnames are shared across all Zoho Mail customers — Zoho identifies the destination account from the SMTP envelope recipient address. The priority ladder means primary delivery goes to <code>mx.zoho.com</code>, with the others as progressively lower-priority fallbacks.</p>
+      <p class="tier-text">Zoho also operates regional infrastructure in the EU and Australia under <code>*.zoho.eu</code> and <code>*.zoho.com.au</code> for data-residency compliance. If a domain uses these regional hostnames it means the account opted into a specific data region during signup.</p>
+      <p class="tier-text">For outbound SPF, Zoho's include string is <code>include:zoho.com</code> (or the appropriate regional variant). Zoho supports DMARC-aligned DKIM signing for custom domains.</p>
+    </div>
+  </div>`;
+
+    case "amazon-ses":
+      return `<div class="bd-card">
+    <div class="bd-card-title">How Amazon SES inbound email processing works</div>
+    <div class="bd-card-body">
+      <p class="tier-text">Amazon SES inbound uses a single MX record per AWS region. The hostname format is <code>inbound-smtp.&lt;region&gt;.amazonaws.com</code>. Common regions:</p>
+      <pre class="learn-example"><code>inbound-smtp.us-east-1.amazonaws.com      # US East (N. Virginia)
+inbound-smtp.us-west-2.amazonaws.com      # US West (Oregon)
+inbound-smtp.eu-west-1.amazonaws.com      # Europe (Ireland)</code></pre>
+      <p class="tier-text">Unlike a hosted mailbox service, SES inbound is a message-routing and processing service. Received messages are delivered to Amazon S3, Lambda, SNS, or WorkMail — the SES account owner configures the routing rules in the AWS Console. There is no built-in mailbox UI; SES inbound is typically used for automated mail processing pipelines, not human inboxes.</p>
+      <p class="tier-text">SES inbound does not affect your outbound mail configuration. For outbound, SES provides dedicated sending IPs whose SPF ranges are published via <code>amazonses.com</code>. DKIM signing for outbound SES uses either Easy DKIM (AWS-managed key rotation) or BYODKIM (bring your own key).</p>
+    </div>
+  </div>`;
+
+    case "cloudflare":
+      return `<div class="bd-card">
+    <div class="bd-card-title">How Cloudflare Email Routing works</div>
+    <div class="bd-card-body">
+      <p class="tier-text">Cloudflare Email Routing is a free service that lets you receive mail at a custom domain and forward it to another inbox (Gmail, Outlook, etc.). It is not a full mailbox — it is a forwarder. Mail sent to <code>you@yourdomain.com</code> is relayed to whichever destination address you configure in the Cloudflare dashboard.</p>
+      <p class="tier-text">When Email Routing is enabled, Cloudflare automatically adds three MX records:</p>
+      <pre class="learn-example"><code>10  route1.mx.cloudflare.net.
+20  route2.mx.cloudflare.net.
+30  route3.mx.cloudflare.net.</code></pre>
+      <p class="tier-text">These records are added automatically when you enable Email Routing in the Cloudflare dashboard — you do not configure them manually. Cloudflare also adds an SPF record (<code>v=spf1 include:_spf.mx.cloudflare.net ~all</code>) to cover its forwarding IPs.</p>
+      <p class="tier-text">Because Cloudflare forwards messages rather than delivering them to a mailbox, the final delivery DMARC check happens at the destination inbox (Gmail, Outlook), not at Cloudflare. Mail forwarded this way may fail DMARC at the destination if the original sender does not allow Cloudflare's forwarding IPs in their SPF or DKIM chain. ARC (Authenticated Received Chain) sealing mitigates this for providers that honor it.</p>
+    </div>
+  </div>`;
+
+    default:
+      return "";
+  }
+}
+
+function dmarcContent(provider: MxProviderData): string {
+  switch (provider.slug) {
+    case "outlook":
+      return `<p class="tier-text">Microsoft 365 handles DMARC evaluation for inbound mail at the Exchange Online layer before the message reaches a mailbox. If the sending domain has a DMARC policy of <code>p=reject</code>, Microsoft 365 will reject or quarantine failing messages according to the policy.</p>
+      <p class="tier-text">For outbound, your SPF record must include <code>include:spf.protection.outlook.com</code> and Exchange Online must be configured as an approved sender. DKIM signing via Microsoft 365 uses the <code>*.domainkey.microsoft.com</code> CNAME chain — add the two CNAME records Microsoft provides in the Microsoft 365 admin center.</p>
+      <p class="tier-text">DMARC aggregate reports (<code>rua=</code>) from domains that receive mail via Exchange Online are sent from Microsoft's report sender address. Check your DMARC report inbox for <code>@microsoft.com</code> aggregate reports if your domain receives mail sent by Microsoft 365 tenants.</p>`;
+
+    case "google":
+      return `<p class="tier-text">Google Workspace enforces DMARC for inbound mail. If the sending domain publishes <code>p=reject</code>, Google will reject failing messages. Google also sends DMARC aggregate reports for mail delivered to Workspace inboxes.</p>
+      <p class="tier-text">For outbound DMARC alignment, add <code>include:_spf.google.com</code> to your SPF record and enable DKIM signing in the Google Admin console (Apps → Google Workspace → Gmail → Authenticate email). Google generates a 2048-bit RSA key by default; the CNAME record is added to your DNS zone.</p>
+      <p class="tier-text">A common pitfall: if you use Google Groups for forwarding and the group re-sends mail externally, DMARC may fail at the final destination because Google does not DKIM-re-sign forwarded mail. Consider disabling external forwarding from groups or using ARC-aware receiving infrastructure.</p>`;
+
+    case "mimecast":
+      return `<p class="tier-text">With a Mimecast gateway, DMARC enforcement for inbound mail happens at Mimecast before the message reaches your platform. Mimecast's DMARC management module lets you configure per-domain policies and view aggregate data — this is separate from the DMARC record in your DNS.</p>
+      <p class="tier-text">For outbound, Mimecast can apply DKIM signatures on behalf of your domain using its own key management infrastructure. You add a CNAME (or TXT) DKIM record that Mimecast provides, then enable signing in the Mimecast console. The signed mail will DMARC-align even if it passes through Mimecast's relay IPs.</p>
+      <p class="tier-text">One nuance: mail delivered inbound by Mimecast to your downstream platform (Microsoft 365, Google) will appear to come from Mimecast's delivery IPs. Your downstream SPF policy should be locked to accept only those IPs. If the downstream SPF is wide open, the gateway provides less isolation than expected.</p>`;
+
+    case "proofpoint":
+      return `<p class="tier-text">Proofpoint Enterprise includes a DMARC reporting module (part of Proofpoint Email Fraud Defense / EFD). It aggregates DMARC rua= reports and provides a dashboard for visibility into senders. If you use Proofpoint, check whether your rua= address is configured to deliver reports to Proofpoint's parsing infrastructure or to a standalone inbox.</p>
+      <p class="tier-text">For outbound DKIM signing, Proofpoint can sign on behalf of your domain as mail passes through the gateway. The DKIM public key is published as a CNAME or TXT record in your DNS zone, pointing to Proofpoint's key infrastructure.</p>
+      <p class="tier-text">SPF: Proofpoint's outbound sending IPs must be included in your SPF record. Use <code>include:pphosted.com</code> for enterprise. Proofpoint Essentials customers should consult the Proofpoint Essentials SPF documentation for the correct include string.</p>`;
+
+    case "fastmail":
+      return `<p class="tier-text">Fastmail supports full DMARC alignment for custom domains. The setup requires: (1) adding <code>include:spf.messagingengine.com</code> to your SPF record to cover Fastmail's outbound IPs, and (2) enabling DKIM signing in Account Settings → Privacy &amp; Security → DKIM, which provides a TXT record to add to your DNS zone.</p>
+      <p class="tier-text">Once both are in place, mail sent via Fastmail will pass both SPF and DKIM checks with alignment to your custom domain, satisfying DMARC. Fastmail enforces DMARC for inbound mail — if a sending domain publishes <code>p=reject</code>, Fastmail will reject failing messages.</p>
+      <p class="tier-text">Fastmail also supports MTA-STS for inbound delivery security. If you publish an MTA-STS policy for your domain, senders that honor MTA-STS will require TLS when delivering to Fastmail's infrastructure.</p>`;
+
+    case "zoho":
+      return `<p class="tier-text">Zoho Mail supports DKIM signing for custom domains through the Zoho Admin Console (Mail Admin → Domains → your domain → Email Authentication). Zoho generates a 2048-bit key and provides a TXT record to add to your DNS zone. Once added, Zoho signs all outbound mail with this key.</p>
+      <p class="tier-text">Add <code>include:zoho.com</code> to your SPF record to cover Zoho's outbound IPs (use <code>include:zoho.eu</code> or <code>include:zoho.com.au</code> for regional accounts). With SPF and DKIM both aligned, a DMARC policy of <code>p=reject</code> will protect your domain from spoofing even for mail transiting through Zoho's infrastructure.</p>
+      <p class="tier-text">Zoho's DMARC report delivery: Zoho sends aggregate DMARC reports for inbound mail received at Zoho inboxes. These reports appear in your <code>rua=</code> inbox and identify senders failing DMARC for your domain's recipients.</p>`;
+
+    case "amazon-ses":
+      return `<p class="tier-text">Amazon SES supports two outbound DKIM approaches. Easy DKIM has AWS generate and rotate 2048-bit RSA keys automatically — you add three CNAME records to your DNS zone that point to AWS key infrastructure. BYODKIM (Bring Your Own DKIM) lets you provide an RSA or Ed25519 private key and manage rotation yourself.</p>
+      <p class="tier-text">For SPF, SES outbound sending IPs are covered by the <code>amazonses.com</code> SPF record. Your domain's SPF record should include this via the MAIL FROM domain that SES assigns (e.g. <code>yourdomain.com.us-east-1.amazonses.com</code>), or use a custom MAIL FROM domain so SPF alignment matches your From: header domain.</p>
+      <p class="tier-text">SES inbound mail processing does not perform DMARC enforcement by default — it delivers the message regardless of the sender's DMARC result and includes the DMARC disposition in the received headers. If you need DMARC-based rejection, implement it in your Lambda or S3 processing pipeline by inspecting the <code>Authentication-Results</code> header.</p>`;
+
+    case "cloudflare":
+      return `<p class="tier-text">Cloudflare Email Routing is a forwarding service, not a mailbox, which creates a specific DMARC complication. When Cloudflare forwards a message, the SMTP envelope sender (MAIL FROM) may or may not be rewritten. If the original sender's DMARC policy is <code>p=reject</code> and the destination inbox (Gmail, Outlook) checks DMARC, the forwarded message may fail because Cloudflare's forwarding IPs are not in the original sender's SPF record and the DKIM signature may break if the message is modified in transit.</p>
+      <p class="tier-text">For your own domain's DMARC, the key question is about outbound mail — what SPF and DKIM records you publish for mail sent from your domain. Cloudflare Email Routing is inbound only; for outbound you use a separate mail service. Your DMARC record at <code>_dmarc.yourdomain.com</code> applies to mail sent by your domain, not to mail forwarded through Cloudflare.</p>
+      <p class="tier-text">Cloudflare adds <code>v=spf1 include:_spf.mx.cloudflare.net ~all</code> to cover its forwarding IPs so that the Cloudflare forwarder appears authorized in SPF. However, this SPF record covers only the forwarding path, not any outbound senders you configure separately.</p>`;
+
+    default:
+      return `<p class="tier-text">Verify your domain's DMARC, SPF, and DKIM records are configured correctly for this provider by scanning your domain above.</p>`;
+  }
+}
+
+export function renderMxHub(): string {
+  const cards = MX_PROVIDERS.map(
+    (p) =>
+      `<li><a href="/mx/${esc(p.slug)}" class="learn-hub-card">
+        <h2>${esc(p.name)}</h2>
+        <p>${esc(p.description)}</p>
+      </a></li>`,
+  ).join("");
+
+  const body = `<main class="breakdown learn">
+  <nav class="report-nav" aria-label="Breadcrumb">
+    <a href="/">${generateCreature("sm")} Home</a>
+    <span class="breadcrumb-sep" aria-hidden="true">&rsaquo;</span>
+    <span class="breadcrumb-current">MX Providers</span>
+  </nav>
+  <h1 class="rubric-title">What does this MX hostname mean?</h1>
+  <p class="rubric-intro">Each email provider uses distinct MX hostnames. If you spotted an unfamiliar hostname in a DNS MX record — in a security tool, a search result, or a dmarcheck scan — these pages explain what it is, who operates it, and what it means for DMARC alignment.</p>
+  <ul class="learn-hub-grid">${cards}</ul>
+  <div class="bd-card">
+    <div class="bd-card-title">Scan a domain</div>
+    <div class="bd-card-body">
+      <form action="/check" method="GET" class="learn-cta-form">
+        <div class="search-box">
+          <input type="text" name="domain" placeholder="Enter a domain to scan" aria-label="Enter a domain" autocapitalize="none" autocorrect="off" spellcheck="false" required>
+          <button type="submit">Scan</button>
+        </div>
+      </form>
+    </div>
+  </div>
+  ${MX_FOOTER}
+</main>`;
+
+  return page({
+    title: "MX record providers — dmarcheck",
+    path: "/mx",
+    description:
+      "What does this MX hostname mean? Identify Microsoft 365, Google Workspace, Mimecast, Proofpoint, Fastmail, Zoho, Amazon SES, and Cloudflare Email Routing from their MX records.",
+    jsonLd: mxHubJsonLd(),
+    body,
+  });
+}
+
+export function renderMxProviderPage(slug: string): string | null {
+  const provider = getMxProvider(slug);
+  if (!provider) return null;
+
+  const body = `<main class="breakdown learn">
+  <nav class="report-nav" aria-label="Breadcrumb">
+    <a href="/">${generateCreature("sm")} Home</a>
+    <span class="breadcrumb-sep" aria-hidden="true">&rsaquo;</span>
+    <a href="/mx">MX Providers</a>
+    <span class="breadcrumb-sep" aria-hidden="true">&rsaquo;</span>
+    <span class="breadcrumb-current">${esc(provider.name)}</span>
+  </nav>
+  <h1 class="rubric-title">${esc(provider.headline)}</h1>
+  ${renderProviderBody(provider)}
+  ${MX_FOOTER}
+</main>`;
+
+  return page({
+    title: `${provider.name} MX records — dmarcheck`,
+    path: `/mx/${provider.slug}`,
+    description: provider.metaDescription,
+    jsonLd: mxJsonLd(provider),
+    body,
+  });
+}

--- a/test/mx-providers.test.ts
+++ b/test/mx-providers.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from "vitest";
+import { lookupMxSlug, MX_PROVIDERS } from "../src/data/mx-providers.js";
+import { app } from "../src/index.js";
+
+describe("lookupMxSlug", () => {
+  it("matches Microsoft 365 protection.outlook.com hostnames", () => {
+    expect(lookupMxSlug("github-com.mail.protection.outlook.com")).toBe(
+      "outlook",
+    );
+    expect(lookupMxSlug("contoso-com.mail.protection.outlook.com")).toBe(
+      "outlook",
+    );
+    expect(lookupMxSlug("contoso-com.olc.protection.outlook.com")).toBe(
+      "outlook",
+    );
+  });
+
+  it("matches Google Workspace hostnames", () => {
+    expect(lookupMxSlug("aspmx.l.google.com")).toBe("google");
+    expect(lookupMxSlug("alt1.aspmx.l.google.com")).toBe("google");
+    expect(lookupMxSlug("alt4.aspmx.l.google.com")).toBe("google");
+    expect(lookupMxSlug("aspmx2.googlemail.com")).toBe("google");
+  });
+
+  it("matches Mimecast hostnames", () => {
+    expect(lookupMxSlug("us-smtp-inbound-1.mimecast.com")).toBe("mimecast");
+    expect(lookupMxSlug("eu-smtp-inbound-2.mimecast.com")).toBe("mimecast");
+  });
+
+  it("matches Proofpoint pphosted.com hostnames", () => {
+    expect(lookupMxSlug("mail.pphosted.com")).toBe("proofpoint");
+    expect(lookupMxSlug("mx-eu.pphosted.com")).toBe("proofpoint");
+  });
+
+  it("matches Proofpoint ppe-hosted.com hostnames", () => {
+    expect(lookupMxSlug("inbound.ppe-hosted.com")).toBe("proofpoint");
+  });
+
+  it("matches Fastmail messagingengine.com hostnames", () => {
+    expect(lookupMxSlug("in1-smtp.messagingengine.com")).toBe("fastmail");
+    expect(lookupMxSlug("in2-smtp.messagingengine.com")).toBe("fastmail");
+  });
+
+  it("matches Zoho Mail hostnames", () => {
+    expect(lookupMxSlug("mx.zoho.com")).toBe("zoho");
+    expect(lookupMxSlug("mx2.zoho.com")).toBe("zoho");
+    expect(lookupMxSlug("mx3.zoho.com")).toBe("zoho");
+  });
+
+  it("matches Amazon SES inbound hostnames", () => {
+    expect(lookupMxSlug("inbound-smtp.us-east-1.amazonaws.com")).toBe(
+      "amazon-ses",
+    );
+    expect(lookupMxSlug("inbound-smtp.eu-west-1.amazonaws.com")).toBe(
+      "amazon-ses",
+    );
+    expect(lookupMxSlug("inbound-smtp.us-west-2.amazonaws.com")).toBe(
+      "amazon-ses",
+    );
+  });
+
+  it("matches Cloudflare Email Routing hostnames", () => {
+    expect(lookupMxSlug("route1.mx.cloudflare.net")).toBe("cloudflare");
+    expect(lookupMxSlug("route2.mx.cloudflare.net")).toBe("cloudflare");
+    expect(lookupMxSlug("route3.mx.cloudflare.net")).toBe("cloudflare");
+  });
+
+  it("is case-insensitive", () => {
+    expect(lookupMxSlug("ASPMX.L.GOOGLE.COM")).toBe("google");
+    expect(lookupMxSlug("GITHUB-COM.MAIL.PROTECTION.OUTLOOK.COM")).toBe(
+      "outlook",
+    );
+  });
+
+  it("strips trailing dot from FQDN", () => {
+    expect(lookupMxSlug("aspmx.l.google.com.")).toBe("google");
+    expect(lookupMxSlug("route1.mx.cloudflare.net.")).toBe("cloudflare");
+  });
+
+  it("returns undefined for unknown hostnames", () => {
+    expect(lookupMxSlug("mail.example.com")).toBeUndefined();
+    expect(lookupMxSlug("mx.unknown-provider.net")).toBeUndefined();
+    expect(lookupMxSlug("")).toBeUndefined();
+  });
+
+  it("does not match partial domain names (no false substring matches)", () => {
+    expect(lookupMxSlug("notgoogle.com")).toBeUndefined();
+    expect(lookupMxSlug("fakeoutlook.com")).toBeUndefined();
+    expect(lookupMxSlug("mimecast.com.attacker.net")).toBeUndefined();
+  });
+});
+
+describe("MX_PROVIDERS data integrity", () => {
+  it("each provider has a unique slug", () => {
+    const slugs = MX_PROVIDERS.map((p) => p.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it("each provider has at least one pattern and one mxExample", () => {
+    for (const p of MX_PROVIDERS) {
+      expect(p.patterns.length).toBeGreaterThan(0);
+      expect(p.mxExamples.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("each provider mxExample matches at least one of its patterns", () => {
+    for (const p of MX_PROVIDERS) {
+      for (const example of p.mxExamples) {
+        const normalized = example.toLowerCase();
+        const matched = p.patterns.some((pat) => pat.test(normalized));
+        expect(matched, `${example} should match a pattern for ${p.slug}`).toBe(
+          true,
+        );
+      }
+    }
+  });
+});
+
+describe("/mx routes", () => {
+  it("GET /mx returns 200 with hub content", async () => {
+    const res = await app.request("/mx");
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("What does this MX hostname mean");
+    expect(html).toContain("/mx/outlook");
+    expect(html).toContain("/mx/google");
+  });
+
+  it("GET /mx/outlook returns 200 with Microsoft 365 content", async () => {
+    const res = await app.request("/mx/outlook");
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("protection.outlook.com");
+    expect(html).toContain("Microsoft 365");
+  });
+
+  it("GET /mx/google returns 200 with Google Workspace content", async () => {
+    const res = await app.request("/mx/google");
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("aspmx.l.google.com");
+    expect(html).toContain("Google Workspace");
+  });
+
+  it("GET /mx/mimecast returns 200", async () => {
+    const res = await app.request("/mx/mimecast");
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("mimecast.com");
+  });
+
+  it("GET /mx/proofpoint returns 200", async () => {
+    const res = await app.request("/mx/proofpoint");
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("pphosted.com");
+  });
+
+  it("GET /mx/fastmail returns 200", async () => {
+    const res = await app.request("/mx/fastmail");
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("messagingengine.com");
+  });
+
+  it("GET /mx/zoho returns 200", async () => {
+    const res = await app.request("/mx/zoho");
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("mx.zoho.com");
+  });
+
+  it("GET /mx/amazon-ses returns 200", async () => {
+    const res = await app.request("/mx/amazon-ses");
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("amazonaws.com");
+  });
+
+  it("GET /mx/cloudflare returns 200", async () => {
+    const res = await app.request("/mx/cloudflare");
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("cloudflare.net");
+  });
+
+  it("GET /mx/unknown-slug returns 404", async () => {
+    const res = await app.request("/mx/not-a-real-provider");
+    expect(res.status).toBe(404);
+  });
+
+  it("all 8 provider slugs return 200", async () => {
+    const slugs = [
+      "outlook",
+      "google",
+      "mimecast",
+      "proofpoint",
+      "fastmail",
+      "zoho",
+      "amazon-ses",
+      "cloudflare",
+    ];
+    for (const slug of slugs) {
+      const res = await app.request(`/mx/${slug}`);
+      expect(res.status, `expected 200 for /mx/${slug}`).toBe(200);
+    }
+  });
+});
+
+describe("/mx sitemap entries", () => {
+  it("sitemap includes /mx hub and all 8 provider pages", async () => {
+    const res = await app.request("/sitemap.xml");
+    const xml = await res.text();
+    expect(xml).toContain("https://dmarc.mx/mx");
+    expect(xml).toContain("https://dmarc.mx/mx/outlook");
+    expect(xml).toContain("https://dmarc.mx/mx/google");
+    expect(xml).toContain("https://dmarc.mx/mx/mimecast");
+    expect(xml).toContain("https://dmarc.mx/mx/proofpoint");
+    expect(xml).toContain("https://dmarc.mx/mx/fastmail");
+    expect(xml).toContain("https://dmarc.mx/mx/zoho");
+    expect(xml).toContain("https://dmarc.mx/mx/amazon-ses");
+    expect(xml).toContain("https://dmarc.mx/mx/cloudflare");
+  });
+});


### PR DESCRIPTION
## Summary

- **New `src/data/mx-providers.ts`**: `MX_PROVIDERS` registry for 8 providers (outlook, google, mimecast, proofpoint, fastmail, zoho, amazon-ses, cloudflare) with `lookupMxSlug()` and `getMxProvider()` helpers
- **New `src/views/mx.ts`**: `renderMxHub()` hub page + `renderMxProviderPage(slug)` individual pages, each with TechArticle + BreadcrumbList JSON-LD, unique deep-dive content per provider, DMARC/SPF guidance, and sibling cross-links
- **Modified `src/views/html.ts`**: `renderMxCard()` now calls `lookupMxSlug()` and renders "What is this MX? →" links to `/mx/<slug>` in the MX card on scan results
- **Modified `src/index.ts`**: `GET /mx` and `GET /mx/:slug` routes (404 for unknown slugs) + 9 sitemap entries at priorities 0.6–0.8
- **New `test/mx-providers.test.ts`**: 224-line test suite covering pattern matching, data integrity, route responses (all 8 slugs return 200, unknown returns 404), and sitemap entries

Closes #364

## Test plan

- [ ] `npm test` — all 1077+ tests pass (4 new describe blocks in `test/mx-providers.test.ts`)
- [ ] `npm run lint` — clean
- [ ] `npm run typecheck` — clean
- [ ] `GET /mx` returns 200 with hub content including "What does this MX hostname mean"
- [ ] `GET /mx/outlook` returns 200 with protection.outlook.com content
- [ ] `GET /mx/google` returns 200 with aspmx.l.google.com content
- [ ] `GET /mx/not-a-real-provider` returns 404
- [ ] `/sitemap.xml` contains all 9 `/mx/*` URLs
- [ ] Scan a domain using Microsoft 365 — MX card shows "What is this MX? →" link to `/mx/outlook`

https://claude.ai/code/session_01CnbNthXu35yeCa6PrvcVM2

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnbNthXu35yeCa6PrvcVM2)_