### PR TITLE
chore(ci): switch CodeQL from default to advanced setup

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,14 @@
+name: dmarcheck CodeQL config
+
+# Exclude test files from CodeQL analysis.
+#
+# Why: tests use String.includes() on warning-message strings as assertions
+# (e.g. expect(v.message.includes("example.com")).toBe(true)). The
+# js/incomplete-url-substring-sanitization rule fires on these as if they were
+# URL sanitization gates, but they have no URL flow, no fetch, and no auth
+# boundary — the .includes() runs on the asserted output, not user input.
+# Tests are not shipped to the Worker runtime, so the security blast radius
+# of excluding them is zero.
+paths-ignore:
+  - test/**
+  - "**/*.test.ts"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly full scan, Monday 12:23 UTC. Keeps coverage for branches that
+    # aren't being actively PR'd.
+    - cron: "23 12 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: github/codeql-action/init@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3.36.0
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
+      - uses: github/codeql-action/analyze@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3.36.0
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/codeql.yml` (advanced setup) and `.github/codeql/codeql-config.yml` excluding `test/**` from analysis.
- Replaces the repo-Settings default setup so the path-ignore config can be expressed in version control.

## Why
The `js/incomplete-url-substring-sanitization` query has been firing on test assertions like `expect(v.message.includes("example.com")).toBe(true)` — no URL flow, no fetch, no auth boundary, just `.includes()` on an asserted output string. Four such alerts (#8, #9, #12, #13) were dismissed as false positives on 2026-05-24; this PR prevents the pattern from re-surfacing on every test edit.

## Cutover sequence (read before merging)
1. **Disable default setup** in repo Settings → Code security → "Default" → switch off, or via API:
   ```
   gh api -X PATCH /repos/schmug/dmarcheck/code-scanning/default-setup -f state=not-configured
   ```
2. Merge this PR.
3. The new workflow runs on push to `main` and produces two checks named `Analyze (actions)` and `Analyze (javascript-typescript)` — matching the previous default-setup job names so no branch-protection update is needed.

If default setup is left enabled when this merges, the advanced workflow will error with "CodeQL analyses from advanced configurations cannot be processed when the default setup is enabled".

## What's covered / not covered
- Languages: `actions` and `javascript-typescript` (the latter covers both JS and TS in modern CodeQL — same coverage as before).
- Triggers: PR + push to `main` + weekly cron (Mon 12:23 UTC).
- Excluded: `test/**` and `**/*.test.ts`. Source code (including `mta-sts-worker/`) still analyzed.

## Test plan
- [ ] Disable default setup before merging
- [ ] After merge, verify `Analyze (actions)` and `Analyze (javascript-typescript)` checks run on `main`
- [ ] Open a throwaway PR that adds a `.includes("example.com")` assertion in a test file → confirm no CodeQL alert is raised
- [ ] Confirm CodeQL still raises alerts for issues outside `test/**`