### PR TITLE
fix: redirect mta-sts subdomain root to dmarc.mx instead of 404

### DIFF
--- a/mta-sts-worker/src/index.ts
+++ b/mta-sts-worker/src/index.ts
@@ -20,6 +20,6 @@ export default {
       });
     }
 
-    return new Response("Not found", { status: 404 });
+    return Response.redirect("https://dmarc.mx/", 301);
   },
 };


### PR DESCRIPTION
## Summary

- Replaces the catch-all `404 Not found` in `mta-sts-worker/src/index.ts` with a `301` redirect to `https://dmarc.mx/`
- Any path other than `/.well-known/mta-sts.txt` now redirects instead of returning a dead 404
- Cleans up the GSC "Not found (404)" entry for `https://mta-sts.dmarc.mx/`

Closes #363

## Test plan

- [ ] `curl -I https://mta-sts.dmarc.mx/` returns `301` with `Location: https://dmarc.mx/`
- [ ] `curl -I https://mta-sts.dmarc.mx/.well-known/mta-sts.txt` still returns `200` with the policy body unchanged
- [ ] Main test suite: 1066 passing, 0 new failures (1 pre-existing network-dependent integration test fails in this environment — unrelated to this change)
- [ ] `npm run lint`: clean
- [ ] `npm run typecheck`: clean

## Deferred follow-ups

None — scope is exactly one line.

https://claude.ai/code/session_01LwHpGrjYRwBmyoMR51JAXM

---
_Generated by [Claude Code](https://claude.ai/code/session_01LwHpGrjYRwBmyoMR51JAXM)_