### PR TITLE
🎨 Palette: Use inline wizard for empty state CTA

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,7 @@
 ## 2024-05-19 - Actionable Empty States
 **Learning:** Generic empty states ("No X found") create dead ends for users. Providing a clear "Next Step" or CTA directly inside the empty state message drastically improves usability.
 **Action:** When creating or reviewing list/table empty states, ensure the text explicitly tells the user *how* to populate the list or *why* it's empty.
+
+## 2025-05-19 - Inline Workflows for Empty States
+**Learning:** Forcing users to navigate to a new page from an empty state can break flow and feel disjointed.
+**Action:** When empty states provide a CTA, prefer triggering inline components (like modals or wizards) over full page navigations to reduce friction.

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -1675,7 +1675,7 @@ export function renderDomainPanel({
 </div>`
       : `<div class="empty-state">
   <p>No domains yet. Add your first domain to start monitoring.</p>
-  <a href="/dashboard/domain/add" class="btn">Add Domain</a>
+  <button type="button" class="btn" data-wizard-open>Add Domain</button>
 </div>`;
   } else {
     let rows = "";


### PR DESCRIPTION
### 💡 What
Changed the "Add Domain" call-to-action in the dashboard's empty state from a standard anchor link that navigates to a new page to a button that triggers the inline add-domain wizard modal.

### 🎯 Why
When a user accesses the dashboard and has no monitored domains (or their filter returns no results), they are presented with an "empty state". The previous "Add Domain" link directed users to the `/dashboard/domain/add` page. However, there is a built-in wizard on the dashboard (triggered by buttons with the `data-wizard-open` attribute) that provides a much smoother, modal-based experience for adding a domain without leaving the current context. Using a standard link in the empty state forced a page navigation, which was a missed opportunity to use the existing, more integrated wizard component. This change aligns the empty state CTA with the primary "Add domain" button in the dashboard header, providing a consistent and frictionless experience for new users setting up their first domain.

### 📸 Before/After
*(Visual change verified in local playwright tests)*
- The CTA is visually identical but its behavior changes from a page navigation to opening the modal.

### ♿ Accessibility
This change ensures that all "Add domain" actions in the dashboard view rely on the same interaction pattern. The button retains its visual styling but appropriately uses the `<button type="button">` semantic element instead of an anchor (`<a>`), properly indicating to screen readers that it performs an in-page action rather than a navigation.

---
*PR created automatically by Jules for task [8972586108524896012](https://jules.google.com/task/8972586108524896012) started by @schmug*