### PR TITLE
fix: style Revoke API key button as btn-danger

### DIFF
--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -2956,7 +2956,7 @@ export function renderApiKeysPage({
           ? ""
           : `<form method="POST" action="/dashboard/settings/api-keys/revoke" style="display:inline" onsubmit="return confirm('Revoke this key? Requests using it will start failing.');">
               <input type="hidden" name="id" value="${esc(k.id)}">
-              <button type="submit" class="btn btn-secondary" style="padding:0.25rem 0.6rem;font-size:0.8125rem" aria-label="Revoke API key ${labelName}">Revoke</button>
+              <button type="submit" class="btn btn-danger" style="padding:0.25rem 0.6rem;font-size:0.8125rem" aria-label="Revoke API key ${labelName}">Revoke</button>
             </form>`;
         return `<tr>
   <td>${name}</td>


### PR DESCRIPTION
## Summary
- Swaps the Revoke button class from `btn-secondary` to `btn-danger` in `renderApiKeysPage` (`src/views/dashboard.ts`)
- Destructive-action styling now consistent with the Delete domain button
- No logic, confirm dialog, aria-label, or form target changes

Closes #373

## Test plan
- [ ] `npm test` passes
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] Revoke button renders with red `.btn-danger` style (matches Delete domain button)
- [ ] `aria-label`, confirm dialog, and form POST target are unchanged

https://claude.ai/code/session_015hLPrZtAn7ixmbJamLgTee

---
_Generated by [Claude Code](https://claude.ai/code/session_015hLPrZtAn7ixmbJamLgTee)_