### PR TITLE
fix: style Revoke API key button as btn-danger

### DIFF
--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -2956,7 +2956,7 @@ export function renderApiKeysPage({
           ? ""
           : `<form method="POST" action="/dashboard/settings/api-keys/revoke" style="display:inline" onsubmit="return confirm('Revoke this key? Requests using it will start failing.');">
               <input type="hidden" name="id" value="${esc(k.id)}">
-              <button type="submit" class="btn btn-secondary" style="padding:0.25rem 0.6rem;font-size:0.8125rem" aria-label="Revoke API key ${labelName}">Revoke</button>
+              <button type="submit" class="btn btn-danger" style="padding:0.25rem 0.6rem;font-size:0.8125rem" aria-label="Revoke API key ${labelName}">Revoke</button>
             </form>`;
         return `<tr>
   <td>${name}</td>


### PR DESCRIPTION
## Summary

- Swaps `btn-secondary` → `btn-danger` on the Revoke button in `renderApiKeysPage` (`src/views/dashboard.ts:2959`)
- Revoke now renders with `var(--clr-fail)` background and `opacity: 0.85` hover, matching the existing Delete domain button

Closes #373

## Test plan

- [x] `npm run lint` — clean (138 files, no fixes applied)
- [x] `npm run typecheck` — clean
- [x] `npm test` — 1072 passing, 1 pre-existing integration test failing (live network call to dmarc.mx; unrelated to this change)
- [ ] Manual: visit `/dashboard/settings/api-keys`, confirm Revoke button is red; confirm aria-label, confirm dialog, and form POST target are unchanged

## Deferred follow-ups

None — this is a single-line style fix with no deferred items.

https://claude.ai/code/session_01J5RxKTJZ5pr7KvUaxyXb9f

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5RxKTJZ5pr7KvUaxyXb9f)_