### PR TITLE
⚡ Bolt: [performance improvement] Replace .reduce() with simple loop in scoring logic

### DIFF
--- a/src/shared/scoring.ts
+++ b/src/shared/scoring.ts
@@ -50,6 +50,16 @@ export interface GradeBreakdown {
   protocolSummaries: Record<string, { status: Status; summary: string }>;
 }
 
+// ⚡ Bolt Optimization: Use a simple loop instead of .reduce()
+// Avoids function creation overhead and reduces GC pressure on a hot path.
+function sumEffects(factors: ScoringFactor[]): number {
+  let sum = 0;
+  for (let i = 0; i < factors.length; i++) {
+    sum += factors[i].effect;
+  }
+  return sum;
+}
+
 // ── Single decision engine ─────────────────────────────────
 
 interface ScoringResult {
@@ -133,7 +143,7 @@ function resolveScoring(protocols: Protocols): ScoringResult {
       ...dkimFactors(dkim),
       ...dmarcFactors(dmarc),
     ];
-    const modifier = factors.reduce((sum, f) => sum + f.effect, 0);
+    const modifier = sumEffects(factors);
     const pctNote = pct < 10 ? ` (pct=${pct}% — effectively quarantine)` : "";
     return {
       grade: applyModifier("C", modifier),
@@ -162,7 +172,7 @@ function resolveScoring(protocols: Protocols): ScoringResult {
         ...dkimFactors(dkim),
         ...dmarcFactors(dmarc),
       ];
-      const modifier = factors.reduce((sum, f) => sum + f.effect, 0);
+      const modifier = sumEffects(factors);
       return {
         grade: "A+",
         tier: "A+",
@@ -182,7 +192,7 @@ function resolveScoring(protocols: Protocols): ScoringResult {
         ...dmarcFactors(dmarc),
         ...mtaStsFactors(mta_sts),
       ];
-      const modifier = factors.reduce((sum, f) => sum + f.effect, 0);
+      const modifier = sumEffects(factors);
       return {
         grade: applyModifier("A", modifier),
         tier: "A",
@@ -216,7 +226,7 @@ function resolveScoring(protocols: Protocols): ScoringResult {
         effect: +1,
       });
     }
-    const modifier = factors.reduce((sum, f) => sum + f.effect, 0);
+    const modifier = sumEffects(factors);
     return {
       grade: applyModifier("B", modifier),
       tier: "B",
@@ -233,7 +243,7 @@ function resolveScoring(protocols: Protocols): ScoringResult {
     ...dkimFactors(dkim),
     ...dmarcFactors(dmarc),
   ];
-  const modifier = factors.reduce((sum, f) => sum + f.effect, 0);
+  const modifier = sumEffects(factors);
   return {
     grade: applyModifier("C", modifier),
     tier: "C",


### PR DESCRIPTION
Replaces `Array.prototype.reduce()` calls with a dedicated `sumEffects` function utilizing a standard `for` loop in `src/shared/scoring.ts`. This avoids the overhead of inline anonymous function creation and multiple callback executions, which reduces GC pressure and CPU cycles on the hot path for computing scores.

💡 What: Replaced 5 instances of `.reduce()` with a simple loop in scoring logic.
🎯 Why: Using `.reduce()` allocates new closures and introduces function call overhead that can add up on hot paths (e.g., bulk scans).
📊 Impact: Minor performance boost on high-traffic or bulk-processing paths by reducing memory allocations and GC pressure.
🔬 Measurement: Verified with `pnpm lint` and `pnpm test`. Logic is identical and tests pass smoothly.

---
*PR created automatically by Jules for task [1762203932160187311](https://jules.google.com/task/1762203932160187311) started by @schmug*