### PR TITLE
security: webhook SSRF fix + LLM security-review skills & threat model

### DIFF
--- a/.claude/skills/threat-model/SKILL.md
+++ b/.claude/skills/threat-model/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: threat-model
+description: >-
+  Build a threat model for a target codebase and write THREAT_MODEL.md. Two
+  modes: "bootstrap" derives a threat model from the code plus past
+  vulnerabilities (git history, CVEs, issue tracker) with no owner present;
+  "interview" walks an application owner through the four-question framework.
+  Both write THREAT_MODEL.md in the shared schema (schema.md). Use when asked
+  to "threat model", "build a threat model", "map the attack surface", or
+  "what should we be worried about in this codebase". Read-only — never builds,
+  runs, or fetches the target's live deployment. Adapted for dmarcheck (a
+  TypeScript Cloudflare Worker) from anthropics/defending-code-reference-harness.
+argument-hint: "[bootstrap|interview] <target-dir> [--vulns <file>] [--depth recon|full]"
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  - Write
+  - Task
+  - AskUserQuestion
+  - Bash(git:*)
+  - Bash(gh api:*)
+  - Bash(find:*)
+  - Bash(ls:*)
+---
+
+# threat-model
+
+A threat model answers **"what could go wrong with this system, who would do
+it, and what should we do about it?"** independently of whether any specific
+bug has been found yet. It is the map; vulnerability discovery is the metal
+detector. A good threat model tells `/vuln-scan` where to look and tells
+`/vuln-triage` which findings matter.
+
+**Litmus test:** if patching one line of code makes an entry disappear, it was
+a *vulnerability*, not a *threat*. A threat ("attacker exfiltrates another
+tenant's scan history via a missing ownership check") still stands after every
+known bug is fixed; a vulnerability ("`src/db/scans.ts:88` forgets the
+`user_id` predicate") does not. This skill produces threats. Vulnerabilities
+appear only as **evidence** that raises a threat's likelihood.
+
+**Invocation:** `/threat-model [bootstrap|interview] <target-dir> [flags]`
+
+---
+
+## Step 0 — Safety preamble (always runs first)
+
+This skill performs **static analysis only**. It reads source, git history,
+and any vulnerability reports you supply, and writes one output file
+(`<target-dir>/THREAT_MODEL.md`). It does **not** build, execute, fuzz, or
+modify the target, and does **not** make network requests against the target's
+live deployment (dmarc.mx or any other host).
+
+Before proceeding, confirm and state in your first response:
+
+1. The target directory exists and is a local checkout you can read.
+2. You will not execute any code from the target directory.
+3. If asked to "fetch CVEs", you will query only public advisory sources
+   (GitHub Security Advisories via `gh api`, the project's own issue tracker)
+   and never the target's live deployment.
+
+The Bash tool is permitted **only** for `git` (history mining), `find`/`ls`
+(layout), and `gh api` (public advisory lookup). The same restriction applies
+to every subagent you spawn — pass it verbatim in each prompt.
+
+---
+
+## Step 1 — Route to a mode
+
+Parse `$ARGUMENTS`:
+
+| First token | Route to |
+|---|---|
+| `bootstrap` | Derive from code + history (below). The default for an existing codebase. |
+| `interview` | Walk an owner through the four questions (below). |
+| empty / other | Ask: **"Is someone who owns or built this system available to answer questions in this session?"** No → `bootstrap`. Yes → `interview` (or `bootstrap` first, then refine with them). |
+
+Both modes write the same artifact (`THREAT_MODEL.md`, schema in `schema.md`)
+so downstream consumers (`/vuln-scan`, `/vuln-triage`) don't need to know which
+mode produced it. **Read `schema.md` immediately before you write the file.**
+
+---
+
+## Bootstrap mode (code + history)
+
+Five stages: research swarm → synthesize sections 1-3 + vuln table →
+generalize vulns into threat classes → STRIDE gap-fill → emit. Read-only and
+language-agnostic.
+
+### Inputs
+
+- `<target-dir>` (required): local checkout.
+- `--vulns <path>` (optional): past vulnerabilities — newline CVE/GHSA IDs, a
+  CSV (`id,title,component,description`), a markdown pentest report, or a JSON
+  array of `{id, description}`. If absent, the History miner + Advisory fetcher
+  cover the same ground from git history and public advisories.
+- `--depth recon|full` (optional, default `full`): `recon` runs stages 1-2
+  only (fast context-building); still write all sections but leave sections 4,
+  5, 8 as headers with a "run with --depth full to populate" note in section 6.
+
+### Stage 1 — Research swarm
+
+Gather everything needed for sections 1-3 and the vuln table, in parallel.
+Spawn the agents below **in a single batch** with the Task tool
+(`subagent_type: "general-purpose"`). Each gets a narrow brief, the absolute
+path to `<target-dir>`, and the read-only restriction verbatim. On a small
+target (<50 source files) or `--depth recon`, run the briefs yourself
+sequentially instead.
+
+| Agent | Brief | Returns |
+|---|---|---|
+| **Docs reader** | Read `README*`, `SECURITY.md`, `CHANGELOG*` / GitHub Releases, `CLAUDE.md` (and any `src/**/CLAUDE.md`), top-level `docs/`, and `package.json` / `wrangler.toml`. Summarize what the project is, who uses it, where it runs, and any security claims or invariants it documents. | Prose system description; list of self-documented security invariants. |
+| **Surface mapper** | Grep the source for entry-point signatures (table below). For each hit name the surface, the `file:function`, and what crosses it. Bound it: skip `node_modules/`, generated code, test fixtures; cap ~5 hits per surface row. | Section 3 candidate rows: `{entry_point, description, trust_boundary, file_refs}`. |
+| **Infra reader** | Read `wrangler.toml`, `.github/workflows/*`, `.github/dependabot.yml`, CODEOWNERS, and any binding/secret declarations (D1, KV, R2, secrets). Name (a) what identity/bindings the Worker runs with and what they reach, (b) any grant managed outside this tree, (c) CI trigger/permission posture. | Section 3 infra rows + section 4 candidate rows where the config itself is the finding. |
+| **Asset finder** | Identify what the code protects or produces: sensitive data (API keys, session tokens, Stripe customer/subscription data, user emails, scan history), integrity of grades/results, service availability, and downstream consumers (API clients, agents). | Section 2 candidate rows: `{asset, description, sensitivity}`. |
+| **History miner** | Derive 6-10 commit-message keywords for this stack (web service → `injection SSRF IDOR auth bypass redirect XSS escape secret signature verify`) on top of the base `CVE security vuln fix exploit`. Then `git -C <target-dir> log --all -i --grep='<base ∪ derived, \|-joined>' --oneline` and read the full message + diff of each hit. | Vuln rows: `{id (commit hash), title, component, class, vector}`. |
+| **Advisory fetcher** | If `git -C <target-dir> remote get-url origin` is GitHub and `gh` is on PATH: `gh api /repos/{owner}/{repo}/security-advisories`. Else return "no public advisory source". | Vuln rows: `{id (CVE/GHSA), title, component, class, vector}`. |
+| **Vuln-file parser** | Only if `--vulns <path>` was given. Parse into normalized rows. | Vuln rows: `{id, title, component, class, vector}`. |
+
+**Surface-mapper grep targets** (pass this table; treat "Look for" as a seed,
+extend with the framework's idioms — here Hono + Cloudflare Workers + D1):
+
+| Surface | Look for |
+|---|---|
+| HTTP routes | Hono `app.get/post/...`, `.route(`, middleware registration, content negotiation |
+| Auth / session | JWT verify, bearer/API-key checks, session cookies, `middleware.ts`, AuthKit/Access |
+| Outbound fetch (SSRF) | `fetch(` to user-influenced hosts; MTA-STS / security-txt / DNS lookups; redirect mode |
+| DB / query | D1 `.prepare(`, `.bind(`, raw SQL string building, per-user scoping predicates |
+| Signature verify | Stripe webhook signature, HMAC (`shared/hmac.ts`), webhook delivery signing |
+| HTML output | template-literal HTML in `src/views/`, `esc()` usage, `data-*` vs inline `<script>` |
+| Input validation | `normalizeDomain`, `parseSelectors`, regex allowlists, query/path param parsing |
+| Rate limit / cache | `rate-limit.ts`, Cache API keys, cache poisoning vectors |
+| Secrets / config | `env.ts`, `wrangler.toml` vars/secrets, tokens in logs or error bodies |
+| Supply chain | `package-lock.json`, pinned GitHub Actions SHAs, `curl \| sh` in scripts |
+
+Collect each agent's structured return; synthesize in Stage 2.
+
+### Stage 2 — Synthesize
+
+This runs in the orchestrator (the join), not a subagent.
+
+- **Section 1 — System context.** From the Docs reader + your glance at the
+  tree: what it is, language, rough size, who deploys/embeds it, where it runs.
+- **Section 2 — Assets.** Dedupe the Asset finder's rows, fill obvious gaps,
+  assign `sensitivity`.
+- **Section 3 — Entry points & trust boundaries.** Merge Surface mapper +
+  Infra reader rows. Name each trust boundary ("unauth HTTP → application
+  logic", "authenticated session → another user's data", "Worker → upstream DNS
+  resolver"). For each, list which section-2 assets are reachable. **Every row
+  here must get at least one threat in Stage 3 or 4** — the coverage invariant.
+- **Vuln working table.** Concatenate History miner + Advisory fetcher +
+  Vuln-file parser rows. Dedupe by `id`. For each, decide which section-3 entry
+  point it traversed and confirm by reading the source. If a vuln's entry point
+  isn't in section 3, the Surface mapper missed one — add it. This table stays
+  in working notes; it becomes the `evidence` column in Stage 3.
+
+### Stage 3 — Generalize: vulns → threats
+
+- **Cluster** the vuln table by `(entry point, bug class, asset reached)`. Each
+  cluster becomes **one** candidate threat. Apply the litmus test: would the
+  threat statement still be true after every listed evidence item is patched?
+  If not, zoom out.
+- **Variant scan** (raises likelihood): grep for siblings — code paths with the
+  same shape that weren't in the vuln list (other routes calling the same
+  unsafe helper, other D1 queries missing the user predicate, other `fetch`
+  calls without the redirect guard). More siblings → higher likelihood. Keep
+  locations in working notes (they seed `/vuln-scan`); do **not** put
+  `file:func` in the `evidence` cell — evidence is confirmed past vulns only.
+- **Score** each cluster: `actor`, `impact`, `likelihood` (≥1 confirmed past
+  vuln in this exact surface → at least `likely`; public exploit →
+  `almost_certain`), `controls` (grep for mitigations: input validation, output
+  escaping, parameterized D1 binds, auth middleware, redirect: manual, rate
+  limiting), `status`. Also note one **class-level** `recommended_mitigation`
+  per cluster (working notes → section 8). Write each cluster as a section-4 row.
+
+### Stage 4 — Gap-fill (what past vulns can't show)
+
+For **every section-3 entry point with no section-4 row yet**, walk STRIDE and
+add the plausible ones:
+
+| | Could an attacker… |
+|---|---|
+| Spoofing | …pretend to be a trusted source (forged webhook, spoofed JWT/session)? |
+| Tampering | …modify data in transit or at rest (grade tampering, cache poisoning)? |
+| Repudiation | …act without attributable logs? |
+| Info disclosure | …read data they shouldn't (another tenant's scans, secrets in errors)? |
+| DoS | …exhaust a resource (ReDoS, unbounded fan-out, expensive DNS)? |
+| Elevation | …gain more privilege (free→paid, user→admin, anon→authed)? |
+
+Also re-walk entry points that **do** have rows — is the existing threat the
+only one live? Gap-fill threats have empty `evidence`; score likelihood from
+technique prevalence and reachability. **The final section-4 table must contain
+at least one empty-evidence row**, or this stage didn't run. Record ruled-out
+threats in section 5 with reasons.
+
+### Stage 5 — Emit
+
+**Coverage check first:** every section-3 entry point must appear in at least
+one section-4 `surface` cell (text match). Any gap means Stage 4 was
+incomplete — fix it now. Then sort section 4 by (impact desc, likelihood desc)
+and assign `id` = `T1, T2, …`.
+
+Populate section 6 (open questions the code couldn't answer — deployment
+context, intended actors, controls you couldn't verify) and section 8
+(recommended class-level mitigations from Stage-3 notes: one row per control,
+`threat_ids` it covers, `closes_class`, `effort`).
+
+**Read `schema.md` now**, then write `<target-dir>/THREAT_MODEL.md` conforming
+to it. Set section 7 provenance:
+
+```
+- mode: bootstrap
+- date: <today>
+- target: <target-dir> @ <git rev-parse --short HEAD or "not a git repo">
+- inputs: <--vulns path, or "git-log + advisories mined">
+- owner: unset
+```
+
+### Hand back
+
+1. Path to the file.
+2. Top 5 threats (id, threat, impact × likelihood).
+3. Count of threats with evidence vs without (shows gap-fill ran).
+4. Sibling locations from the variant scan, as leads for `/vuln-scan`.
+5. Top 3 recommended mitigations (by closes_class, then effort asc).
+6. Section-6 open questions, framed as "ask the owner".
+
+---
+
+## Interview mode (owner present)
+
+Four-question framework, conversational, multi-turn via AskUserQuestion. Use
+when the risk lives in business logic the code doesn't show, or for a design
+review. Best paired *after* a bootstrap pass (`--seed THREAT_MODEL.md`) so the
+owner refines a code-grounded draft instead of starting cold.
+
+| Q | Question | Fills |
+|---|---|---|
+| Q1 | What are we working on? | section 1 context, section 2 assets, section 3 entry points |
+| Q2 | What can go wrong? | section 4 threat rows (id, threat, actor, surface, asset) |
+| Q3 | What are we going to do about it? | section 4 impact/likelihood/status/controls; section 5; section 8 |
+| Q4 | Did we do a good job? | validate ranking, coverage check, section 6 open questions |
+
+Ask one question at a time; record answers as a `context` dict echoed into the
+output. Write the same `THREAT_MODEL.md` schema, provenance `mode: interview`,
+owner = their name. After writing, print the path, top 5 threats, and any owner
+statements you could not verify in code (these seed follow-up code review).
+
+---
+
+## Constraints
+
+- **Never execute target code.** No `npm run`, no `wrangler`, no `fetch`
+  against dmarc.mx, no builds. Static reasoning only.
+- **Stay in `<target-dir>`.** Don't follow symlinks or `..` out of it.
+- This skill produces **threats**, not verdicts on specific bugs. For
+  candidate vulnerabilities, hand off to `/vuln-scan <target-dir>`.
+
+## Provenance
+
+Adapted from `anthropics/defending-code-reference-harness`
+(`.claude/skills/threat-model/`). The C/C++/ASan pipeline and the
+`checkpoint.py` resume machinery are dropped — for a ~80-file TS Worker the
+swarm fits in one pass. The five-stage bootstrap, STRIDE gap-fill, litmus test,
+and `schema.md` contract are preserved; the surface-mapper grep targets are
+re-pointed at Hono / Cloudflare Workers / D1 idioms.

--- a/.claude/skills/threat-model/schema.md
+++ b/.claude/skills/threat-model/schema.md
@@ -1,0 +1,180 @@
+# THREAT_MODEL.md schema
+
+Both `/threat-model bootstrap` and `/threat-model interview` write this file to
+`<target-dir>/THREAT_MODEL.md`. The format is markdown so humans can read and
+edit it, but the section headings, table columns, and enum values below are a
+contract: keep the headings and column order exactly as shown so downstream
+tooling (`/vuln-scan`, `/vuln-triage`) can parse them with regex.
+
+---
+
+## Required sections, in order
+
+```markdown
+# Threat Model: <system name>
+
+## 1. System context
+
+## 2. Assets
+
+## 3. Entry points & trust boundaries
+
+## 4. Threats
+
+## 5. Deprioritized
+
+## 6. Open questions
+
+## 7. Provenance
+
+## 8. Recommended mitigations
+```
+
+A consumer that only needs the threat table can regex for `^## 4\. Threats$`
+and read until the next `^## `. Section 8 is optional and additive.
+
+---
+
+## Section contents
+
+### 1. System context
+
+One to three paragraphs of prose: what the system is, what it does, who uses
+it, where it runs. No table.
+
+### 2. Assets
+
+Markdown table. One row per thing worth protecting.
+
+| asset | description | sensitivity |
+|---|---|---|
+
+`sensitivity` ∈ {`low`, `medium`, `high`, `critical`}.
+
+### 3. Entry points & trust boundaries
+
+Markdown table. One row per place untrusted input enters the system or
+privilege level changes.
+
+| entry_point | description | trust_boundary | reachable_assets |
+|---|---|---|---|
+
+`trust_boundary` is free text naming the crossing (e.g. "unauth HTTP →
+application logic", "authenticated session → another user's data", "Worker →
+upstream DNS/HTTP fetch").
+`reachable_assets` is a comma-separated list of asset names from section 2.
+
+### 4. Threats
+
+Markdown table. **This is the threat model proper.** One row per
+actor-wants-outcome pair, at the abstraction level where it survives a patch.
+
+| id | threat | actor | surface | asset | impact | likelihood | status | controls | evidence |
+|---|---|---|---|---|---|---|---|---|---|
+
+- `id`: `T1`, `T2`, … Stable across edits; do not renumber when rows are
+  removed.
+- `threat`: one sentence, active voice, names the outcome. "Cross-tenant scan
+  history disclosure via missing ownership check", not "missing user_id in
+  scans.ts query".
+- `actor` ∈ {`remote_unauth`, `remote_auth`, `adjacent_network`,
+  `local_user`, `local_admin`, `supply_chain`, `insider`}.
+- `surface`: which entry point(s) from section 3 this threat traverses.
+- `asset`: which asset(s) from section 2 this threat compromises.
+- `impact` ∈ {`low`, `medium`, `high`, `critical`, `existential`}.
+- `likelihood` ∈ {`very_rare`, `rare`, `possible`, `likely`, `almost_certain`}.
+- `status` ∈ {`unmitigated`, `partially_mitigated`, `mitigated`, `risk_accepted`}.
+- `controls`: current mitigations, or `none`.
+- `evidence`: CVE/GHSA IDs, issue links, pentest finding IDs, or git commit
+  hashes that **instantiate** this threat. May be empty. **Evidence raises
+  likelihood; it is not the threat.**
+
+Sort by (impact, likelihood) descending so the top rows are the priorities.
+
+### 5. Deprioritized
+
+| threat | reason |
+|---|---|
+
+Common reasons: out of scope, actor not in threat model, asset not present,
+risk accepted by owner.
+
+### 6. Open questions
+
+Bullet list. For `bootstrap`, questions for a human owner; for `interview`,
+owner claims not verifiable in code.
+
+### 7. Provenance
+
+```markdown
+- mode: interview | bootstrap | bootstrap-then-interview
+- date: YYYY-MM-DD
+- target: <path or repo url @ commit>
+- inputs: <design doc path | --vulns path | "git-log + advisories mined">
+- owner: <name, for interview> | <unset, for bootstrap>
+```
+
+### 8. Recommended mitigations
+
+Optional, additive. Each row is **one class-level control**, not a per-finding
+patch: a mitigation that closes or materially shrinks an entire threat cluster
+regardless of which instance is found next.
+
+```markdown
+| mitigation | threat_ids | closes_class | effort |
+|---|---|---|---|
+```
+
+- `mitigation`: imperative, one line (e.g., "centralize per-user row scoping in
+  a query helper", "verify every inbound webhook signature before parsing",
+  "escape all user input in HTML via esc() — never inline into <script>").
+- `threat_ids`: comma-separated section-4 ids (e.g., `T1,T3`).
+- `closes_class`: `yes` | `partial`.
+- `effort`: `S` | `M` | `L`.
+
+---
+
+## Scoring guide
+
+### Impact
+
+| value | means |
+|---|---|
+| `low` | Nuisance; no data or availability loss. |
+| `medium` | Limited data exposure or degraded availability for some users. |
+| `high` | Significant data exposure, integrity loss, or full availability loss. |
+| `critical` | Full compromise of a primary asset (RCE, auth bypass, data exfil at scale). |
+| `existential` | Compromise threatens the organization's continued operation. |
+
+### Likelihood
+
+| value | means |
+|---|---|
+| `very_rare` | Requires nation-state resources or an unlikely chain of preconditions. |
+| `rare` | Requires significant skill and a non-default configuration. |
+| `possible` | A motivated attacker with public tooling could plausibly do this. |
+| `likely` | The surface is reachable, the technique is well known, and prior evidence exists here or in similar systems. |
+| `almost_certain` | Actively exploited in the wild, or trivially automatable against the default configuration. |
+
+Evidence (past CVEs in the same surface, pentest findings, public exploit code)
+moves likelihood **up**. Existing controls move it **down**. Score the
+**residual** likelihood after current controls.
+
+---
+
+## Example (excerpt — a web service)
+
+```markdown
+## 4. Threats
+
+| id | threat | actor | surface | asset | impact | likelihood | status | controls | evidence |
+|---|---|---|---|---|---|---|---|---|---|
+| T1 | Cross-tenant disclosure of scan history / API keys via missing ownership check | remote_auth | dashboard + history API | user scan data, API keys | high | possible | unmitigated | per-route auth middleware | |
+| T2 | Server-side request forgery / policy bypass via attacker-controlled redirect on MTA-STS fetch | remote_unauth | MTA-STS policy fetch | service integrity, internal network | high | possible | partially_mitigated | redirect: manual + opaqueredirect guard | #58, #92 |
+| T3 | Stored XSS via unescaped DNS record content rendered into the HTML report | remote_unauth | /check HTML report | report viewer's session | medium | possible | partially_mitigated | esc() on interpolated values | |
+| T4 | Billing privilege escalation (free → paid features) via forged or unverified Stripe webhook | remote_unauth | Stripe webhook endpoint | subscription state | high | rare | unmitigated | webhook signature verification | |
+```
+
+T1 stays in the model after any single missing-predicate bug is fixed: the
+class of "a query that forgets to scope by the caller's identity" persists.
+The evidence column lists specific past instances; the threat is the pattern.

--- a/.claude/skills/vuln-scan/SKILL.md
+++ b/.claude/skills/vuln-scan/SKILL.md
@@ -1,0 +1,301 @@
+---
+name: vuln-scan
+description: >-
+  Static source-code vulnerability scan for the dmarcheck TypeScript Cloudflare
+  Worker. Reads a target directory (and THREAT_MODEL.md if present), spawns
+  parallel review subagents per focus area, and writes VULN-FINDINGS.json +
+  .md for /vuln-triage to consume. Read-only — no building, running, or
+  network. Category menu is tuned for web/Worker bugs (SSRF, authz/IDOR, auth
+  bypass, injection, XSS, signature verification, secrets, redirect posture),
+  not C/C++ memory corruption. Use when asked to "scan for vulns", "review this
+  code for security issues", "find bugs in <dir>", or as the step between
+  /threat-model and /vuln-triage.
+argument-hint: "<target-dir> [--focus <area>] [--single] [--extra <file>] [--no-score]"
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  - Write
+  - Task
+  - Bash(rg:*)
+  - Bash(grep:*)
+  - Bash(ls:*)
+  - Bash(wc:*)
+  - Bash(head:*)
+---
+
+# /vuln-scan
+
+Static vulnerability review of a source tree. Produces `VULN-FINDINGS.json`
+(+ a human-readable `.md`) that `/vuln-triage` ingests directly.
+
+**This skill does not execute code.** It reads source and reasons about it. No
+`npm run`, no `wrangler`, no `fetch` against any host. There is no execution
+oracle here — findings are *candidates*; `/vuln-triage` does the rigorous
+verification and is where false positives get removed.
+
+**Tool fallbacks.** Prefer the dedicated Glob and Grep tools. When they're
+unavailable, fall back to the read-only Bash commands above: `rg --files
+<scope>` / `ls -R` for enumeration, `rg -n` / `grep -rn` for search, `wc` /
+`head` for sniffing. These are the ONLY permitted Bash commands; do not write
+helper scripts or pipe target content into a shell interpreter.
+
+## Arguments
+
+- `<target-dir>` (required) — directory to scan (e.g. `src` or `.`).
+- `--focus <area>` — scan only this focus area (repeatable). Skips recon.
+- `--single` — no subagent fan-out; one sequential pass. For tiny targets or
+  prompt debugging.
+- `--extra <file>` — append the file's contents to the review brief (after the
+  category list). Use for org-specific vuln classes or stack patterns.
+- `--no-score` — skip the Step 3b confidence pass.
+
+## Step 1 — Scope
+
+1. Resolve `<target-dir>`. If it doesn't exist or has no source files, stop.
+2. Look for `<target-dir>/THREAT_MODEL.md` **or** a `THREAT_MODEL.md` at the
+   repo root. If present, parse section 3 "Entry points & trust boundaries"
+   and section 4 "Threats" for focus areas and threat classes — this is the
+   preferred scoping input.
+3. If no THREAT_MODEL.md and no `--focus`: do a **quick recon** — list the
+   source tree, read entry points and dispatch code (`src/index.ts`, route
+   registration, middleware), and propose 3-10 focus areas using the pattern
+   `<subsystem> (<dir/file>) — <key operations>`.
+4. If `--focus` was given, use exactly those.
+
+Tell the user the focus areas and the source-file count before fanning out.
+
+## Step 2 — Fan out
+
+Unless `--single`, spawn **one Task subagent per focus area** in parallel
+(`subagent_type: "general-purpose"`). Cap at 10 concurrent. Each gets the
+review brief below with its focus area filled in. On tiny targets (<15 source
+files), fall through to `--single`.
+
+### Review brief (per subagent)
+
+```
+You are conducting authorized static security review of source code for an
+internet-facing TypeScript service running on Cloudflare Workers (Hono
+framework, D1 database, KV/Cache API, outbound fetch + DNS). Your focus area:
+**{focus_area}**. Other agents cover other areas; duplication is wasted effort.
+
+TARGET: {target_dir}
+TRUST BOUNDARY: {from THREAT_MODEL.md section 3, or "untrusted HTTP request →
+application logic; authenticated session → another user's data"}
+
+TASK: read the source in your focus area and identify candidate
+vulnerabilities. This is static review — do NOT build, run, or probe anything.
+Reason from the code.
+
+REPORTING BAR: report anything with a plausible exploit path. Skip style
+concerns and purely theoretical issues with no attack story — but if unsure
+whether something is real, REPORT IT with a low confidence score rather than
+dropping it. A downstream triage step does rigorous verification; your job is
+to not miss things.
+
+WHAT TO LOOK FOR (web / Cloudflare Worker classes — HIGH VALUE):
+
+  AUTHENTICATION & AUTHORIZATION:
+  - missing or incorrect ownership/tenant check (IDOR): a query, update, or
+    delete reachable by an authenticated user that does NOT scope by the
+    caller's user_id / org_id — cross-tenant read or write
+  - auth bypass: JWT/session/bearer/API-key verification that can be skipped,
+    forged, or downgraded; missing signature/expiry/issuer/audience checks;
+    accepting unsigned/`alg:none`; comparing secrets non-constant-time
+  - privilege escalation: free→paid feature gating that trusts client input;
+    role checks that are advisory only
+  - missing auth on a route that mutates or returns sensitive data
+
+  SSRF & OUTBOUND REQUEST SAFETY:
+  - attacker-controlled host/scheme in a server-side fetch (DNS lookups,
+    MTA-STS / security-txt / well-known fetches built from the scanned domain)
+  - redirect handling: a fetch that follows redirects (`redirect: "follow"` or
+    default) where RFC/policy requires `redirect: "manual"` — note dmarcheck's
+    MTA-STS invariant (must stay `manual`; do not regress to `error`/`follow`)
+  - requests reaching internal/metadata addresses (169.254.169.254, .internal,
+    localhost, RFC1918) without an allowlist
+
+  INJECTION & OUTPUT SAFETY:
+  - SQL injection: D1 query built by string concatenation/interpolation
+    instead of `.prepare(...).bind(...)`; user input in a raw SQL fragment
+  - XSS: user-influenced data (scanned domain, DNS record contents, query
+    params, DB rows) interpolated into server-rendered HTML template literals
+    WITHOUT esc(); raw user input inside an inline <script> block or data-URI;
+    unescaped values in attributes/event handlers
+  - header / response splitting, open redirect via unvalidated redirect target
+  - regex built from user input; ReDoS in a regex applied to untrusted input
+
+  CRYPTO, SECRETS & DATA EXPOSURE:
+  - inbound webhook (Stripe, etc.) parsed/acted on BEFORE signature
+    verification, or signature verified against attacker-suppliable data
+  - HMAC / signature compare that is not constant-time; weak or missing nonce
+  - secrets, API keys, tokens, or session ids logged or returned in error
+    bodies / responses
+  - PII (emails, customer ids) leaked across a trust boundary
+  - tokens (unsubscribe, API key, reset) that are guessable, unscoped, or
+    not invalidated
+
+  LOGIC & STATE:
+  - cache poisoning: a cache key that omits a security-relevant input, or
+    serves one user's cached result to another
+  - rate-limit bypass: limiter keyed on a spoofable header (e.g. raw
+    X-Forwarded-For) or skippable path
+  - TOCTOU on a security check; mass-assignment of privileged fields
+
+  LOW VALUE — note briefly, keep looking:
+  - missing defense-in-depth headers with no concrete exploit
+  - error handling that returns a generic 500 (not a leak)
+
+DO NOT REPORT (common false positives — skip even if technically present):
+  - volumetric DoS / rate-limiting / resource-exhaustion — BUT ReDoS,
+    algorithmic-complexity blowup, and unbounded fan-out driven by untrusted
+    input ARE reportable
+  - XSS where the value is passed through esc() / a framework auto-escape on
+    every path to the sink
+  - SSRF where the attacker controls only the path, not the host or scheme
+  - findings in test files, fixtures, build scripts, docs, or .md
+  - missing hardening / best-practice gaps with no concrete exploit
+  - env vars, wrangler secrets, and CLI flags as the attack vector
+    (operator-controlled, not attacker-controlled)
+  - regex injection, log spoofing, self-XSS, tabnabbing, CSRF on logout
+  - outdated third-party dependency versions
+  - "predictable" identifiers that are actually UUIDv4 / 128-bit random tokens
+
+{if --extra <file> was given: append its contents here verbatim}
+
+For each finding you DO report, trace: where does the untrusted input enter,
+what path reaches the sink, and what condition triggers it.
+
+OUTPUT — one block per finding, nothing else:
+
+<finding>
+<id>F-{focus_idx:02d}-{n:02d}</id>
+<file>{relative/path}</file>
+<line>{line_number}</line>
+<category>{idor | auth-bypass | privilege-escalation | ssrf | open-redirect | sql-injection | xss | header-injection | redos | webhook-signature-bypass | timing-unsafe-compare | secret-exposure | cache-poisoning | rate-limit-bypass | ...}</category>
+<severity>{HIGH | MEDIUM | LOW}</severity>
+<confidence>{0.0-1.0}</confidence>
+<title>{one line}</title>
+<description>{root cause, attacker control, trigger, data flow from entry to sink. Cite line numbers.}</description>
+<exploit_scenario>{concrete attack: what request, from whom, causing what outcome}</exploit_scenario>
+<recommendation>{specific fix: add the user_id predicate, verify the signature first, wrap in esc(), set redirect: manual, etc.}</recommendation>
+</finding>
+
+SEVERITY: HIGH = directly exploitable → auth bypass, cross-tenant data breach,
+SSRF to internal services, RCE. MEDIUM = significant impact under specific
+conditions. LOW = defense-in-depth.
+
+If you find nothing reportable after a thorough read, emit a single <finding>
+with category=none and a one-line note of what you covered.
+```
+
+## Step 3 — Collate
+
+1. Collect `<finding>` blocks from all subagents. Drop `category=none`
+   placeholders.
+2. **Light dedupe** — same `file:line` + same category → keep the longer
+   description, note the duplicate id. (Heavy dedupe is `/vuln-triage`'s job.)
+3. Assign stable ids `F-001`, `F-002`, … in (severity desc, file, line) order.
+
+## Step 3b — Confidence pass (skip if `--no-score`)
+
+A cheap second-opinion read that **ranks** findings by signal quality.
+**Nothing is dropped.** Spawn one Task subagent per finding in parallel:
+
+```
+You are giving ONE candidate security finding an independent confidence score.
+You are NOT deciding whether to keep it — every finding is kept. You are
+deciding how likely it is to survive rigorous triage.
+
+FINDING:
+{the full <finding> block}
+
+TARGET: {target_dir} (you may Read/Grep inside it; do NOT execute)
+
+STEP 1 — Re-read the cited code. Does it actually do what the description claims?
+STEP 2 — Check against false-positive patterns (esc'd/auto-escaped output,
+parameterized D1 bind present, path-only SSRF, operator-controlled env var,
+test/fixture file, UUID/random token, missing-hardening-only). A match lowers
+confidence sharply but does not auto-zero it.
+STEP 3 — Score 1-10 that this is a real, actionable vulnerability:
+  1-3  likely false positive or noise
+  4-5  plausible but speculative
+  6-7  credible, needs investigation
+  8-10 high confidence, clear pattern
+
+OUTPUT (exactly this, nothing else):
+  CONFIDENCE: <1-10>
+  REASON: <one line>
+```
+
+**Resolve:** overwrite each finding's `confidence` with the score (÷10) and
+attach `confidence_reason`. Re-sort by (`confidence` desc, `severity` desc,
+`file`, `line`) and reassign ids `F-001..`. Compute `low_confidence_count` =
+findings with confidence < 0.4.
+
+## Step 4 — Write output
+
+Write **both** files to `<target-dir>/` (or repo root if scanning `.`):
+
+**`VULN-FINDINGS.json`** — the `/vuln-triage` ingest shape:
+
+```json
+{
+  "target": "<target-dir>",
+  "scanned_at": "<iso8601>",
+  "focus_areas": ["..."],
+  "findings": [
+    {
+      "id": "F-001",
+      "file": "src/db/scans.ts",
+      "line": 88,
+      "category": "idor",
+      "severity": "HIGH",
+      "confidence": 0.9,
+      "title": "...",
+      "description": "...",
+      "exploit_scenario": "...",
+      "recommendation": "...",
+      "confidence_reason": "..."
+    }
+  ],
+  "summary": {"total": 0, "high": 0, "medium": 0, "low": 0, "low_confidence": 0}
+}
+```
+
+**`VULN-FINDINGS.md`** — human-readable: a summary table (id | severity |
+category | file:line | title), then one `### F-NNN` section per finding.
+
+## Step 5 — Hand back
+
+1. Counts: N findings (H/M/L split, X low-confidence), across K focus areas,
+   from M source files.
+2. Top 3 by confidence, one line each.
+3. Next step: `/vuln-triage <target-dir>/VULN-FINDINGS.json --repo <repo-root>`
+4. Remind: these are **static candidates**, not verified.
+
+> **Public-repo note (dmarcheck-specific):** `VULN-FINDINGS.*` and `TRIAGE.*`
+> are gitignored. Do NOT commit them — a file enumerating live unpatched bugs
+> in a public repo is an attacker roadmap. Report findings in-session; commit
+> only the patches for confirmed issues.
+
+## Constraints
+
+- **Never execute target code.** No Bash beyond the read-only allowlist, no
+  builds, no network. If asked to "reproduce" or "confirm with a PoC", decline.
+- **Don't fabricate line numbers.** Every `file:line` must be something you
+  Read or Grep'd. If unsure of the exact line, cite the function and say so.
+- **Stay in `<target-dir>`.** Don't follow symlinks or `..` out of it.
+- This skill **never drops a finding** — Step 3b only ranks. `/vuln-triage`
+  does the N-vote verification where false positives are removed.
+
+## Provenance
+
+The focus-area recon pattern and per-finding confidence pass are adapted from
+`anthropics/defending-code-reference-harness` (`.claude/skills/vuln-scan/`).
+The memory-safety category tiers from the original are replaced with web /
+Cloudflare Worker classes (IDOR, auth bypass, SSRF, XSS, webhook-signature
+bypass, redirect posture) appropriate to this codebase; the DO-NOT-REPORT
+exclusions and the `exploit_scenario`/`recommendation` output fields are
+retained.

--- a/.claude/skills/vuln-triage/SKILL.md
+++ b/.claude/skills/vuln-triage/SKILL.md
@@ -1,0 +1,375 @@
+---
+name: vuln-triage
+description: >-
+  Adversarially triage a batch of raw security-scanner findings (e.g. from
+  /vuln-scan's VULN-FINDINGS.json). Verify each is real, collapse duplicates,
+  re-rank by derived exploitability rather than the scanner's claimed severity,
+  and route each to a component owner. Writes TRIAGE.json + TRIAGE.md sorted by
+  what actually needs attention. Read-only — never executes target code or
+  reaches the network. Named vuln-triage to avoid colliding with the repo's
+  issue/PR /triage skill. Use when asked to "triage findings", "validate
+  scanner output", "prioritize vulns", or "review the security backlog".
+  Adapted for dmarcheck from anthropics/defending-code-reference-harness.
+argument-hint: "<findings-path> [--auto] [--votes N] [--repo PATH] [--fp-rules FILE]"
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  - Write
+  - Task
+  - AskUserQuestion
+  - Bash(git log:*)
+  - Bash(jq:*)
+  - Bash(find:*)
+  - Bash(ls:*)
+  - Bash(wc:*)
+---
+
+# vuln-triage
+
+Adversarial triage of raw security-scanner output. Four jobs: **verify** each
+finding is real, **deduplicate** across runs and scanners, **rank** survivors
+by derived exploitability rather than the scanner's claimed severity, and
+**route** each to a component owner. Output is a short, ranked, owned list
+instead of a raw dump.
+
+Invoke with `/vuln-triage <findings-path> [--auto] [--votes N] [--repo PATH] [--fp-rules FILE]`.
+
+**Do not execute target code.** No building, running, installing dependencies,
+or sending requests. "Couldn't write a working PoC" is weak evidence of
+non-exploitability — every conclusion comes from reading source. This applies
+to the orchestrator and every subagent; include the constraint in every Task
+prompt. For high-confidence HIGH findings, recommend a human-built PoC as a
+follow-up instead. **Do not reach the network** (no CVE-DB or upstream fetches).
+
+Bash is permitted only for `git log` (owner hints), `jq`/`find`/`ls`/`wc`
+(ingest). The safety property is "no execution of target code."
+
+## Arguments
+
+- findings path (first positional, required): a `VULN-FINDINGS.json`, a
+  directory of JSON files, a single `.json`/`.jsonl`, or a markdown report.
+- `--auto`: skip the interview, use defaults. Default mode is **interactive**.
+- `--votes N`: verifier votes per finding (default 3; 1 for a quick pass, 5
+  for high-stakes batches).
+- `--repo PATH`: path to the target codebase, read-only (default cwd).
+  Verification needs source access; stop with an error if cited files aren't
+  reachable.
+- `--fp-rules FILE`: append the file's contents to the verifier's exclusion
+  list (Phase 3a). For org-specific precedents.
+
+## Phase 0 — Mode select & interview
+
+Parse arguments. If interactive (default), use **AskUserQuestion** (one call,
+up to 4 questions) to gather context that shapes verification and ranking.
+Free-text via "Other" is expected; the options are prompts, not constraints.
+
+1. **Environment & trust boundary** (single-select): `What kind of system, and
+   where does untrusted input enter?` Default for dmarcheck:
+   `Internet-facing web service (HTTP is untrusted; authenticated users are
+   semi-trusted but must not cross tenants)`.
+2. **Threat model** (multi-select): `What must never happen?` e.g.
+   `Cross-tenant data leakage`, `Auth/billing bypass`, `SSRF to internal
+   network`, `Secret/API-key exposure`, `Stored XSS in the report`. If a
+   `THREAT_MODEL.md` exists at `--repo`, read its section 4 and pre-fill.
+3. **Scoring standard** (single-select): default `Derived HIGH/MEDIUM/LOW from
+   preconditions`.
+4. **Noise tolerance** (single-select): `Precision: drop anything not
+   majority-confirmed` (default) / `Recall: keep split votes as
+   needs_manual_test` / `Ask me per-finding`.
+
+**Auto-mode defaults:** environment = "internet-facing web service; treat any
+externally-reachable entry point as untrusted"; threat model = empty; scoring =
+derived; noise tolerance = precision.
+
+Record answers as a `context` dict carried through every phase and echoed in
+the output under `triage_context`.
+
+## Phase 1 — Ingest & normalize
+
+Turn the input into a flat `findings[]` with stable ids.
+
+- **Detect shape:** `VULN-FINDINGS.json` → read `.findings[]`. A directory →
+  Glob `**/*.json`. A bare list or `{findings|results|issues|vulnerabilities}`
+  array → that array. Markdown → split on `##`/`###` headings and extract
+  `file`/`line`/`category`/`severity`/`description` by pattern (best-effort,
+  mark `source_format: "markdown_heuristic"`).
+- **Normalize fields** (alias → canonical): `path|location.file` → `file`;
+  `line_number|lineno` → `line`; `type|cwe|rule_id` → `category`;
+  `level|priority|risk` → `severity`; `name|summary` → `title`;
+  `details|body` → `description`; `confidence|score` → `scanner_confidence`
+  (→ 0.0-1.0); `fix|remediation` → `recommendation`.
+- **Attach** to each: `id` (`f001`, `f002`, … in ingest order, highest
+  `scanner_confidence` first if present); `source`; `missing_fields`. If `file`
+  is missing or doesn't resolve under `--repo`, mark **unlocatable**: emit
+  directly with `verdict: false_positive`, `verify_verdict: needs_manual_test`,
+  `confidence: 0`, rationale "no source location; human review required". Never
+  confidently verdict a finding you couldn't locate, and never let it
+  participate in dedup.
+- **Locate the repo:** resolve `--repo` (default cwd). Check the first 5
+  located findings resolve. If none do, stop and suggest a `--repo` value.
+
+## Phase 2 — Deduplicate (before verification)
+
+Collapse repeats so duplicates don't each burn N verifiers.
+
+- **Deterministic pass (inline):** cluster findings with same `file` + same
+  `category` (case-insensitive) + `line` within 10. Canonical = fewest
+  `missing_fields`, ties to lowest id. Others get `verdict: duplicate`,
+  `duplicate_of`, and drop out; record `absorbed: [...]` on the canonical.
+- **Semantic pass (one subagent, only if >1 cluster survives):** spawn ONE Task
+  (`subagent_type: "general-purpose"`). Two findings are DUPLICATES if fixing
+  one fixes the other (same root cause, shared vulnerable helper reported per
+  call site, one missing global control reported per endpoint, cause +
+  consequence in the same path). DISTINCT if independent root causes even in
+  the same file/category. Give it only `id | file:line | category | title` per
+  finding; respond with `GROUP: <canonical> <- <dup>, <dup>` lines only.
+
+Carry `candidates[]` = surviving canonicals.
+
+## Phase 3 — Verify
+
+For each candidate, N independent adversarial verifiers re-derive the claim
+from the code and vote. Each starts from the code at the cited location (not
+the scanner's description) and **never sees the other verifiers' reasoning**.
+
+### 3a. Verifier prompt (assemble once, reuse per spawn)
+
+```
+You are a skeptical security engineer adversarially verifying ONE finding from
+an automated scanner. Your default assumption is that the scanner is WRONG.
+Re-derive the claim from the source code yourself and decide TRUE_POSITIVE or
+FALSE_POSITIVE.
+
+Read-only access scoped to {REPO_PATH} ONLY. Do NOT read/grep/glob outside it.
+You may NOT build, run, test, install deps, or reach the network. Every
+conclusion must come from reading source under {REPO_PATH}.
+
+ENVIRONMENT (defines the trust boundary): {context.environment}
+
+PROCEDURE — follow all four steps:
+1. READ THE CODE AT THE CITED LOCATION YOURSELF. Open {file}:{line}. Don't
+   trust the scanner's description; scanners misread code.
+2. TRACE REACHABILITY BACKWARDS FROM THE SINK. Grep for callers; follow imports
+   and route registration. Establish whether attacker-controlled input (per
+   ENVIRONMENT) actually reaches this line. QUOTE the first call-site file:line.
+   For an IDOR claim, confirm whether the query/handler is reachable by an
+   authenticated user and whether it is scoped by the caller's identity.
+3. HUNT FOR PROTECTIONS. Look for reasons the finding is WRONG: input
+   validation/normalization upstream (normalizeDomain, parseSelectors); output
+   escaping (esc()); parameterized D1 binds; auth/ownership middleware; a
+   verified signature before the sink; redirect: manual; type/enum constraints;
+   dead/test code.
+4. STRESS-TEST EACH PROTECTION. Applied on EVERY path to the sink, or only the
+   one traced? Any encoding/alternate entry point that bypasses it?
+
+EXCLUSION RULES — if matched, FALSE_POSITIVE even if technically accurate; cite
+the rule number:
+  1. Volumetric DoS / missing rate-limiting (infra layer). ReDoS, algorithmic
+     complexity, unbounded fan-out ARE valid.
+  2. Test/dead/example/fixture code, or a crash with no security impact.
+  3. Intended design (a documented, deliberate posture).
+  4. Memory-safety concerns in a memory-safe language outside FFI.
+  5. SSRF where the attacker controls only the path, not host or scheme.
+  6. User input flowing into an AI/LLM prompt (prompt injection ≠ code vuln).
+  7. Operator-controlled inputs as the vector (env vars, wrangler secrets, CLI
+     flags) UNLESS ENVIRONMENT marks them untrusted.
+  8. Client-side code flagged for a server-side vuln class.
+  9. Outdated dependency versions (separate process).
+ 10. Weak random used for non-security purposes (jitter, cache spreading).
+ 11. Low-impact nuisance (log spoofing, CSRF on logout, self-XSS, tabnabbing,
+     open redirect with no privileged sink, regex injection).
+ 12. Missing hardening / best-practice gap with no concrete exploit path
+     (missing header, no audit log, permissive config not reached by untrusted
+     input).
+ 13. XSS where the sink value passes through esc() (or a framework
+     auto-escape) on every path. Raw-HTML escape hatches (interpolating user
+     input into an inline <script> or unescaped attribute) are STILL valid.
+ 14. Identifiers unguessable by construction (UUIDv4, 128-bit+ random tokens)
+     flagged as "predictable".
+ 15. Theoretical-only TOCTOU/race with no realistic window or no
+     security-relevant state change.
+ 16. MTA-STS using redirect: "manual" flagged as wrong — that is the REQUIRED
+     RFC 8461 §3.3 posture for dmarcheck, not a bug.
+
+{if context.extra_fp_rules: append verbatim under "ORG-SPECIFIC RULES:"}
+
+VERDICT — your response MUST end with EXACTLY:
+  VERDICT: TRUE_POSITIVE | FALSE_POSITIVE | CANNOT_VERIFY
+  CONFIDENCE: <0-10>
+  REFUTE_REASON: <doesnt_exist|already_handled|implausible_trigger|
+    intentional_behavior|misread_code|duplicate|not_actionable|n/a>
+  EXCLUSION_RULE: <1-16, org rule, or none>
+  FIRST_LINK: <file:line of the first call site you read, or "none found">
+  RATIONALE: <2-5 sentences citing file:line evidence for reachability,
+    protections found/absent, and why each held or didn't>
+
+TRUE_POSITIVE requires ALL of: reachable from untrusted input per ENVIRONMENT;
+protections insufficient or bypassable; real-world exploitation feasible.
+FALSE_POSITIVE requires ANY of: unreachable; adequately protected on all paths;
+scanner misread; an exclusion rule applies.
+CANNOT_VERIFY: static reasoning genuinely hit its limit. Use sparingly.
+```
+
+### 3b. Spawn N verifiers per candidate, all in one message
+
+For each candidate, build N Task calls (`subagent_type: "general-purpose"`,
+`description: "verify {id} vote {k}/{N}"`). **Always set `subagent_type`** —
+omitting it forks the orchestrator and the verifier inherits this
+conversation's context, defeating independence. Append to each prompt:
+
+```
+FINDING UNDER REVIEW (treat as a CLAIM, not a fact):
+  id: {id}   file: {file}   line: {line}   category: {category}
+  severity (claimed): {severity}
+  title: {title}
+  description: {description}
+  exploit_scenario: {exploit_scenario or "(not provided)"}
+
+You are vote {k} of {N}. You have NOT seen the other verifiers' reasoning and
+must NOT seek it. Work independently from the code.
+```
+
+Put all verifier Task calls in a **single message** so they run concurrently.
+Don't background them. If `candidates × N > ~40`, shard into sequential batches
+of ~40, each a single message. Findings with a `file` but no `line` get one
+vote regardless of `--votes`.
+
+### 3c. Tally
+
+For each candidate, parse the trailing block from its N verifiers. Re-spawn a
+verifier once if it errored or produced no parseable block; if the retry fails,
+count it `cannot_verify`. Build `vote_breakdown`, `confidence` (mean of votes
+agreeing with the majority), `exclusion_rule` (modal among FP votes),
+`refute_reasons`, `first_links`, and `rationale` (highest-confidence vote on
+the winning side, verbatim).
+
+**Decide `verdict`:** majority TRUE_POSITIVE → `true_positive` (→ Phase 4);
+majority FALSE_POSITIVE → `false_positive` (skip Phase 4); no majority →
+precision: `false_positive` (note "split vote, dropped"); recall:
+`true_positive` + `verify_verdict: needs_manual_test`; ask: collect splits into
+one AskUserQuestion at end of Phase 3. Build `confirmed[]`.
+
+## Phase 4 — Rank by exploitability (confirmed only)
+
+Spawn one Task per confirmed finding (all in one message). The verdict is
+settled; derive **how bad** independently of the claimed severity.
+
+```
+You are assigning severity to a CONFIRMED finding. Assume it's real. Derive how
+bad, independently of the scanner's claim. Read/Grep {REPO_PATH}; do NOT execute.
+
+ENVIRONMENT: {context.environment}
+THREAT MODEL: {context.threat_model bullets or "(none)"}
+
+FINDING: {id} {file}:{line} {category}, claimed {severity}
+reachability: {first_links}   verifier rationale: {rationale}
+
+STEP 1 — Enumerate EVERY precondition (auth state, config, prior request, race
+window, attacker position). State the minimum ACCESS LEVEL (unauthenticated
+remote / authenticated / local / physical).
+STEP 2 — Derive severity:
+  | Preconditions | Access required           | Severity |
+  | 0             | Unauthenticated remote    | HIGH     |
+  | 1-2           | Authenticated             | MEDIUM   |
+  | 3+            | Local-only / no demo path | LOW      |
+  Evaluate columns independently, take the LOWER. (0 preconditions but
+  authenticated-only = MEDIUM. If preconditions ≥ 3, HIGH is almost surely wrong.)
+STEP 3 — Threat-model match: if non-empty and this maps onto an entry, note it;
+  a match may raise severity by ONE step, never two.
+STEP 4 — Judge the claimed severity from the view of an engineer allergic to
+  inflation. Score -5..+5 (+ = justified, - = inflated).
+STEP 5 — verify_verdict: exploitable | mitigated (name the control) |
+  needs_manual_test.
+
+Respond with ONLY:
+  PRECONDITIONS:
+  - <one per line>
+  ACCESS_LEVEL: <unauthenticated_remote|authenticated|local|physical>
+  SEVERITY: <HIGH|MEDIUM|LOW>
+  THREAT_MATCH: <entry or none>
+  SEVERITY_ALIGNMENT: <-5..+5>
+  VERIFY_VERDICT: <exploitable|mitigated|needs_manual_test>
+  RANK_RATIONALE: <2-4 sentences>
+```
+
+Merge results onto each confirmed finding. Non-confirmed findings get
+`severity: null`, `verify_verdict: null`, `preconditions: []`.
+
+## Phase 5 — Route
+
+Tag each confirmed true-positive with the most specific owner, first hit wins:
+
+1. **CODEOWNERS.** Grep `--repo` for `.github/CODEOWNERS`; match the finding's
+   `file` against its patterns (last match wins). Hint:
+   `"CODEOWNERS: <pattern> -> <owner>"`.
+2. **git log.** `git -C {REPO} log --format='%an' -n 50 -- "{file}" | sort |
+   uniq -c | sort -rn | head -3`. Hint: `"top committer: <name>; no CODEOWNERS"`.
+3. **Module fallback.** `"component: <top-level dir>/"`.
+
+Attach as `owner_hint` (state the source). Non-true-positives get `null`.
+
+## Phase 6 — Output
+
+**Sort** all findings: by `verdict` (true_positive, then duplicate, then
+false_positive); within true positives by severity (HIGH>MEDIUM>LOW) then
+`confidence` desc then `severity_alignment` desc; others by id.
+
+**Write `<repo>/TRIAGE.json`** — every input finding appears exactly once
+(duplicates reference their canonical via `duplicate_of`); don't drop anything.
+Shape:
+
+```json
+{
+  "triage_completed": true,
+  "triage_context": {"mode": "...", "environment": "...", "threat_model": ["..."], "scoring": "...", "noise_tolerance": "...", "votes_per_finding": 3, "repo": "..."},
+  "summary": {"input_count": 0, "duplicates": 0, "false_positives": 0, "true_positives": 0, "needs_manual_test": 0, "by_severity": {"HIGH": 0, "MEDIUM": 0, "LOW": 0}},
+  "findings": [
+    {"id": "f001", "title": "...", "file": "...", "line": 0, "category": "...",
+     "claimed_severity": "HIGH", "verdict": "true_positive|false_positive|duplicate",
+     "verify_verdict": "exploitable|mitigated|needs_manual_test|null",
+     "confidence": 0.0, "severity": "HIGH|MEDIUM|LOW|null", "severity_alignment": 0,
+     "preconditions": ["..."], "access_level": "...", "threat_match": "...|null",
+     "rationale": "file:line-cited reachability/protections + ranking rationale",
+     "vote_breakdown": {"true_positive": 0, "false_positive": 0, "cannot_verify": 0},
+     "refute_reasons": ["..."], "exclusion_rule": null, "first_links": ["file:line"],
+     "duplicate_of": null, "absorbed": ["..."], "owner_hint": "...", "missing_fields": ["..."]}
+  ]
+}
+```
+
+**Write `<repo>/TRIAGE.md`** — reviewer-facing. Title + summary line + `## Act
+on these` (one `### [SEVERITY] title (id)` block per true_positive with
+file:line, owner, verdict+votes, preconditions, threat match, why, reachability
+evidence), then a `## Dropped` table (false positives with refute_reason +
+exclusion rule; duplicates with `duplicate of X`; unlocatable).
+
+**Terminal summary** (≤12 lines): `N findings → T confirmed, F false positives,
+D duplicates`, the H/M/L counts, top HIGH + owner, top 3 refute reasons.
+
+> **Public-repo note (dmarcheck):** `TRIAGE.*` and `VULN-FINDINGS.*` are
+> gitignored. Don't commit them. Report confirmed findings in-session; commit
+> only patches.
+
+## Design notes
+
+- **Dedupe before verify** cuts verifier spend by the duplication factor.
+- **Verifier independence** is the load-bearing property: each gets a fresh
+  context and only the one finding. Sharing context propagates blind spots.
+- **`CANNOT_VERIFY`** maps to `needs_manual_test` under recall, a drop under
+  precision.
+- **Threat-model boost capped at one step** so a stated threat can't re-inflate
+  a LOW back to HIGH and defeat the precondition rule.
+- **No network, deliberately** — preserves the air-gapped-review property.
+
+## Provenance
+
+Adapted from `anthropics/defending-code-reference-harness`
+(`.claude/skills/triage/`). The phase structure (ingest → dedupe → N-vote
+adversarial verify → exploitability rank → route → output), the verifier and
+ranking prompts, and the precondition→severity table are preserved. The
+`checkpoint.py` resume machinery and ASan/pipeline-`report.json` ingest are
+dropped (overkill for an ~80-file TS Worker); the exclusion rules are adjusted
+for web/Worker classes, including rule 16 protecting the MTA-STS `redirect:
+manual` invariant. Renamed `vuln-triage` to avoid colliding with this repo's
+existing issue/PR `/triage` skill.

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,14 @@ docs/internal/
 pnpm-lock.yaml
 .jules/
 .claude/
+
+# Security-scan artifacts (vuln-scan / vuln-triage). Point-in-time findings —
+# never commit on a public repo: a list of live unpatched bugs is an attacker
+# roadmap. Report in-session and commit only the patches. THREAT_MODEL.md (a
+# map of threats, not bugs) is intentionally NOT ignored.
+VULN-FINDINGS.json
+VULN-FINDINGS.md
+TRIAGE.json
+TRIAGE.md
+.triage-state/
+.threat-model-state/

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -1,0 +1,120 @@
+# Threat Model: dmarcheck
+
+## 1. System context
+
+dmarcheck is a DNS email-security analyzer (DMARC, SPF, DKIM, BIMI, MTA-STS,
+MX, security.txt, TLS-RPT) implemented as a single TypeScript Cloudflare Worker
+on the Hono framework. It performs DNS lookups via `node:dns` (`nodejs_compat`),
+runs one analyzer module per protocol in parallel through an orchestrator
+(`Promise.allSettled`), computes a letter grade, and serves dual output: a JSON
+API and a server-rendered interactive HTML report. It is live at dmarc.mx,
+deployed continuously from `main` via Cloudflare Git integration. Dependencies
+are lean (`hono`, `jose`, `@sentry/cloudflare`).
+
+The same MIT-licensed code runs as three tiers: a free anonymous scanner
+(rate-limited 10 req/IP/min), a Pro tier ($19/mo, active only when D1 + WorkOS
++ Stripe bindings are configured — nightly cron monitoring, email grade-drop
+alerts, saved scan history, bulk scan, 60 req/hr API keys), and self-hosting.
+It additionally exposes agent-discovery surfaces (RFC 9727 linkset, OpenAPI,
+an unauthenticated `POST /mcp` `scan_domain` tool). Maintained by a single
+developer; autonomous Claude Code "Routine" pipelines open and auto-merge PRs
+unattended, gated by a fail-closed trust gate plus branch protection. It runs
+on Cloudflare's edge with a D1 database, a daily cron, an email-sending
+binding, and a sibling `mta-sts.dmarc.mx` helper worker.
+
+## 2. Assets
+
+| asset | description | sensitivity |
+|---|---|---|
+| Stripe secret key & webhook signing secret | Billing API auth + inbound webhook verification; grants charge/refund/customer access if leaked | critical |
+| Cloudflare API / D1 / deploy tokens | Infra control; the D1-edit token is deliberately scoped and separated from the deploy token to limit blast radius | critical |
+| User API keys (`dmk_…` bearer tokens) | Authenticate Pro API callers (60 req/hr); SHA-256 hashed at rest | high |
+| Session tokens / JWTs | Authenticate dashboard users (WorkOS AuthKit relying party); HS256 session cookie | high |
+| User emails & Stripe customer/subscription rows (D1) | PII + billing linkage; target of IDOR / cross-tenant leak | high |
+| Integrity of computed grades / scan results | The product's core trust output; manipulation misleads users about their email-security posture | high |
+| Scan history & monitored-domain lists (D1) | Per-user saved results; cross-tenant read risk | medium |
+| Email-sending binding (`alerts@dmarc.mx`) | Abuse = spoofed alerts / spam from a verified sender | medium |
+| Service availability (dmarc.mx + mta-sts helper) | Edge availability; DoS is out of scope per SECURITY.md but the outbound-fetch surface is real | medium |
+
+## 3. Entry points & trust boundaries
+
+| entry_point | description | trust_boundary | reachable_assets |
+|---|---|---|---|
+| E1 — Public scan API (`/check`, `/api/check`, `/api/check/stream`, `/badge`, `/mx/:slug`) | Attacker controls `?domain`, `?selectors`, `?format`, `Accept`; drives DNS lookups + HTML/JSON/CSV/SSE rendering | unauth HTTP → app logic; Worker → upstream DNS | grade integrity, service availability |
+| E2 — MCP handler (`POST /mcp` `scan_domain`) | Arbitrary JSON-RPC body; `domain`/`dkim_selectors` drive a full scan. No bearer requirement and **no rate-limit middleware** (contrast `/check`) | unauth HTTP → Worker → DNS/HTTP | service availability, grade integrity |
+| E3 — Analyzer outbound fetch (MTA-STS, security.txt, BIMI) | Scanned domain interpolated into upstream HTTPS URLs; MTA-STS uses `redirect: "manual"`, security.txt uses `redirect: "follow"` | Worker → attacker-named upstream HTTP | internal network, service integrity |
+| E4 — Outbound webhook dispatch | Fetches a Pro user's saved `webhook.url`; save path validates only `protocol === "https:"` | authenticated user → Worker outbound to arbitrary host | internal network, service integrity |
+| E5 — Auth & session (session cookie JWT, bearer API key, Cloudflare Access JWT) | HS256 session HMAC + exp; `dmk_` API key SHA-256 lookup; `jose` RS256 Access JWT (preview only, fail-closed) | unauth → authenticated identity | all authenticated assets |
+| E6 — Dashboard CRUD + history/bulk-scan APIs (D1, per-user) | Authenticated reads/writes scoped by `WHERE user_id = ?` / `getDomainByUserAndName` | authenticated session → another user's data | scan history, API keys, user/billing data |
+| E7 — Stripe webhook (`POST /webhooks/stripe`) | Raw-body HMAC-SHA256 verify, 5-min skew, event-id idempotency, then mutates subscription state | unauth internet → billing state mutation | subscription state, billing data |
+| E8 — HTML report rendering (`src/views/*`) | User/DNS-derived values interpolated into template-literal HTML | scan data → rendered HTML in a viewer's browser | viewer session, grade integrity |
+| E9 — Rate limiter / cache | Keyed on `CF-Connecting-IP` (`ip:<x>`) or `user:<id>`; Cache API store with in-memory fallback | spoofable identity / shared cache key | service availability |
+| E10 — CI/CD + deploy (GitHub Actions: ci, codeql, migrate, release, deploy-mta-sts; Cloudflare Git integration) | `pull_request` on a public repo; `main`-gated jobs hold prod D1 / deploy / release tokens | PR/main → CI runner → prod | infra tokens, prod D1, releases |
+| E11 — Autonomous-routine PR merge path | External routine identity opens + auto-merges PRs; CODEOWNERS + fail-closed gate | external automation → `main` | analyzers, orchestration, scoring, CI |
+
+## 4. Threats
+
+| id | threat | actor | surface | asset | impact | likelihood | status | controls | evidence |
+|---|---|---|---|---|---|---|---|---|---|
+| T1 | Authentication/session bypass via JWT, API-key, or Access-token verification flaw | remote_unauth | E5 | all authenticated assets | critical | rare | partially_mitigated | jose for Access JWT; session HMAC verify hardcoded to HS256; API keys SHA-256 hashed and shape-checked | |
+| T2 | SSRF / internal-network probing via attacker-controlled outbound webhook URL | remote_auth | E4 | internal network, service integrity | high | possible | partially_mitigated | `protocol === "https:"` check on save; no host allowlist or private-IP/redirect guard on dispatch fetch | |
+| T3 | SSRF / policy bypass via redirect or IP-literal on analyzer outbound fetch | remote_unauth | E3 | internal network, service integrity | high | possible | partially_mitigated | MTA-STS `redirect: "manual"` + opaqueredirect guard; `normalizeDomain` rejects IPv4 literals; 3s timeout | #58, #92, #104, #108 |
+| T4 | Cross-tenant disclosure of scan history / API keys / billing data via missing ownership check (IDOR) | remote_auth | E6 | scan history, API keys, user/billing data | high | possible | partially_mitigated | parameterized D1 `.bind()` everywhere; `WHERE user_id = ?` / `getDomainByUserAndName` ownership scoping | |
+| T5 | Malicious security-sensitive change auto-merged while the CODEOWNERS gate is advisory | supply_chain | E11 | analyzers, orchestration, scoring | high | possible | partially_mitigated | fail-closed `routine-gate` (allowlist + `spec-approved` label + risk-path denylist); CODEOWNERS path-scoping | #299, #300 |
+| T6 | Secret or PII exposure via logs or error responses | remote_unauth | E1, E5, E7 | secrets, user/billing data | high | possible | unmitigated | Sentry capture; no documented scrubbing audit | |
+| T7 | Billing privilege escalation (free → paid) via forged or replayed Stripe webhook | remote_unauth | E7 | subscription state | high | rare | partially_mitigated | raw-body HMAC-SHA256 verify, constant-time compare, 5-min skew, event-id idempotency | |
+| T8 | Supply-chain / CI compromise escalating to prod D1 write or deploy | supply_chain | E10 | prod D1, infra tokens, releases | high | rare | partially_mitigated | SHA-pinned actions, ubuntu-latest only, explicit `permissions:` blocks, secrets only on `main`-gated jobs | |
+| T9 | Rate-limit bypass → DNS amplification / scan abuse via unauthenticated, unmetered `/mcp` and non-`/check` scan routes | remote_unauth | E2, E9 | service availability, upstream DNS | medium | likely | partially_mitigated | `CF-Connecting-IP` keying on `/check`; XFF no longer trusted | #71, #123, #59 |
+| T10 | Stored/reflected XSS via unescaped scan data rendered into the HTML report | remote_unauth | E8, E1 | viewer session, grade integrity | medium | possible | partially_mitigated | `esc()` on interpolated values; per-request CSP nonce + `strict-dynamic`; `default-src 'none'` | #59, #281, 0fc81e2 |
+| T11 | Denial of service via DNS resource exhaustion or scan-abort on attacker-controlled domains | remote_unauth | E1, E3 | service availability | medium | possible | partially_mitigated | SPF lookup-limit early-exit; `Promise.allSettled` orchestration; `DnsLookupError` catch on external lookups | #90, #354 |
+| T12 | Login CSRF / OAuth-flow tampering | remote_unauth | E5 | user session | medium | rare | mitigated | OAuth `state` cookie (HttpOnly/Secure/SameSite=Lax) + strict callback match | #150 |
+
+## 5. Deprioritized
+
+| threat | reason |
+|---|---|
+| Volumetric / network-layer DoS against dmarc.mx | Explicitly out of scope per SECURITY.md; handled at the Cloudflare edge. Application-layer amplification (T9, T11) is in scope. |
+| Cloud metadata-service SSRF (169.254.169.254) | Cloudflare Workers egress does not expose a cloud metadata endpoint; IP-literal reject (`normalizeDomain`) is defense-in-depth. Internal-service SSRF (T2, T3) remains in scope. |
+| Repudiation / audit-log tampering | Single-operator service; no multi-admin actions whose attribution is security-relevant. |
+| Alg-confusion on the session JWT | Verify is hardcoded to HS256, so the unvalidated header `alg` is not currently exploitable. Tracked as a brittleness note in section 6, not an active threat. |
+
+## 6. Open questions
+
+- **Sentry / log scrubbing (T6):** Are request bodies, headers (cookies,
+  bearer tokens), and Stripe payloads scrubbed before capture? What goes into
+  error-response bodies on a 500?
+- **Webhook SSRF posture (T2):** Is the outbound-webhook feature intended to
+  reach arbitrary user hosts, or should it enforce a public-IP/host allowlist
+  and `redirect: "manual"`? Does the dispatch fetch currently follow redirects?
+- **`/mcp` rate limiting (T9):** Is the unauthenticated MCP scan path
+  intentionally exempt from `rateLimitMiddleware`, or an oversight? Same
+  question for `/badge` and `/mx/:slug`.
+- **Bot-identity split (T5):** Has #299 landed? Until the routine runs as a
+  non-admin identity, the CODEOWNERS gate is advisory (admin bypasses the
+  ruleset).
+- **D1 token scope (T8):** Is `deploy-mta-sts.yml`'s broad `CLOUDFLARE_API_TOKEN`
+  reducible to a Worker-scoped token like the D1 migration token?
+- **Session JWT `alg` (brittleness):** Should `session.ts` assert the header
+  `alg` is `HS256` to harden against a future change that introduces key
+  flexibility?
+
+## 7. Provenance
+
+- mode: bootstrap
+- date: 2026-05-28
+- target: /Users/cory/dmarcheck @ a2f0205
+- inputs: git-log + GitHub advisories mined (no public advisories); no `--vulns` file
+- owner: unset
+
+## 8. Recommended mitigations
+
+| mitigation | threat_ids | closes_class | effort |
+|---|---|---|---|
+| Enforce a public-host allowlist + `redirect: "manual"` + private-IP/DNS-rebinding guard on all server-side fetches built from user input | T2, T3 | partial | M |
+| Apply `rateLimitMiddleware` to every scan-triggering route (`/mcp`, `/badge`, `/mx/:slug`, SSE) — centralize "any route that performs a DNS scan is rate-limited" | T9, T11 | yes | S |
+| Centralize per-user row scoping in a query helper so no handler can issue an unscoped read/write of a tenant-owned table | T4 | yes | M |
+| Keep all HTML interpolation behind `esc()` and the CSP nonce; lint/block raw user input inside inline `<script>` or unescaped attributes | T10 | yes | S |
+| Audit Sentry/error paths for secret + PII scrubbing; never echo internal state in 5xx bodies | T6 | partial | S |
+| Land the #299 bot-identity split so routines run as a non-admin identity and the CODEOWNERS gate becomes enforcing, not advisory | T5 | yes | M |
+| Assert `alg: HS256` when verifying the session JWT (defense-in-depth against future key-flexibility regressions) | T1 | partial | S |
+| Scope `deploy-mta-sts.yml` to a Worker-scoped token instead of the broad `CLOUDFLARE_API_TOKEN` | T8 | partial | S |

--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -49,6 +49,7 @@ import { scan } from "../orchestrator.js";
 import { normalizeDomain } from "../shared/domain.js";
 import { PRO_WATCHLIST_CAP, watchlistCapForPlan } from "../shared/limits.js";
 import { computeGradeBreakdown } from "../shared/scoring.js";
+import { isAllowedWebhookUrl } from "../shared/ssrf.js";
 import {
   renderAddDomainPage,
   renderApiKeysPage,
@@ -1177,13 +1178,11 @@ dashboardRoutes.post("/settings/webhook", async (c) => {
   const body = await c.req.parseBody();
   const url = body.webhookUrl as string;
 
-  // Validate URL
-  try {
-    const parsed = new URL(url);
-    if (parsed.protocol !== "https:") {
-      return c.redirect("/dashboard/settings");
-    }
-  } catch {
+  // Validate URL: must be a public https host. The host guard blocks SSRF to
+  // internal/reserved addresses (loopback, link-local/metadata, RFC1918, ULA)
+  // and internal-only names. The dispatcher re-checks at fetch time and uses
+  // redirect: "manual" so a 3xx can't pivot past this.
+  if (!isAllowedWebhookUrl(url)) {
     return c.redirect("/dashboard/settings");
   }
 

--- a/src/shared/ssrf.ts
+++ b/src/shared/ssrf.ts
@@ -1,0 +1,68 @@
+// SSRF guard for user-supplied URLs that the Worker fetches server-side
+// (currently: outbound webhook delivery). Distinct from `normalizeDomain` in
+// domain.ts, which rejects ALL IP literals because scanning a bare IP is never
+// a legitimate DMARC/SPF/etc. lookup. Here we must allow arbitrary PUBLIC hosts
+// (a webhook receiver can be any public HTTPS endpoint) while blocking hosts
+// that point at internal/reserved address space.
+//
+// This is a string/literal-level guard: it stops an attacker from directly
+// naming an internal address (`https://169.254.169.254/`, `https://10.0.0.5/`,
+// `https://localhost/`). It does NOT defend against DNS rebinding — a public
+// hostname whose A record resolves to an internal IP — which needs a
+// resolution-time check the Workers fetch API does not cleanly expose. Pair it
+// with `redirect: "manual"` on the fetch so a 3xx can't pivot past this guard.
+
+function isPrivateIPv4(host: string): boolean {
+  const parts = host.split(".");
+  if (parts.length !== 4) return false;
+  const octets = parts.map((p) => Number(p));
+  if (octets.some((n) => !Number.isInteger(n) || n < 0 || n > 255))
+    return false;
+  const [a, b] = octets;
+  if (a === 0) return true; // 0.0.0.0/8 "this network"
+  if (a === 10) return true; // 10.0.0.0/8 private
+  if (a === 127) return true; // 127.0.0.0/8 loopback
+  if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local (+ metadata)
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12 private
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16 private
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 CGNAT
+  if (a === 198 && (b === 18 || b === 19)) return true; // 198.18.0.0/15 benchmark
+  if (a >= 224) return true; // 224.0.0.0/4 multicast + 240.0.0.0/4 reserved + 255.* broadcast
+  return false;
+}
+
+function isPrivateIPv6(host: string): boolean {
+  // `new URL(...).hostname` yields the canonical compressed lowercase form.
+  if (host === "::1") return true; // loopback
+  if (host === "::") return true; // unspecified
+  if (host.startsWith("fc") || host.startsWith("fd")) return true; // fc00::/7 ULA
+  if (/^fe[89ab]/.test(host)) return true; // fe80::/10 link-local
+  if (host.startsWith("::ffff:")) return true; // IPv4-mapped — no legit webhook use
+  return false;
+}
+
+// True if a hostname (as produced by `new URL(url).hostname`) points at
+// internal/reserved space or an internal-only name and must NOT be fetched.
+export function isBlockedFetchHost(hostname: string): boolean {
+  let host = hostname.trim().toLowerCase();
+  if (host === "") return true;
+  // `new URL(...).hostname` wraps IPv6 literals in brackets, e.g. "[::1]".
+  if (host.startsWith("[") && host.endsWith("]")) host = host.slice(1, -1);
+  if (host === "localhost" || host.endsWith(".localhost")) return true;
+  if (host.endsWith(".local") || host.endsWith(".internal")) return true;
+  if (/^\d{1,3}(?:\.\d{1,3}){3}$/.test(host)) return isPrivateIPv4(host);
+  if (host.includes(":")) return isPrivateIPv6(host);
+  return false;
+}
+
+// True only for an https: URL whose host is safe to fetch server-side.
+export function isAllowedWebhookUrl(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== "https:") return false;
+  return !isBlockedFetchHost(parsed.hostname);
+}

--- a/src/webhooks/dispatcher.ts
+++ b/src/webhooks/dispatcher.ts
@@ -1,6 +1,7 @@
 import { insertWebhookDelivery } from "../db/webhook-deliveries.js";
 import { getWebhookForUser } from "../db/webhooks.js";
 import { hmacSha256Hex } from "../shared/hmac.js";
+import { isAllowedWebhookUrl } from "../shared/ssrf.js";
 import {
   getFormatAdapter,
   type ScanCompletedData,
@@ -67,6 +68,29 @@ export async function dispatchWebhook(
   const { body } = adapter(envelope);
   const bodySha = await sha256Hex(body);
 
+  // SSRF guard at the sink (defense in depth alongside save-time validation in
+  // dashboard routes): refuse to fetch a stored URL whose host is internal /
+  // reserved. Catches rows saved before this check existed.
+  if (!isAllowedWebhookUrl(webhook.url)) {
+    const result: DispatchResult = {
+      ok: false,
+      status: null,
+      error: "webhook URL host is not allowed (must be a public https host)",
+      attempted_at: now,
+      event_id: eventId,
+    };
+    await recordDelivery(
+      db,
+      userId,
+      webhook.id,
+      webhook.url,
+      event.type,
+      bodySha,
+      result,
+    );
+    return result;
+  }
+
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     "User-Agent": "dmarcheck-webhook/1",
@@ -100,12 +124,39 @@ export async function dispatchWebhook(
     headers["Dmarcheck-Signature"] = `t=${now},v1=${signature}`;
   }
 
+  // Map a fetch Response to a DispatchResult. With `redirect: "manual"` a 3xx
+  // yields an opaque-redirect Response (type === "opaqueredirect", ok === false,
+  // status === 0); treat it as a failure instead of following the hop, so an
+  // attacker-controlled receiver cannot 30x-pivot the Worker past the SSRF
+  // guard to a new host. Same posture as the MTA-STS fetch in
+  // src/analyzers/mta-sts.ts.
+  const toResult = (response: Response): DispatchResult => {
+    if ((response.type as string) === "opaqueredirect") {
+      return {
+        ok: false,
+        status: null,
+        error:
+          "redirect not followed (3xx) — receiver must accept the POST directly",
+        attempted_at: now,
+        event_id: eventId,
+      };
+    }
+    return {
+      ok: response.ok,
+      status: response.status,
+      error: response.ok ? null : `HTTP ${response.status}`,
+      attempted_at: now,
+      event_id: eventId,
+    };
+  };
+
   let result: DispatchResult;
   try {
     const response = await fetch(webhook.url, {
       method: "POST",
       headers,
       body,
+      redirect: "manual",
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
 
@@ -119,23 +170,12 @@ export async function dispatchWebhook(
         method: "POST",
         headers,
         body,
+        redirect: "manual",
         signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
       });
-      result = {
-        ok: retry.ok,
-        status: retry.status,
-        error: retry.ok ? null : `HTTP ${retry.status}`,
-        attempted_at: now,
-        event_id: eventId,
-      };
+      result = toResult(retry);
     } else {
-      result = {
-        ok: response.ok,
-        status: response.status,
-        error: response.ok ? null : `HTTP ${response.status}`,
-        attempted_at: now,
-        event_id: eventId,
-      };
+      result = toResult(response);
     }
   } catch (err) {
     result = {

--- a/test/ssrf.test.ts
+++ b/test/ssrf.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { isAllowedWebhookUrl, isBlockedFetchHost } from "../src/shared/ssrf.js";
+
+describe("shared/ssrf.isBlockedFetchHost", () => {
+  it("blocks loopback and internal-only hostnames", () => {
+    for (const h of [
+      "localhost",
+      "app.localhost",
+      "db.internal",
+      "printer.local",
+      "",
+    ]) {
+      expect(isBlockedFetchHost(h)).toBe(true);
+    }
+  });
+
+  it("blocks private / reserved IPv4 literals", () => {
+    for (const ip of [
+      "127.0.0.1",
+      "10.0.0.5",
+      "172.16.0.1",
+      "172.31.255.255",
+      "192.168.1.1",
+      "169.254.169.254", // cloud metadata
+      "100.64.0.1", // CGNAT
+      "0.0.0.0",
+      "198.18.0.1", // benchmarking
+      "224.0.0.1", // multicast
+      "255.255.255.255",
+    ]) {
+      expect(isBlockedFetchHost(ip)).toBe(true);
+    }
+  });
+
+  it("allows public IPv4 literals and normal hostnames", () => {
+    for (const h of [
+      "8.8.8.8",
+      "1.1.1.1",
+      "203.0.113.10",
+      "hooks.slack.com",
+      "chat.googleapis.com",
+      "example.com",
+    ]) {
+      expect(isBlockedFetchHost(h)).toBe(false);
+    }
+  });
+
+  it("blocks private / reserved IPv6 literals (bracketed and bare)", () => {
+    for (const h of [
+      "[::1]",
+      "::1",
+      "[fe80::1]",
+      "[fc00::1]",
+      "[fd12::1]",
+      "::",
+      "[::ffff:7f00:1]",
+    ]) {
+      expect(isBlockedFetchHost(h)).toBe(true);
+    }
+  });
+
+  it("allows a public IPv6 literal", () => {
+    expect(isBlockedFetchHost("[2606:4700:4700::1111]")).toBe(false);
+  });
+});
+
+describe("shared/ssrf.isAllowedWebhookUrl", () => {
+  it("requires https", () => {
+    expect(isAllowedWebhookUrl("http://hooks.slack.com/x")).toBe(false);
+    expect(isAllowedWebhookUrl("https://hooks.slack.com/x")).toBe(true);
+  });
+
+  it("rejects internal hosts even over https", () => {
+    expect(isAllowedWebhookUrl("https://127.0.0.1:8787/admin")).toBe(false);
+    expect(
+      isAllowedWebhookUrl("https://169.254.169.254/latest/meta-data/"),
+    ).toBe(false);
+    expect(isAllowedWebhookUrl("https://localhost/hook")).toBe(false);
+    expect(isAllowedWebhookUrl("https://[::1]/hook")).toBe(false);
+  });
+
+  it("rejects unparseable URLs", () => {
+    expect(isAllowedWebhookUrl("not a url")).toBe(false);
+    expect(isAllowedWebhookUrl("")).toBe(false);
+  });
+
+  it("allows a normal public https receiver", () => {
+    expect(isAllowedWebhookUrl("https://hook.example/receive")).toBe(true);
+  });
+});

--- a/test/webhooks-dispatcher.test.ts
+++ b/test/webhooks-dispatcher.test.ts
@@ -103,6 +103,63 @@ describe("webhooks/dispatcher.dispatchWebhook", () => {
     expect(deliveries).toHaveLength(0);
   });
 
+  it("refuses to fetch a webhook URL pointing at an internal host (SSRF guard)", async () => {
+    webhooksByUser.set("u1", {
+      id: 99,
+      user_id: "u1",
+      url: "https://169.254.169.254/latest/meta-data/",
+      secret: "shhh",
+      format: "raw",
+      created_at: 0,
+    });
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const db = makeDb();
+
+    const result = await dispatchWebhook(db, "u1", {
+      type: "webhook.test",
+      data: { message: "ping" },
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result?.ok).toBe(false);
+    expect(result?.status).toBeNull();
+    expect(result?.error).toMatch(/host is not allowed/i);
+    // The blocked attempt is still recorded for the dashboard.
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0].ok).toBe(0);
+  });
+
+  it("uses redirect: manual and treats an opaque-redirect (3xx) as a failed delivery", async () => {
+    webhooksByUser.set("u1", {
+      id: 88,
+      user_id: "u1",
+      url: "https://hook.example/receive",
+      secret: "shhh",
+      format: "raw",
+      created_at: 0,
+    });
+    // A 3xx under redirect: "manual" surfaces as an opaque-redirect Response.
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      type: "opaqueredirect",
+      ok: false,
+      status: 0,
+    } as unknown as Response);
+    const db = makeDb();
+
+    const result = await dispatchWebhook(db, "u1", {
+      type: "webhook.test",
+      data: { message: "ping" },
+    });
+
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(init.redirect).toBe("manual");
+    expect(result?.ok).toBe(false);
+    expect(result?.status).toBeNull();
+    expect(result?.error).toMatch(/redirect not followed/i);
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0].ok).toBe(0);
+  });
+
   it("POSTs a signed envelope and records a successful delivery", async () => {
     webhooksByUser.set("u1", {
       id: 42,


### PR DESCRIPTION
## Summary

Reviews and implements the methodology from Anthropic's [defending-code-reference-harness](https://github.com/anthropics/defending-code-reference-harness) for dmarcheck, and ships the first concrete fix it surfaced.

- **Port the read-only review skills** (adapted for this TS Worker; the C/C++ ASan/gVisor pipeline + `checkpoint.py` are dropped as N/A): `/threat-model`, `/vuln-scan`, `/vuln-triage` in `.claude/skills/`.
- **`THREAT_MODEL.md`** — bootstrap threat model (12 threats), addressing the attack-surface analysis requested in #387.
- **Fix the outbound-webhook SSRF** — the cleanest confirmed finding from a full threat-model → scan → triage pass.

## What the security pass found

13 candidate findings across 9 focus areas; all triaged, severities recalibrated by independent adversarial verifiers (a stateless Worker has no private VPC / metadata endpoint, so the SSRF/rate-limit items are MEDIUM, not HIGH). IDOR, XSS, and the alerts/email + unsubscribe-token flow came back clean. The remaining confirmed findings are filed as **private draft security advisories** (GHSA-q9r7-w7w2-6wgc, -jjm8-8r36-mf4h, -v7qc-7qh8-h69g, -2c2x-h546-gmf8, -ffpg-35vp-hv2m) rather than public issues, since this is a public repo.

## The fix (only code change here)

Webhook URLs were validated for `https:` only, then fetched server-side following redirects by default. New `src/shared/ssrf.ts` rejects loopback / link-local-metadata / RFC1918 / CGNAT / ULA / internal-only hosts; enforced at save and re-checked at dispatch; both dispatch fetches now use `redirect: "manual"` (matching the documented MTA-STS posture) and treat a 3xx opaque-redirect as a failed delivery. DNS-rebinding residual tracked in GHSA-q9r7-w7w2-6wgc.

> **Review note:** touches CODEOWNERS-gated paths (input validation / redirect posture / webhooks) — needs code-owner approval. The skills + `THREAT_MODEL.md` are additive (no runtime impact). Scan artifacts (`VULN-FINDINGS.*`, `TRIAGE.*`) are gitignored and intentionally not committed.

## Test plan
- [x] `npm test` — 1084 passing (incl. new `test/ssrf.test.ts` + dispatcher SSRF/redirect tests)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — biome clean
- [ ] Confirm a public webhook (Slack/Google Chat/raw) still delivers in a real environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)