### PR TITLE
feat: configurable scoring rubric for self-hosted deployments (#25)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Live at dmarc.mx | Repo: github.com/schmug/dmarcheck
 - `src/dns/client.ts` — DNS abstraction over node:dns (NXDOMAIN returns null)
 - `src/analyzers/` — One module per protocol (dmarc, spf, dkim, bimi, mta-sts, mx, security-txt)
 - `src/orchestrator.ts` — Runs all analyzers in parallel via Promise.allSettled
-- `src/shared/scoring.ts` — Grade computation (F if no DMARC or p=none)
+- `src/shared/scoring.ts` — Grade computation (F if no DMARC or p=none). Knobs are configurable per-deploy via the `SCORING_CONFIG` env var (`src/shared/scoring-config.ts` parses/validates it; absent/invalid → shipped defaults, so hosted dmarc.mx is unaffected). `computeGrade`/`computeGradeBreakdown` take an optional `Partial<ScoringConfig>`; `scan`/`scanStreaming` require it (compile-time enforcement that every call site threads the active config)
 - `src/cache.ts` — SSE result caching
 - `src/csv.ts` — CSV export for scan results
 - `src/api/catalog.ts` + `src/api/openapi.ts` — Agent discovery (RFC 9727 linkset at `/.well-known/api-catalog`, OpenAPI 3.1 at `/openapi.json`)

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ polyfill in production) is used.
 | Rate limit | `src/rate-limit.ts` → `LIMIT` | 10 req/IP/min |
 | Rate limit window | `src/rate-limit.ts` → `WINDOW_SECONDS` | 60s |
 | DKIM selectors | `src/analyzers/dkim.ts` → `COMMON_SELECTORS` | ~30 common selectors |
+| Scoring rubric | `wrangler.toml` → `[vars].SCORING_CONFIG` (JSON) | shipped rubric — see [`src/shared/scoring-config.ts`](src/shared/scoring-config.ts) for the knobs |
 
 ### Database migrations
 

--- a/src/api/bulk-scan.ts
+++ b/src/api/bulk-scan.ts
@@ -6,9 +6,10 @@ import {
   getDomainByUserAndName,
 } from "../db/domains.js";
 import { recordScan } from "../db/scans.js";
-import { scan as defaultScan } from "../orchestrator.js";
+import { scan } from "../orchestrator.js";
 import { normalizeDomain } from "../shared/domain.js";
 import { PRO_WATCHLIST_CAP } from "../shared/limits.js";
+import type { ScoringConfig } from "../shared/scoring.js";
 
 // Phase 4c — bulk scan core. Two callers (POST /api/bulk-scan with bearer
 // auth, POST /dashboard/bulk with session auth) share this logic; both must
@@ -49,6 +50,8 @@ export interface ProcessBulkScanInput {
   rawDomains: string[];
   // Injectable for tests — defaults to the orchestrator's `scan`.
   scanFn?: (domain: string) => Promise<ScanLike>;
+  // Self-host scoring rubric override, forwarded to scan() (issue #25).
+  scoringConfig?: Partial<ScoringConfig>;
   now?: number;
   // Knobs for tests; defaults match the production caps above.
   inBandCap?: number;
@@ -82,7 +85,9 @@ export function isCapExceeded(
 export async function processBulkScan(
   input: ProcessBulkScanInput,
 ): Promise<ProcessBulkScanOutcome> {
-  const scanFn = input.scanFn ?? defaultScan;
+  const scanFn =
+    input.scanFn ??
+    ((domain: string) => scan(domain, [], input.scoringConfig ?? {}));
   const inBandCap = input.inBandCap ?? BULK_IN_BAND_CAP;
   const batchSize = input.batchSize ?? BULK_BATCH_SIZE;
 

--- a/src/cron/rescan.ts
+++ b/src/cron/rescan.ts
@@ -9,7 +9,8 @@ import { recordAlerts } from "../db/alerts.js";
 import { type Domain, getDueDomains } from "../db/domains.js";
 import { recordScan } from "../db/scans.js";
 import { getUserById } from "../db/users.js";
-import { scan as defaultScan } from "../orchestrator.js";
+import { scan } from "../orchestrator.js";
+import type { ScoringConfig } from "../shared/scoring.js";
 import { fireScanCompletedWebhook } from "../webhooks/triggers.js";
 
 export interface RescanResult {
@@ -34,6 +35,8 @@ interface RescanDeps {
   now: number;
   batchSize?: number;
   scanFn?: (domain: string) => Promise<ScanResult>;
+  // Self-host scoring rubric override, forwarded to scan() (issue #25).
+  scoringConfig?: Partial<ScoringConfig>;
   fireWebhookFn?: WebhookFireFn;
 }
 
@@ -107,7 +110,9 @@ async function rescanOne(
   deps: RescanDeps,
   domain: Domain,
 ): Promise<{ alerts: number; error?: unknown }> {
-  const scanFn = deps.scanFn ?? defaultScan;
+  const scanFn =
+    deps.scanFn ??
+    ((domain: string) => scan(domain, [], deps.scoringConfig ?? {}));
   const prevStatuses = await getPreviousProtocolStatuses(deps.db, domain.id);
 
   let result: ScanResult;

--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -48,7 +48,11 @@ import { getRecentDeliveriesForUser } from "../db/webhook-deliveries.js";
 import { scan } from "../orchestrator.js";
 import { normalizeDomain } from "../shared/domain.js";
 import { PRO_WATCHLIST_CAP, watchlistCapForPlan } from "../shared/limits.js";
-import { computeGradeBreakdown } from "../shared/scoring.js";
+import {
+  computeGradeBreakdown,
+  type ScoringConfig,
+} from "../shared/scoring.js";
+import { parseScoringConfig } from "../shared/scoring-config.js";
 import { isAllowedWebhookUrl } from "../shared/ssrf.js";
 import {
   renderAddDomainPage,
@@ -148,6 +152,7 @@ function asProtocolStatus(
 
 function buildDrawerDetail(
   rawScanRows: import("../db/scans.js").ScanHistoryRow[],
+  config: Partial<ScoringConfig>,
 ): DrawerDetail {
   const empty: DrawerDetail = {
     protocols: {
@@ -261,6 +266,7 @@ function buildDrawerDetail(
   try {
     const breakdown = computeGradeBreakdown(
       parsed as Parameters<typeof computeGradeBreakdown>[0],
+      config,
     );
     recommendations = breakdown.recommendations;
   } catch {
@@ -827,6 +833,9 @@ dashboardRoutes.post("/bulk", async (c) => {
     userId: session.sub,
     rawDomains: lines,
     watchlistCap: watchlistCapForPlan(plan),
+    scoringConfig: parseScoringConfig(
+      (c.env as { SCORING_CONFIG?: string }).SCORING_CONFIG,
+    ),
   });
   if (isCapExceeded(outcome)) {
     return c.html(
@@ -878,7 +887,10 @@ dashboardRoutes.get("/domain/:domain{.+\\.json}", async (c) => {
     getScanHistoryWithProtocols(db, domain.id, limit),
     getScanHistory(db, domain.id, 2),
   ]);
-  const detail = buildDrawerDetail(rawRows);
+  const detail = buildDrawerDetail(
+    rawRows,
+    parseScoringConfig((c.env as { SCORING_CONFIG?: string }).SCORING_CONFIG),
+  );
   return c.json({
     domain: domain.domain,
     grade: domain.last_grade ?? "—",
@@ -973,7 +985,11 @@ dashboardRoutes.post("/domain/:domain/scan", async (c) => {
     return c.text("Domain not found", 404);
   }
 
-  const result = await scan(owned.domain);
+  const result = await scan(
+    owned.domain,
+    [],
+    parseScoringConfig((c.env as { SCORING_CONFIG?: string }).SCORING_CONFIG),
+  );
   await recordScan(db, {
     domainId: owned.id,
     grade: result.grade,

--- a/src/env.ts
+++ b/src/env.ts
@@ -21,6 +21,11 @@ export interface Env {
   // but lives here so self-host forks don't accidentally ship data to the
   // hosted tier's dashboard.
   CF_ANALYTICS_TOKEN?: string;
+  // Self-host scoring rubric override (issue #25). A single JSON string of
+  // ScoringConfig knobs (see src/shared/scoring-config.ts). Absent/invalid →
+  // the shipped default rubric, so hosted dmarc.mx and config-less self-hosts
+  // are unaffected. Parsed per request via parseScoringConfig().
+  SCORING_CONFIG?: string;
   // Cloudflare Access enforcement on `*.workers.dev` preview-branch deploys.
   // Both must be set together — the middleware fail-CLOSEDs (503) on a
   // workers.dev hostname when either is missing. The production custom

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ import {
 import { normalizeDomain } from "./shared/domain.js";
 import { listIndexableScanDomains } from "./shared/indexable-domains.js";
 import { watchlistCapForPlan } from "./shared/limits.js";
+import { parseScoringConfig } from "./shared/scoring-config.js";
 import { CSS_PATH, JS_PATH } from "./views/assets.js";
 import {
   APPLE_TOUCH_ICON_BASE64,
@@ -623,6 +624,7 @@ app.get("/api/check/stream", async (c) => {
         });
         if (pending) protocolWrites.push(pending);
       },
+      parseScoringConfig(c.env?.SCORING_CONFIG),
     );
     await Promise.all(protocolWrites);
 
@@ -722,7 +724,9 @@ app.get("/badge", async (c) => {
 
   try {
     const cached = await getCachedScan(domain, []);
-    const result = cached ?? (await scan(domain, []));
+    const result =
+      cached ??
+      (await scan(domain, [], parseScoringConfig(c.env?.SCORING_CONFIG)));
     if (!cached) {
       const pendingCacheWrite = setCachedScan(domain, [], result);
       if (pendingCacheWrite) {
@@ -864,7 +868,10 @@ app.post("/mcp", async (c) => {
       400,
     );
   }
-  return handleMcpRequest(body, { executionCtx: c.executionCtx });
+  return handleMcpRequest(body, {
+    executionCtx: c.executionCtx,
+    scoringConfig: parseScoringConfig(c.env?.SCORING_CONFIG),
+  });
 });
 
 // SEP-1649 MCP server card — minimal shape, served before the RFC finalises.
@@ -975,7 +982,7 @@ app.get("/", (c) => {
 app.get("/scoring", (c) => {
   if (wantsMarkdown(c))
     return markdownResponse(c, renderScoringRubricMarkdown());
-  return c.html(renderScoringRubric());
+  return c.html(renderScoringRubric(parseScoringConfig(c.env?.SCORING_CONFIG)));
 });
 
 app.get("/learn", (c) => {
@@ -1039,7 +1046,13 @@ app.get("/api/check", async (c) => {
       data: { domain },
       level: "info",
     });
-    const result = cached ?? (await scan(domain, selectors));
+    const result =
+      cached ??
+      (await scan(
+        domain,
+        selectors,
+        parseScoringConfig(c.env?.SCORING_CONFIG),
+      ));
     tagScanResult(result);
     if (!cached) {
       const pendingCacheWrite = setCachedScan(domain, selectors, result);
@@ -1123,6 +1136,7 @@ app.post("/api/bulk-scan", async (c) => {
     userId: bearer.userId,
     rawDomains,
     watchlistCap: watchlistCapForPlan(plan),
+    scoringConfig: parseScoringConfig(c.env?.SCORING_CONFIG),
   });
   if (isCapExceeded(outcome)) {
     return c.json(
@@ -1229,7 +1243,11 @@ app.get("/check/score", async (c) => {
       data: { domain, selectors },
       level: "info",
     });
-    const result = await scan(domain, selectors);
+    const result = await scan(
+      domain,
+      selectors,
+      parseScoringConfig(c.env?.SCORING_CONFIG),
+    );
     tagScanResult(result);
     return c.html(renderScoreBreakdown(result));
   } catch (err) {
@@ -1280,7 +1298,13 @@ app.get("/check", async (c) => {
         level: "info",
       });
       const cached = await getCachedScan(domain, selectors);
-      const result = cached ?? (await scan(domain, selectors));
+      const result =
+        cached ??
+        (await scan(
+          domain,
+          selectors,
+          parseScoringConfig(c.env?.SCORING_CONFIG),
+        ));
       tagScanResult(result);
       if (!cached) {
         const pendingCacheWrite = setCachedScan(domain, selectors, result);
@@ -1304,7 +1328,11 @@ app.get("/check", async (c) => {
         data: { domain, selectors },
         level: "info",
       });
-      const result = await scan(domain, selectors);
+      const result = await scan(
+        domain,
+        selectors,
+        parseScoringConfig(c.env?.SCORING_CONFIG),
+      );
       tagScanResult(result);
       return c.json(result);
     } catch (err) {
@@ -1322,7 +1350,11 @@ app.get("/check", async (c) => {
         data: { domain, selectors },
         level: "info",
       });
-      const result = await scan(domain, selectors);
+      const result = await scan(
+        domain,
+        selectors,
+        parseScoringConfig(c.env?.SCORING_CONFIG),
+      );
       tagScanResult(result);
       return c.body(generateCsv(result), 200, {
         "Content-Type": "text/csv; charset=utf-8",
@@ -1351,7 +1383,13 @@ app.get("/check", async (c) => {
         data: { domain },
         level: "info",
       });
-      const result = cached ?? (await scan(domain, selectors));
+      const result =
+        cached ??
+        (await scan(
+          domain,
+          selectors,
+          parseScoringConfig(c.env?.SCORING_CONFIG),
+        ));
       tagScanResult(result);
       if (!cached) {
         const pendingCacheWrite = setCachedScan(domain, selectors, result);
@@ -1405,6 +1443,7 @@ async function scheduled(
     const rescanResult = await runDueRescans({
       db: env.DB,
       now: Math.floor(Date.now() / 1000),
+      scoringConfig: parseScoringConfig(env.SCORING_CONFIG),
     });
     const scope = Sentry.getCurrentScope();
     scope.setTag("cron.scanned", String(rescanResult.scanned));

--- a/src/mcp/handler.ts
+++ b/src/mcp/handler.ts
@@ -6,6 +6,7 @@
 import { getCachedScan, setCachedScan } from "../cache.js";
 import { scan } from "../orchestrator.js";
 import { normalizeDomain } from "../shared/domain.js";
+import type { ScoringConfig } from "../shared/scoring.js";
 
 // DKIM selector charset per RFC 6376 §3.1 — mirrors VALID_SELECTOR in index.ts.
 const VALID_SELECTOR = /^[A-Za-z0-9._-]+$/;
@@ -90,6 +91,8 @@ function rpcError(
 
 export interface McpEnv {
   executionCtx: ExecutionContext;
+  // Self-host scoring rubric override, forwarded to scan() (issue #25).
+  scoringConfig: Partial<ScoringConfig>;
 }
 
 export async function handleMcpRequest(
@@ -167,7 +170,7 @@ async function handleToolCall(
 
   try {
     const cached = await getCachedScan(domain, selectors);
-    const result = cached ?? (await scan(domain, selectors));
+    const result = cached ?? (await scan(domain, selectors, env.scoringConfig));
     if (!cached) {
       const pendingWrite = setCachedScan(domain, selectors, result);
       if (pendingWrite) {

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -20,7 +20,7 @@ import type {
   TlsRptResult,
 } from "./analyzers/types.js";
 import { queryTxt } from "./dns/client.js";
-import { computeGradeBreakdown } from "./shared/scoring.js";
+import { computeGradeBreakdown, type ScoringConfig } from "./shared/scoring.js";
 
 export type ProtocolId =
   | "mx"
@@ -44,6 +44,7 @@ export type ProtocolResult =
 async function buildScanResult(
   domain: string,
   protocols: ScanResult["protocols"],
+  config: Partial<ScoringConfig>,
 ): Promise<ScanResult> {
   // Cross-check MX hosts against MTA-STS policy patterns (RFC 8461 §3.4)
   const consistencyValidations = checkMxMtaStsConsistency(
@@ -62,7 +63,7 @@ async function buildScanResult(
     protocols.mta_sts.status = hasFailure ? "fail" : hasWarn ? "warn" : "pass";
   }
 
-  const breakdown = computeGradeBreakdown(protocols);
+  const breakdown = computeGradeBreakdown(protocols, config);
 
   // Easter egg: S grade for A+ domains advertising dmarc.mx
   if (breakdown.grade === "A+") {
@@ -102,7 +103,8 @@ async function buildScanResult(
 
 export async function scan(
   domain: string,
-  customSelectors: string[] = [],
+  customSelectors: string[],
+  config: Partial<ScoringConfig>,
 ): Promise<ScanResult> {
   // Fire all independent DNS queries immediately
   const dmarcPromise = analyzeDmarc(domain);
@@ -196,22 +198,27 @@ export async function scan(
     level: "info",
   });
 
-  return await buildScanResult(domain, {
-    mx: mxResult,
-    dmarc: dmarcResult,
-    spf: spfResult,
-    dkim: dkimResult,
-    bimi: bimiResult,
-    mta_sts: mtaStsResult,
-    security_txt: securityTxtResult,
-    tls_rpt: tlsRptResult,
-  });
+  return await buildScanResult(
+    domain,
+    {
+      mx: mxResult,
+      dmarc: dmarcResult,
+      spf: spfResult,
+      dkim: dkimResult,
+      bimi: bimiResult,
+      mta_sts: mtaStsResult,
+      security_txt: securityTxtResult,
+      tls_rpt: tlsRptResult,
+    },
+    config,
+  );
 }
 
 export async function scanStreaming(
   domain: string,
   customSelectors: string[],
   onResult: (id: ProtocolId, result: ProtocolResult) => void,
+  config: Partial<ScoringConfig>,
 ): Promise<ScanResult> {
   // ⚡ Bolt Optimization: Start all independent DNS queries immediately.
   // Previously, the streaming sequence awaited MX resolution before dispatching
@@ -341,14 +348,18 @@ export async function scanStreaming(
     tlsRptPromise,
   ]);
 
-  return await buildScanResult(domain, {
-    mx: mxResult,
-    dmarc: dmarcResult,
-    spf: spfResult,
-    dkim: dkimResult,
-    bimi: bimiResult,
-    mta_sts: mtaStsResult,
-    security_txt: securityTxtResult,
-    tls_rpt: tlsRptResult,
-  });
+  return await buildScanResult(
+    domain,
+    {
+      mx: mxResult,
+      dmarc: dmarcResult,
+      spf: spfResult,
+      dkim: dkimResult,
+      bimi: bimiResult,
+      mta_sts: mtaStsResult,
+      security_txt: securityTxtResult,
+      tls_rpt: tlsRptResult,
+    },
+    config,
+  );
 }

--- a/src/shared/scoring-config.ts
+++ b/src/shared/scoring-config.ts
@@ -1,0 +1,59 @@
+import type { ScoringConfig } from "./scoring.js";
+
+// Boolean knobs are accepted only when the JSON value is a real boolean.
+const BOOLEAN_KEYS = [
+  "requireBimiForAPlus",
+  "requireMtaStsForAPlus",
+] as const satisfies readonly (keyof ScoringConfig)[];
+
+// Numeric knobs are accepted only when finite and non-negative; anything else
+// is dropped so the corresponding default applies.
+const NUMBER_KEYS = [
+  "spfEfficientLookupThreshold",
+  "dkimKeyMinBits",
+  "lowPctDowngradeThreshold",
+  "dkimRotationSelectorCount",
+] as const satisfies readonly (keyof ScoringConfig)[];
+
+// Parses the SCORING_CONFIG wrangler var into a validated partial config.
+// Returns {} (→ shipped defaults) when the var is absent, not valid JSON, not
+// an object, or contains only unrecognised/invalid values. Per-key validation
+// is permissive: unknown keys and bad values are dropped silently; only a
+// hard JSON/shape failure emits a single console.warn. Self-hosters get a
+// working free-tier deploy regardless of what they put in the var.
+export function parseScoringConfig(
+  raw: string | undefined,
+): Partial<ScoringConfig> {
+  if (!raw) return {};
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    console.warn("SCORING_CONFIG is not valid JSON; using the default rubric.");
+    return {};
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    console.warn(
+      "SCORING_CONFIG must be a JSON object; using the default rubric.",
+    );
+    return {};
+  }
+
+  const source = parsed as Record<string, unknown>;
+  const out: Partial<ScoringConfig> = {};
+
+  for (const key of BOOLEAN_KEYS) {
+    const value = source[key];
+    if (typeof value === "boolean") out[key] = value;
+  }
+  for (const key of NUMBER_KEYS) {
+    const value = source[key];
+    if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+      out[key] = value;
+    }
+  }
+
+  return out;
+}

--- a/src/shared/scoring.ts
+++ b/src/shared/scoring.ts
@@ -60,6 +60,37 @@ function sumEffects(factors: ScoringFactor[]): number {
   return sum;
 }
 
+// ── Configurable rubric ────────────────────────────────────
+
+// Self-hosters can tune these knobs via the SCORING_CONFIG wrangler var
+// (see src/shared/scoring-config.ts). Every field defaults to dmarc.mx's
+// shipped behavior, so an unset/absent config produces identical grades.
+// Config holds only numbers/booleans — never user-supplied strings — so it
+// introduces no new HTML-output surface.
+export interface ScoringConfig {
+  // Whether the A+ tier requires a BIMI record.
+  requireBimiForAPlus: boolean;
+  // Whether the A+ tier requires enforcing (non-testing) MTA-STS.
+  requireMtaStsForAPlus: boolean;
+  // SPF DNS lookups at or below this earn the efficiency bonus.
+  spfEfficientLookupThreshold: number;
+  // DKIM keys below this many bits incur the weak-key penalty.
+  dkimKeyMinBits: number;
+  // DMARC pct below this downgrades the effective enforcement tier.
+  lowPctDowngradeThreshold: number;
+  // This many found DKIM selectors (or more) earns the rotation bonus.
+  dkimRotationSelectorCount: number;
+}
+
+export const DEFAULT_SCORING_CONFIG: ScoringConfig = {
+  requireBimiForAPlus: true,
+  requireMtaStsForAPlus: true,
+  spfEfficientLookupThreshold: 5,
+  dkimKeyMinBits: 2048,
+  lowPctDowngradeThreshold: 10,
+  dkimRotationSelectorCount: 2,
+};
+
 // ── Single decision engine ─────────────────────────────────
 
 interface ScoringResult {
@@ -71,7 +102,10 @@ interface ScoringResult {
   factors: ScoringFactor[];
 }
 
-function resolveScoring(protocols: Protocols): ScoringResult {
+function resolveScoring(
+  protocols: Protocols,
+  config: ScoringConfig,
+): ScoringResult {
   const { dmarc, spf, dkim, bimi, mta_sts } = protocols;
   const dmarcPolicy = dmarc.tags?.p?.toLowerCase() ?? null;
 
@@ -112,11 +146,11 @@ function resolveScoring(protocols: Protocols): ScoringResult {
   const hasBimi = bimi.record !== null;
   const hasMtaSts = mta_sts.status === "pass";
 
-  // pct < 10 effectively downgrades the policy one tier
-  // reject with pct < 10 → treated as quarantine-equivalent
-  // quarantine with pct < 10 → treated as near-none (C-tier max)
+  // pct below the downgrade threshold effectively drops the policy one tier
+  // reject with low pct → treated as quarantine-equivalent
+  // quarantine with low pct → treated as near-none (C-tier max)
   const effectivePolicy =
-    pct < 10
+    pct < config.lowPctDowngradeThreshold
       ? dmarcPolicy === "reject"
         ? "quarantine"
         : "quarantine"
@@ -139,12 +173,15 @@ function resolveScoring(protocols: Protocols): ScoringResult {
   // C tier: quarantine (or reject downgraded by low pct) with SPF + DKIM
   if (effectivePolicy === "quarantine") {
     const factors = [
-      ...spfFactors(spf),
-      ...dkimFactors(dkim),
-      ...dmarcFactors(dmarc),
+      ...spfFactors(spf, config),
+      ...dkimFactors(dkim, config),
+      ...dmarcFactors(dmarc, config),
     ];
     const modifier = sumEffects(factors);
-    const pctNote = pct < 10 ? ` (pct=${pct}% — effectively quarantine)` : "";
+    const pctNote =
+      pct < config.lowPctDowngradeThreshold
+        ? ` (pct=${pct}% — effectively quarantine)`
+        : "";
     return {
       grade: applyModifier("C", modifier),
       tier: "C",
@@ -163,14 +200,14 @@ function resolveScoring(protocols: Protocols): ScoringResult {
     // A+ tier: strong SPF + both BIMI and MTA-STS (enforcing)
     if (
       spfStrong &&
-      hasBimi &&
-      hasMtaSts &&
-      mta_sts.policy?.mode !== "testing"
+      (!config.requireBimiForAPlus || hasBimi) &&
+      (!config.requireMtaStsForAPlus ||
+        (hasMtaSts && mta_sts.policy?.mode !== "testing"))
     ) {
       const factors = [
-        ...spfFactors(spf),
-        ...dkimFactors(dkim),
-        ...dmarcFactors(dmarc),
+        ...spfFactors(spf, config),
+        ...dkimFactors(dkim, config),
+        ...dmarcFactors(dmarc, config),
       ];
       const modifier = sumEffects(factors);
       return {
@@ -187,9 +224,9 @@ function resolveScoring(protocols: Protocols): ScoringResult {
     // A tier: strong SPF + at least one extra
     if (spfStrong && hasExtras) {
       const factors = [
-        ...spfFactors(spf),
-        ...dkimFactors(dkim),
-        ...dmarcFactors(dmarc),
+        ...spfFactors(spf, config),
+        ...dkimFactors(dkim, config),
+        ...dmarcFactors(dmarc, config),
         ...mtaStsFactors(mta_sts),
       ];
       const modifier = sumEffects(factors);
@@ -207,9 +244,9 @@ function resolveScoring(protocols: Protocols): ScoringResult {
 
     // B tier
     const factors = [
-      ...spfFactors(spf),
-      ...dkimFactors(dkim),
-      ...dmarcFactors(dmarc),
+      ...spfFactors(spf, config),
+      ...dkimFactors(dkim, config),
+      ...dmarcFactors(dmarc, config),
       ...mtaStsFactors(mta_sts),
     ];
     if (hasBimi) {
@@ -239,9 +276,9 @@ function resolveScoring(protocols: Protocols): ScoringResult {
 
   // Fallback (shouldn't normally reach here)
   const factors = [
-    ...spfFactors(spf),
-    ...dkimFactors(dkim),
-    ...dmarcFactors(dmarc),
+    ...spfFactors(spf, config),
+    ...dkimFactors(dkim, config),
+    ...dmarcFactors(dmarc, config),
   ];
   const modifier = sumEffects(factors);
   return {
@@ -256,13 +293,25 @@ function resolveScoring(protocols: Protocols): ScoringResult {
 
 // ── Public API (thin wrappers) ────────────────────────
 
-export function computeGrade(protocols: Protocols): string {
-  return resolveScoring(protocols).grade;
+export function computeGrade(
+  protocols: Protocols,
+  config: Partial<ScoringConfig> = {},
+): string {
+  return resolveScoring(protocols, { ...DEFAULT_SCORING_CONFIG, ...config })
+    .grade;
 }
 
-export function computeGradeBreakdown(protocols: Protocols): GradeBreakdown {
-  const scoring = resolveScoring(protocols);
-  const recommendations = generateRecommendations(scoring.tier, protocols);
+export function computeGradeBreakdown(
+  protocols: Protocols,
+  config: Partial<ScoringConfig> = {},
+): GradeBreakdown {
+  const merged = { ...DEFAULT_SCORING_CONFIG, ...config };
+  const scoring = resolveScoring(protocols, merged);
+  const recommendations = generateRecommendations(
+    scoring.tier,
+    protocols,
+    merged,
+  );
   const protocolSummaries = buildProtocolSummaries(protocols);
 
   return {
@@ -290,22 +339,25 @@ function modifierToLabel(modifier: number): string {
 
 // ── Factor helpers ────────────────────────────────
 
-function spfFactors(spf: SpfResult): ScoringFactor[] {
+function spfFactors(spf: SpfResult, config: ScoringConfig): ScoringFactor[] {
   const factors: ScoringFactor[] = [];
-  if (spf.lookups_used <= 5) {
+  if (spf.lookups_used <= config.spfEfficientLookupThreshold) {
     factors.push({
       protocol: "spf",
-      label: `${spf.lookups_used} DNS lookups (≤5, efficient)`,
+      label: `${spf.lookups_used} DNS lookups (≤${config.spfEfficientLookupThreshold}, efficient)`,
       effect: +1,
     });
   }
   return factors;
 }
 
-function dmarcFactors(dmarc: DmarcResult): ScoringFactor[] {
+function dmarcFactors(
+  dmarc: DmarcResult,
+  config: ScoringConfig,
+): ScoringFactor[] {
   const factors: ScoringFactor[] = [];
   const pct = dmarc.tags?.pct ? Number.parseInt(dmarc.tags.pct, 10) : 100;
-  if (pct >= 10 && pct < 100) {
+  if (pct >= config.lowPctDowngradeThreshold && pct < 100) {
     factors.push({
       protocol: "dmarc",
       label: `Policy applied to only ${pct}% of messages (pct=${pct})`,
@@ -340,7 +392,7 @@ function mtaStsFactors(mta_sts: MtaStsResult): ScoringFactor[] {
   return factors;
 }
 
-function dkimFactors(dkim: DkimResult): ScoringFactor[] {
+function dkimFactors(dkim: DkimResult, config: ScoringConfig): ScoringFactor[] {
   const factors: ScoringFactor[] = [];
 
   // ⚡ Bolt Optimization: Use for...in instead of Object.entries().filter()
@@ -352,7 +404,7 @@ function dkimFactors(dkim: DkimResult): ScoringFactor[] {
     const s = dkim.selectors[name];
     if (s.found) {
       foundCount++;
-      if (s.key_bits && s.key_bits < 2048) {
+      if (s.key_bits && s.key_bits < config.dkimKeyMinBits) {
         weakKeyNames.push(name);
       }
     }
@@ -361,11 +413,11 @@ function dkimFactors(dkim: DkimResult): ScoringFactor[] {
   if (weakKeyNames.length > 0) {
     factors.push({
       protocol: "dkim",
-      label: `Key under 2048 bits (${weakKeyNames.join(", ")})`,
+      label: `Key under ${config.dkimKeyMinBits} bits (${weakKeyNames.join(", ")})`,
       effect: -1,
     });
   }
-  if (foundCount >= 2) {
+  if (foundCount >= config.dkimRotationSelectorCount) {
     factors.push({
       protocol: "dkim",
       label: `${foundCount} selectors found (rotation ready)`,
@@ -445,6 +497,7 @@ function buildProtocolSummaries(
 function generateRecommendations(
   tier: string,
   protocols: Protocols,
+  config: ScoringConfig,
 ): Recommendation[] {
   const { dmarc, spf, dkim, bimi, mta_sts } = protocols;
   const recs: Recommendation[] = [];
@@ -510,15 +563,15 @@ function generateRecommendations(
   // DMARC improvements
   const pct = dmarc.tags?.pct ? Number.parseInt(dmarc.tags.pct, 10) : 100;
   if (pct < 100) {
+    const lowPct = pct < config.lowPctDowngradeThreshold;
     recs.push({
-      priority: pct < 10 ? 1 : 2,
+      priority: lowPct ? 1 : 2,
       protocol: "dmarc",
       title: "Increase DMARC pct to 100%",
       description: `Only ${pct}% of failing messages are subject to your policy. Gradually increase pct to 100 for full enforcement.`,
-      impact:
-        pct < 10
-          ? "Would raise effective enforcement tier"
-          : "Removes a scoring penalty",
+      impact: lowPct
+        ? "Would raise effective enforcement tier"
+        : "Removes a scoring penalty",
     });
   }
   if (!dmarc.tags?.rua) {
@@ -533,12 +586,12 @@ function generateRecommendations(
   }
 
   // SPF improvements
-  if (hasSpf && spf.lookups_used > 5) {
+  if (hasSpf && spf.lookups_used > config.spfEfficientLookupThreshold) {
     recs.push({
       priority: 3,
       protocol: "spf",
       title: "Reduce SPF DNS lookups",
-      description: `Your SPF record uses ${spf.lookups_used} DNS lookups. Flatten includes or remove unused entries to get to ≤5 for a scoring bonus.`,
+      description: `Your SPF record uses ${spf.lookups_used} DNS lookups. Flatten includes or remove unused entries to get to ≤${config.spfEfficientLookupThreshold} for a scoring bonus.`,
       impact: "Adds a scoring bonus",
     });
   }
@@ -552,7 +605,7 @@ function generateRecommendations(
     const s = dkim.selectors[name];
     if (s.found) {
       foundSelectorCount++;
-      if (s.key_bits && s.key_bits < 2048) {
+      if (s.key_bits && s.key_bits < config.dkimKeyMinBits) {
         weakKeyNames.push(name);
       }
     }
@@ -563,8 +616,8 @@ function generateRecommendations(
     recs.push({
       priority: 2,
       protocol: "dkim",
-      title: `Upgrade DKIM key${weakKeyNames.length > 1 ? "s" : ""} to 2048 bits`,
-      description: `The ${names} selector${weakKeyNames.length > 1 ? "s use" : " uses"} a key under 2048 bits. Rotate to a 2048-bit or larger key.`,
+      title: `Upgrade DKIM key${weakKeyNames.length > 1 ? "s" : ""} to ${config.dkimKeyMinBits} bits`,
+      description: `The ${names} selector${weakKeyNames.length > 1 ? "s use" : " uses"} a key under ${config.dkimKeyMinBits} bits. Rotate to a ${config.dkimKeyMinBits}-bit or larger key.`,
       impact: "Removes a scoring penalty",
     });
   }
@@ -622,7 +675,7 @@ function generateRecommendations(
   }
 
   // DKIM rotation
-  if (hasDkim && foundSelectorCount < 2) {
+  if (hasDkim && foundSelectorCount < config.dkimRotationSelectorCount) {
     recs.push({
       priority: 3,
       protocol: "dkim",

--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -10,6 +10,10 @@ import type {
   TlsRptResult,
 } from "../analyzers/types.js";
 import { isIndexableScanDomain } from "../shared/indexable-domains.js";
+import {
+  DEFAULT_SCORING_CONFIG,
+  type ScoringConfig,
+} from "../shared/scoring.js";
 import { CSS_PATH, JS_PATH } from "./assets.js";
 import {
   dkimSelectorGrid,
@@ -642,7 +646,19 @@ const SCORING_JSON_LD = JSON.stringify({
   ],
 });
 
-export function renderScoringRubric(): string {
+export function renderScoringRubric(
+  config: Partial<ScoringConfig> = {},
+): string {
+  const cfg = { ...DEFAULT_SCORING_CONFIG, ...config };
+  // A+ extras prose reflects the active requireBimi/requireMtaSts knobs.
+  const aplusReq =
+    cfg.requireBimiForAPlus && cfg.requireMtaStsForAPlus
+      ? "<em>both</em> BIMI and MTA-STS (enforcing)"
+      : cfg.requireBimiForAPlus
+        ? "BIMI"
+        : cfg.requireMtaStsForAPlus
+          ? "MTA-STS (enforcing)"
+          : "no additional extras";
   const body = `<main class="breakdown">
   <div class="report-nav">
     <a href="/">${generateCreature("sm")} Home</a>
@@ -665,7 +681,7 @@ export function renderScoringRubric(): string {
         <tbody>
           <tr class="rubric-row-a">
             <td><span class="rubric-grade grade-a">A+</span></td>
-            <td>DMARC p=reject + SPF within lookup limit + DKIM + <em>both</em> BIMI and MTA-STS (enforcing)</td>
+            <td>DMARC p=reject + SPF within lookup limit + DKIM + ${aplusReq}</td>
           </tr>
           <tr class="rubric-row-a">
             <td><span class="rubric-grade grade-a">A</span></td>
@@ -677,7 +693,7 @@ export function renderScoringRubric(): string {
           </tr>
           <tr class="rubric-row-c">
             <td><span class="rubric-grade grade-c">C</span></td>
-            <td>DMARC p=quarantine + SPF + DKIM passing (or p=reject with pct &lt; 10%)</td>
+            <td>DMARC p=quarantine + SPF + DKIM passing (or p=reject with pct &lt; ${cfg.lowPctDowngradeThreshold}%)</td>
           </tr>
           <tr class="rubric-row-d">
             <td><span class="rubric-grade grade-c">D</span></td>
@@ -702,9 +718,9 @@ export function renderScoringRubric(): string {
           <tr><td>DMARC aggregate reporting (rua) configured</td><td class="effect-plus">+1</td></tr>
           <tr><td>No DMARC reporting (rua/ruf) configured</td><td class="effect-minus">&minus;1</td></tr>
           <tr><td>DMARC pct &lt; 100% (partial enforcement)</td><td class="effect-minus">&minus;1</td></tr>
-          <tr><td>SPF uses &le;5 DNS lookups</td><td class="effect-plus">+1</td></tr>
-          <tr><td>Any DKIM key under 2048 bits</td><td class="effect-minus">&minus;1</td></tr>
-          <tr><td>2 or more DKIM selectors found</td><td class="effect-plus">+1</td></tr>
+          <tr><td>SPF uses &le;${cfg.spfEfficientLookupThreshold} DNS lookups</td><td class="effect-plus">+1</td></tr>
+          <tr><td>Any DKIM key under ${cfg.dkimKeyMinBits} bits</td><td class="effect-minus">&minus;1</td></tr>
+          <tr><td>${cfg.dkimRotationSelectorCount} or more DKIM selectors found</td><td class="effect-plus">+1</td></tr>
           <tr><td>BIMI configured (B tier)</td><td class="effect-plus">+1</td></tr>
           <tr><td>MTA-STS configured (B tier)</td><td class="effect-plus">+1</td></tr>
           <tr><td>MTA-STS in testing mode</td><td class="effect-minus">&minus;1</td></tr>

--- a/test/api-check-stream.test.ts
+++ b/test/api-check-stream.test.ts
@@ -411,6 +411,7 @@ describe("GET /api/check/stream — custom selectors", () => {
       "test.example.com",
       ["google", "microsoft"],
       expect.any(Function),
+      {},
     );
   });
 

--- a/test/scoring-config-integration.test.ts
+++ b/test/scoring-config-integration.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Integration anchor: proves the SCORING_CONFIG knob actually reaches the
+ * grade computation through scan() → buildScanResult() → computeGradeBreakdown().
+ * The analyzer layer is mocked to a fixed A-tier domain (p=reject + strong SPF
+ * + DKIM + enforcing MTA-STS, no BIMI). Under defaults that domain is the A
+ * tier; flipping requireBimiForAPlus off must promote it to A+ — which can only
+ * happen if scan() forwarded the config.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/analyzers/dmarc.js", () => ({
+  analyzeDmarc: vi.fn().mockResolvedValue({
+    status: "pass",
+    record: "v=DMARC1; p=reject; rua=mailto:dmarc@example.com",
+    tags: { v: "DMARC1", p: "reject", rua: "mailto:dmarc@example.com" },
+    validations: [],
+  }),
+}));
+vi.mock("../src/analyzers/spf.js", () => ({
+  analyzeSpf: vi.fn().mockResolvedValue({
+    status: "pass",
+    record: "v=spf1 -all",
+    lookups_used: 3,
+    lookup_limit: 10,
+    include_tree: null,
+    validations: [],
+  }),
+}));
+vi.mock("../src/analyzers/dkim.js", () => ({
+  analyzeDkim: vi.fn().mockResolvedValue({
+    status: "pass",
+    selectors: {
+      google: { found: true, key_type: "rsa", key_bits: 2048 },
+      selector1: { found: true, key_type: "rsa", key_bits: 2048 },
+    },
+    validations: [],
+  }),
+}));
+vi.mock("../src/analyzers/bimi.js", () => ({
+  prefetchBimiDns: vi.fn().mockResolvedValue(null),
+  analyzeBimi: vi.fn().mockResolvedValue({
+    status: "warn",
+    record: null,
+    tags: null,
+    validations: [],
+  }),
+}));
+vi.mock("../src/analyzers/mta-sts.js", () => ({
+  analyzeMtaSts: vi.fn().mockResolvedValue({
+    status: "pass",
+    dns_record: "v=STSv1; id=20260101",
+    policy: {
+      version: "STSv1",
+      mode: "enforce",
+      mx: ["*.example.com"],
+      max_age: 86400,
+    },
+    validations: [],
+  }),
+}));
+vi.mock("../src/analyzers/mx.js", () => ({
+  analyzeMx: vi.fn().mockResolvedValue({
+    status: "info",
+    records: [],
+    providers: [],
+    validations: [],
+  }),
+}));
+vi.mock("../src/analyzers/mx-mta-sts-consistency.js", () => ({
+  checkMxMtaStsConsistency: vi.fn().mockReturnValue([]),
+}));
+vi.mock("../src/analyzers/security-txt.js", () => ({
+  analyzeSecurityTxt: vi.fn().mockResolvedValue({
+    status: "info",
+    source_url: null,
+    signed: false,
+    fields: null,
+    validations: [],
+  }),
+}));
+vi.mock("../src/analyzers/tls-rpt.js", () => ({
+  analyzeTlsRpt: vi.fn().mockResolvedValue({
+    status: "info",
+    record: null,
+    tags: null,
+    validations: [],
+  }),
+}));
+vi.mock("../src/dns/client.js", () => ({
+  queryTxt: vi.fn().mockResolvedValue(null),
+  queryMx: vi.fn().mockResolvedValue(null),
+}));
+
+import { scan } from "../src/orchestrator.js";
+
+describe("scan() forwards SCORING_CONFIG to the grade computation", () => {
+  it("grades the A tier under default config", async () => {
+    const result = await scan("example.com", [], {});
+    expect(result.breakdown.tier).toBe("A");
+  });
+
+  it("grades the A+ tier when requireBimiForAPlus is disabled", async () => {
+    const result = await scan("example.com", [], {
+      requireBimiForAPlus: false,
+    });
+    expect(result.breakdown.tier).toBe("A+");
+  });
+});

--- a/test/scoring-config.test.ts
+++ b/test/scoring-config.test.ts
@@ -1,0 +1,275 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  BimiResult,
+  DkimResult,
+  DmarcResult,
+  MtaStsResult,
+  SpfResult,
+} from "../src/analyzers/types.js";
+import { computeGradeBreakdown } from "../src/shared/scoring.js";
+import { parseScoringConfig } from "../src/shared/scoring-config.js";
+
+function makeDmarc(overrides: Partial<DmarcResult> = {}): DmarcResult {
+  return {
+    status: "pass",
+    record: "v=DMARC1; p=reject; rua=mailto:dmarc@example.com",
+    tags: { v: "DMARC1", p: "reject", rua: "mailto:dmarc@example.com" },
+    validations: [],
+    ...overrides,
+  };
+}
+
+function makeSpf(overrides: Partial<SpfResult> = {}): SpfResult {
+  return {
+    status: "pass",
+    record: "v=spf1 -all",
+    lookups_used: 3,
+    lookup_limit: 10,
+    include_tree: null,
+    validations: [],
+    ...overrides,
+  };
+}
+
+function makeDkim(overrides: Partial<DkimResult> = {}): DkimResult {
+  return {
+    status: "pass",
+    selectors: {
+      google: { found: true, key_type: "rsa", key_bits: 2048 },
+      selector1: { found: true, key_type: "rsa", key_bits: 2048 },
+    },
+    validations: [],
+    ...overrides,
+  };
+}
+
+function makeBimi(overrides: Partial<BimiResult> = {}): BimiResult {
+  const base = {
+    status: "warn" as const,
+    record: null as string | null,
+    tags: null as Record<string, string> | null,
+    validations: [] as BimiResult["validations"],
+  };
+  const merged = { ...base, ...overrides };
+  if (merged.status === "pass" && merged.record === null) {
+    merged.record = "v=BIMI1; l=https://example.com/logo.svg";
+    merged.tags = { v: "BIMI1", l: "https://example.com/logo.svg" };
+  }
+  return merged;
+}
+
+function makeMtaSts(overrides: Partial<MtaStsResult> = {}): MtaStsResult {
+  return {
+    status: "fail",
+    dns_record: null,
+    policy: null,
+    validations: [],
+    ...overrides,
+  };
+}
+
+const enforcingMtaSts = makeMtaSts({
+  status: "pass",
+  policy: {
+    version: "STSv1",
+    mode: "enforce",
+    mx: ["*.example.com"],
+    max_age: 86400,
+  },
+});
+
+describe("scoring config — requireBimiForAPlus", () => {
+  it("lands in the A tier (not A+) for reject+SPF+DKIM+MTA-STS but no BIMI under defaults", () => {
+    const bd = computeGradeBreakdown({
+      dmarc: makeDmarc(),
+      spf: makeSpf(),
+      dkim: makeDkim(),
+      bimi: makeBimi(),
+      mta_sts: enforcingMtaSts,
+    });
+    expect(bd.tier).toBe("A");
+  });
+
+  it("lands in the A+ tier for the same domain when requireBimiForAPlus is false", () => {
+    const bd = computeGradeBreakdown(
+      {
+        dmarc: makeDmarc(),
+        spf: makeSpf(),
+        dkim: makeDkim(),
+        bimi: makeBimi(),
+        mta_sts: enforcingMtaSts,
+      },
+      { requireBimiForAPlus: false },
+    );
+    expect(bd.tier).toBe("A+");
+  });
+});
+
+describe("scoring config — requireMtaStsForAPlus", () => {
+  it("lands in the A+ tier with BIMI but no MTA-STS when requireMtaStsForAPlus is false", () => {
+    const bd = computeGradeBreakdown(
+      {
+        dmarc: makeDmarc(),
+        spf: makeSpf(),
+        dkim: makeDkim(),
+        bimi: makeBimi({ status: "pass" }),
+        mta_sts: makeMtaSts(),
+      },
+      { requireMtaStsForAPlus: false },
+    );
+    expect(bd.tier).toBe("A+");
+  });
+});
+
+describe("scoring config — numeric factor knobs", () => {
+  const base = {
+    dmarc: makeDmarc(),
+    dkim: makeDkim(),
+    bimi: makeBimi(),
+    mta_sts: makeMtaSts(),
+  };
+
+  it("withholds the SPF efficiency bonus above the configured threshold by default", () => {
+    const bd = computeGradeBreakdown({
+      ...base,
+      spf: makeSpf({ lookups_used: 7 }),
+    });
+    expect(bd.factors.some((f) => f.protocol === "spf" && f.effect === 1)).toBe(
+      false,
+    );
+  });
+
+  it("awards the SPF efficiency bonus when spfEfficientLookupThreshold is raised", () => {
+    const bd = computeGradeBreakdown(
+      { ...base, spf: makeSpf({ lookups_used: 7 }) },
+      { spfEfficientLookupThreshold: 8 },
+    );
+    expect(bd.factors.some((f) => f.protocol === "spf" && f.effect === 1)).toBe(
+      true,
+    );
+  });
+
+  it("penalizes a 2048-bit DKIM key when dkimKeyMinBits is raised to 4096", () => {
+    const bd = computeGradeBreakdown(
+      { ...base, spf: makeSpf() },
+      { dkimKeyMinBits: 4096 },
+    );
+    expect(
+      bd.factors.some((f) => f.protocol === "dkim" && f.effect === -1),
+    ).toBe(true);
+  });
+
+  it("withholds the DKIM rotation bonus when dkimRotationSelectorCount exceeds the selector count", () => {
+    const bd = computeGradeBreakdown(
+      { ...base, spf: makeSpf() },
+      { dkimRotationSelectorCount: 3 },
+    );
+    expect(
+      bd.factors.some((f) => f.protocol === "dkim" && f.effect === 1),
+    ).toBe(false);
+  });
+});
+
+describe("scoring config — lowPctDowngradeThreshold", () => {
+  const lowPctDmarc = makeDmarc({
+    tags: {
+      v: "DMARC1",
+      p: "reject",
+      rua: "mailto:dmarc@example.com",
+      pct: "5",
+    },
+  });
+
+  it("downgrades reject to the C tier at pct=5 under the default threshold of 10", () => {
+    const bd = computeGradeBreakdown({
+      dmarc: lowPctDmarc,
+      spf: makeSpf(),
+      dkim: makeDkim(),
+      bimi: makeBimi(),
+      mta_sts: makeMtaSts(),
+    });
+    expect(bd.tier).toBe("C");
+  });
+
+  it("keeps reject in the B tier at pct=5 when lowPctDowngradeThreshold is 3", () => {
+    const bd = computeGradeBreakdown(
+      {
+        dmarc: lowPctDmarc,
+        spf: makeSpf(),
+        dkim: makeDkim(),
+        bimi: makeBimi(),
+        mta_sts: makeMtaSts(),
+      },
+      { lowPctDowngradeThreshold: 3 },
+    );
+    expect(bd.tier).toBe("B");
+  });
+});
+
+describe("scoring config — recommendations follow the knobs (AC#3)", () => {
+  it("recommends a DKIM key upgrade when dkimKeyMinBits is raised above the actual key size", () => {
+    const bd = computeGradeBreakdown(
+      {
+        dmarc: makeDmarc(),
+        spf: makeSpf(),
+        dkim: makeDkim(),
+        bimi: makeBimi(),
+        mta_sts: makeMtaSts(),
+      },
+      { dkimKeyMinBits: 4096 },
+    );
+    expect(
+      bd.recommendations.some(
+        (r) => r.protocol === "dkim" && /upgrade dkim key/i.test(r.title),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("parseScoringConfig", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns an empty partial when the var is undefined", () => {
+    expect(parseScoringConfig(undefined)).toEqual({});
+  });
+
+  it("returns an empty partial for an empty string", () => {
+    expect(parseScoringConfig("")).toEqual({});
+  });
+
+  it("parses a valid subset of known keys", () => {
+    expect(
+      parseScoringConfig(
+        '{"spfEfficientLookupThreshold":8,"requireMtaStsForAPlus":false}',
+      ),
+    ).toEqual({ spfEfficientLookupThreshold: 8, requireMtaStsForAPlus: false });
+  });
+
+  it("ignores unknown keys", () => {
+    expect(parseScoringConfig('{"dkimKeyMinBits":4096,"foo":1}')).toEqual({
+      dkimKeyMinBits: 4096,
+    });
+  });
+
+  it("warns once and falls back to {} on invalid JSON", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(parseScoringConfig("not json{")).toEqual({});
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops a knob whose value is the wrong type", () => {
+    expect(parseScoringConfig('{"requireBimiForAPlus":"yes"}')).toEqual({});
+  });
+
+  it("drops a numeric knob that is out of range", () => {
+    expect(parseScoringConfig('{"dkimKeyMinBits":-5}')).toEqual({});
+  });
+
+  it("falls back to {} when the JSON is not an object", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(parseScoringConfig("42")).toEqual({});
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -21,6 +21,18 @@ port = 8790
 ACCESS_AUD = "7b283d5d9b56f6fffa342280310a4ae68f13cbb05dc27f3c1d2faec2deae507a"
 ACCESS_TEAM_DOMAIN = "coryrankin.cloudflareaccess.com"
 
+# Self-host scoring rubric override (issue #25). A single JSON string of
+# ScoringConfig knobs; absent or invalid → the shipped default rubric, so
+# hosted dmarc.mx leaves this UNSET. Recognized keys (with defaults):
+#   requireBimiForAPlus         (bool, true)  — A+ requires a BIMI record
+#   requireMtaStsForAPlus       (bool, true)  — A+ requires enforcing MTA-STS
+#   spfEfficientLookupThreshold (num,  5)     — SPF lookups ≤ this earn +1
+#   dkimKeyMinBits              (num,  2048)  — keys below this incur −1
+#   lowPctDowngradeThreshold    (num,  10)    — pct below this downgrades a tier
+#   dkimRotationSelectorCount   (num,  2)     — this many selectors earn +1
+# Example (self-hosters uncomment and edit):
+# SCORING_CONFIG = '{"requireBimiForAPlus":false,"dkimKeyMinBits":4096}'
+
 [triggers]
 crons = ["17 6 * * *"]
 


### PR DESCRIPTION
## Summary

Closes #25. Lets self-hosters tune the grading rubric (per-tier protocol requirements + numeric thresholds) via a single `SCORING_CONFIG` JSON env var, instead of forking `src/shared/scoring.ts`. Absent or invalid → the shipped default rubric, so **hosted dmarc.mx and config-less self-hosts are byte-for-byte unaffected**.

Spec/plan: confirmed in [#25](https://github.com/schmug/dmarcheck/issues/25); decided format = single JSON blob, custom-rec text + KV runtime config out of v1.

## What changed

- **`src/shared/scoring.ts`** — `ScoringConfig` type + `DEFAULT_SCORING_CONFIG`; `computeGrade`/`computeGradeBreakdown` take an optional `Partial<ScoringConfig>` merged over defaults (backward-compatible). Knobs thread through `resolveScoring`, the factor helpers, and `generateRecommendations` (numbers interpolated so customized rubrics don't show stale text).
- **`src/shared/scoring-config.ts`** (new) — parses + validates the env var with a hand-rolled type guard (no new dependency): unknown keys and out-of-range/wrong-type values are dropped; one `console.warn` on malformed JSON / non-object → `{}`.
- **Threading** — `scan`/`scanStreaming` take a **required** `config` param, so the compiler enforces that every call site (index routes, `/mcp`, bulk-scan, cron rescan, dashboard) passes the active config. This turns "silently-missed route → A on `/api/check` but A+ on `/mcp`" into a compile error.
- **`/scoring`** — the HTML rubric reflects active thresholds when the var is set. `SCORING_JSON_LD` and the markdown renderer intentionally stay canonical defaults (SEO/structured data; hosted dmarc.mx never sets the var).
- **Docs** — `wrangler.toml` documents the var with an example; README + CLAUDE.md updated.

### Knobs (all default to current behavior)
`requireBimiForAPlus` · `requireMtaStsForAPlus` · `spfEfficientLookupThreshold` (5) · `dkimKeyMinBits` (2048) · `lowPctDowngradeThreshold` (10) · `dkimRotationSelectorCount` (2)

## Tests

**1093 passing, 0 failing.** Lint (biome) + typecheck (tsc) clean. New coverage in `test/scoring-config.test.ts` (18: per-knob behavior + parser validation) and `test/scoring-config-integration.test.ts` (2: proves config flows `scan` → breakdown end-to-end). The existing 44 scoring tests pass unchanged — the regression guard for "defaults are identical".

## Out of scope (v1)

- Custom recommendation **text** (free-text → HTML = XSS surface; self-hosters fork).
- **KV** runtime config (deploy-time vars only).
- `SCORING_JSON_LD` + markdown `/scoring` reflecting custom config — deliberate boundary; follow-up issue to come.

## Review note

Touches CODEOWNERS-gated paths (`src/shared/scoring.ts`, `src/orchestrator.ts`) → requires a code-owner approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
