### PR TITLE
docs: OSPS Baseline governance + security-policy hardening

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing to dmarcheck
+
+Thanks for your interest in dmarcheck — a DNS email-security analyzer (DMARC,
+SPF, DKIM, BIMI, MTA-STS) running as a Cloudflare Worker, live at
+[dmarc.mx](https://dmarc.mx). This guide covers how to report problems and how
+to land a change.
+
+## Reporting bugs and requesting features
+
+- **Security vulnerabilities — do not open a public issue.** Follow the private
+  disclosure process in [SECURITY.md](SECURITY.md) instead.
+- **Bugs and feature requests** go in the
+  [GitHub issue tracker](https://github.com/schmug/dmarcheck/issues). Search
+  open issues first to avoid duplicates.
+
+A good bug report includes: what you ran (the domain or API call), what you
+expected, what actually happened, and — for scan results — whether you can
+reproduce it against [dmarc.mx](https://dmarc.mx) or only a self-hosted build.
+
+## Development setup
+
+Requires Node.js 22 (the version CI runs on; v18+ works locally).
+
+```bash
+git clone https://github.com/schmug/dmarcheck.git
+cd dmarcheck
+npm ci            # clean install from the lockfile (use `npm install` only when changing deps)
+npm run dev       # local dev server on http://localhost:8790
+```
+
+## The four commands you'll use
+
+| Command | What it does |
+|---------|--------------|
+| `npm test` | Vitest unit tests (`test/`) |
+| `npm run lint` | Biome lint + format check (`npm run lint:fix` to auto-fix) |
+| `npm run typecheck` | `tsc --noEmit` |
+| `npm run dev` | Local Worker on port 8790 |
+
+See [AGENTS.md](AGENTS.md) for the full command list and architecture notes.
+
+> **Do not run `npm run deploy`.** Deployment is automatic via Cloudflare's Git
+> integration on push to `main`; a manual deploy collides with it and causes
+> stale deploys.
+
+## Submitting a change
+
+1. **Branch off `main`** — never push to `main` directly (it's protected).
+2. **Write tests for non-trivial changes.** New analyzer behavior, scoring
+   boundaries, and parsing logic all need test coverage; CI runs `npm test` on
+   every PR and a change that needs tests but ships without them will be asked
+   to add them. Pure-docs changes don't.
+3. **Run the gate locally before pushing:**
+   ```bash
+   npm run lint && npm run typecheck && npm test
+   ```
+4. **Use a [conventional commit](https://www.conventionalcommits.org/) prefix.**
+   The changelog is generated from commit history by git-cliff, so the prefix
+   matters. Allowed prefixes: `feat:`, `fix:`, `refactor:`, `test:`, `chore:`,
+   `docs:`, `security:`, `seo:`.
+5. **Open a pull request against `main`.** CI must pass: lint, typecheck, tests,
+   and a `npm audit --audit-level=high --omit=dev` supply-chain gate.
+
+## Review and merge
+
+Most PRs merge once CI is green. PRs that touch security-sensitive paths
+(CI workflows, lockfiles, input validation, redirect posture, rate limiting,
+DB migrations, analyzer modules, orchestration, or scoring) require an
+approving review from a code owner — see
+[`.github/CODEOWNERS`](.github/CODEOWNERS) and
+[MAINTAINERS.md](MAINTAINERS.md). The autonomous-routine auto-merge path and its
+compensating controls are documented in
+[docs/OSPS-DEVIATIONS.md](docs/OSPS-DEVIATIONS.md).
+
+## Code of conduct
+
+Be respectful and constructive. A formal `CODE_OF_CONDUCT.md` may be added
+later; until then, the maintainer moderates participation at their discretion.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,58 @@
+# Maintainers
+
+This file lists the people responsible for dmarcheck and the policy for how
+that responsibility is granted and removed. It satisfies the project-governance
+expectations of the OSPS Baseline (GV-01, GV-04).
+
+## Current maintainers
+
+| Handle | Role | Scope | Contact |
+|--------|------|-------|---------|
+| [@schmug](https://github.com/schmug) | Maintainer | Full: write access, releases, secrets, security disclosures | via [GitHub profile](https://github.com/schmug) / [SECURITY.md](SECURITY.md) |
+
+dmarcheck is currently maintained by a single person in their spare time.
+
+## Roles
+
+- **Maintainer** — write access to the repository, authority to merge and
+  release, holds deployment/billing secrets, and is the named code owner in
+  [`.github/CODEOWNERS`](.github/CODEOWNERS). Maintainers are the approvers for
+  security-sensitive PRs.
+- **Triager** *(none today; defined for future growth)* — triage access:
+  label, assign, and close issues/PRs, but no merge or release authority.
+
+## Automation identity
+
+Autonomous [Claude Code Routines](docs/routine-pipeline.md) open and merge
+routine PRs unattended. Today those commits are authored by **@schmug** because
+the routines run with the maintainer's credentials. Splitting them onto a
+dedicated non-admin `dmarcheck-bot` identity — which is what makes the
+[`CODEOWNERS`](.github/CODEOWNERS) human-review gate *enforcing* rather than
+advisory — is tracked in
+[#299](https://github.com/schmug/dmarcheck/issues/299). Until #299 lands, treat
+the CODEOWNERS gate on security-sensitive paths as advisory for automation. See
+[docs/OSPS-DEVIATIONS.md](docs/OSPS-DEVIATIONS.md) for the full rationale and
+compensating controls.
+
+## Becoming a maintainer
+
+There is no formal nomination process yet given the project's size. A
+contributor with a sustained track record of quality PRs and issue triage may
+be invited by an existing maintainer to take a Triager or Maintainer role.
+Maintainership requires the ability to be reached for security disclosures.
+
+## Removing a maintainer
+
+A maintainer may step down at any time by opening a PR removing themselves from
+this file. A maintainer may be removed by consensus of the remaining
+maintainers for inactivity (no activity for ~6 months) or for conduct that
+undermines the project. When a maintainer is removed, their write access,
+secret access, and CODEOWNERS entries are revoked in the same change.
+
+## Security and review policy
+
+- Vulnerability reports follow [SECURITY.md](SECURITY.md) (private disclosure).
+- The human-review gate for security-sensitive paths is defined in
+  [`.github/CODEOWNERS`](.github/CODEOWNERS) and enforced by the
+  `main-protection` ruleset.
+- The contribution workflow is in [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -199,6 +199,20 @@ Cloudflare Web Analytics dashboard.
 - Rate limited via Cloudflare Cache API (no extra bindings needed)
 - Pro features (auth, billing, history, cron) use Cloudflare D1 + WorkOS + Stripe. The hosted tier at `dmarc.mx` runs on the same code and same stack — no private fork.
 
+## Contributing & reporting
+
+- **Found a bug or want a feature?** Open an issue in the
+  [issue tracker](https://github.com/schmug/dmarcheck/issues) — search first to
+  avoid duplicates.
+- **Found a security vulnerability?** Please **don't** open a public issue.
+  Report it privately via the process in [SECURITY.md](SECURITY.md).
+- **Want to contribute code?** See [CONTRIBUTING.md](CONTRIBUTING.md) for setup,
+  the test/lint/typecheck gate, and commit conventions. Maintainers and the
+  review policy are listed in [MAINTAINERS.md](MAINTAINERS.md).
+
+Security posture is documented in [SECURITY.md](SECURITY.md) and the
+[threat model](THREAT_MODEL.md).
+
 ## License
 
 MIT

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,10 +20,25 @@ Please include:
 - The impact you believe the issue has
 - Any suggested remediation, if you have one in mind
 
-You can expect an initial acknowledgement within a few days. dmarcheck is
-maintained by a single person in their spare time, so fix timelines depend on
-severity and complexity — critical issues affecting the live service at
-[dmarc.mx](https://dmarc.mx) are prioritised.
+### Disclosure timeline
+
+dmarcheck is maintained by a single person in their spare time, so these are
+best-effort targets rather than contractual SLAs — but they are concrete so you
+know what to expect:
+
+| Stage | Target |
+|-------|--------|
+| **Acknowledgement** — we confirm we received your report | within **3 business days** |
+| **Triage** — we validate the issue and assign a severity | within **7 business days** of acknowledgement |
+| **Fix** — a remediation ships to the live service | **critical/high:** target **30 days**; **medium/low:** next convenient release |
+| **Public disclosure** — the advisory is published | when the fix is deployed, or **90 days** after the report, whichever comes first |
+
+Because dmarcheck is a rolling release deployed continuously from `main` (see
+[Supported versions](#supported-versions)), a fix reaches all users as soon as
+it merges — there is no back-porting. Critical issues affecting the live service
+at [dmarc.mx](https://dmarc.mx) are prioritised over everything else. We'll keep
+you updated through the advisory and credit you in the published advisory unless
+you ask us not to.
 
 ## Scope
 
@@ -49,6 +64,39 @@ Out of scope:
 dmarcheck is a rolling release deployed continuously from `main`. There are
 no long-lived branches or LTS versions. The only supported version is the
 current contents of `main` / the deployed Worker.
+
+## Vulnerability management
+
+We run automated software-composition analysis (SCA) and static analysis (SAST)
+on every change, with the following remediation thresholds:
+
+**Dependencies (SCA).**
+
+- CI runs `npm audit --audit-level=high --omit=dev` as a required `check` step.
+  A **HIGH or CRITICAL** CVE in a **runtime** dependency **blocks the merge** and
+  must be fixed (upgrade, patch, or remove the dependency) before the PR can land.
+- **Moderate/low** runtime CVEs and **dev-only** dependency CVEs (biome, vitest,
+  wrangler, sharp — none of which ship to the Worker runtime) do not block
+  merges. They are surfaced as Dependabot alerts in the **Security** tab and
+  batched into routine dependency-bump PRs.
+- [Dependabot](.github/dependabot.yml) opens dependency and GitHub-Actions
+  update PRs weekly.
+
+**Code (SAST).**
+
+- [CodeQL](.github/workflows/codeql.yml) runs on every pull request and on a
+  weekly schedule (`Analyze (actions)` and `Analyze (javascript-typescript)`).
+- **Error-severity** CodeQL alerts are triaged and remediated before the
+  associated change merges; warning/note-level alerts are reviewed in the
+  Security tab and fixed or dismissed-with-justification.
+
+These thresholds intentionally match CI's gate so the "what blocks a merge"
+answer is the same whether you read the policy or the workflow. They tighten if
+the [threat model](THREAT_MODEL.md) expands to cover developer machines.
+
+See [docs/OSPS-DEVIATIONS.md](docs/OSPS-DEVIATIONS.md) for where dmarcheck
+intentionally deviates from the OSPS Baseline, and [THREAT_MODEL.md](THREAT_MODEL.md)
+for the system's assets, entry points, and threats.
 
 ## Safe harbour
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,7 +31,7 @@ know what to expect:
 | **Acknowledgement** — we confirm we received your report | within **3 business days** |
 | **Triage** — we validate the issue and assign a severity | within **7 business days** of acknowledgement |
 | **Fix** — a remediation ships to the live service | **critical/high:** target **30 days**; **medium/low:** next convenient release |
-| **Public disclosure** — the advisory is published | when the fix is deployed, or **90 days** after the report, whichever comes first |
+| **Public disclosure** — the advisory is published as a [GitHub Security Advisory](https://github.com/schmug/dmarcheck/security/advisories) under `schmug/dmarcheck` | when the fix is deployed, or **90 days** after the report, whichever comes first |
 
 Because dmarcheck is a rolling release deployed continuously from `main` (see
 [Supported versions](#supported-versions)), a fix reaches all users as soon as
@@ -81,6 +81,13 @@ on every change, with the following remediation thresholds:
   batched into routine dependency-bump PRs.
 - [Dependabot](.github/dependabot.yml) opens dependency and GitHub-Actions
   update PRs weekly.
+- **Exception process:** if a HIGH/CRITICAL runtime CVE genuinely cannot be
+  remediated (no patch is available yet, or the advisory does not apply to how
+  the dependency is actually used), the maintainer may accept the risk by
+  recording the justification in the PR and overriding the gate — the same
+  dismiss-with-justification discipline applied to CodeQL alerts below. The
+  override and its rationale stay visible in the PR history, and the CVE is
+  re-checked when Dependabot's next bump lands a fix.
 
 **Code (SAST).**
 

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -6,7 +6,8 @@ dmarcheck is a DNS email-security analyzer (DMARC, SPF, DKIM, BIMI, MTA-STS,
 MX, security.txt, TLS-RPT) implemented as a single TypeScript Cloudflare Worker
 on the Hono framework. It performs DNS lookups via `node:dns` (`nodejs_compat`),
 runs one analyzer module per protocol in parallel through an orchestrator
-(`Promise.allSettled`), computes a letter grade, and serves dual output: a JSON
+(each analyzer isolated, so one failure surfaces as a synthetic result rather
+than aborting the scan), computes a letter grade, and serves dual output: a JSON
 API and a server-rendered interactive HTML report. It is live at dmarc.mx,
 deployed continuously from `main` via Cloudflare Git integration. Dependencies
 are lean (`hono`, `jose`, `@sentry/cloudflare`).
@@ -117,7 +118,7 @@ flowchart LR
 | T8 | Supply-chain / CI compromise escalating to prod D1 write or deploy | supply_chain | E10 | prod D1, infra tokens, releases | high | rare | partially_mitigated | SHA-pinned actions, ubuntu-latest only, explicit `permissions:` blocks, secrets only on `main`-gated jobs | |
 | T9 | Rate-limit bypass → DNS amplification / scan abuse via unauthenticated, unmetered `/mcp` and non-`/check` scan routes | remote_unauth | E2, E9 | service availability, upstream DNS | medium | likely | partially_mitigated | `CF-Connecting-IP` keying on `/check`; XFF no longer trusted | #71, #123, #59 |
 | T10 | Stored/reflected XSS via unescaped scan data rendered into the HTML report | remote_unauth | E8, E1 | viewer session, grade integrity | medium | possible | partially_mitigated | `esc()` on interpolated values; per-request CSP nonce + `strict-dynamic`; `default-src 'none'` | #59, #281, 0fc81e2 |
-| T11 | Denial of service via DNS resource exhaustion or scan-abort on attacker-controlled domains | remote_unauth | E1, E3 | service availability | medium | possible | partially_mitigated | SPF lookup-limit early-exit; `Promise.allSettled` orchestration; `DnsLookupError` catch on external lookups | #90, #354 |
+| T11 | Denial of service via DNS resource exhaustion or scan-abort on attacker-controlled domains | remote_unauth | E1, E3 | service availability | medium | possible | partially_mitigated | SPF lookup-limit early-exit; per-analyzer failure isolation (one analyzer error can't abort the scan); `DnsLookupError` catch on external lookups | #90, #354 |
 | T12 | Login CSRF / OAuth-flow tampering | remote_unauth | E5 | user session | medium | rare | mitigated | OAuth `state` cookie (HttpOnly/Secure/SameSite=Lax) + strict callback match | #150 |
 
 ## 5. Deprioritized

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -38,6 +38,57 @@ binding, and a sibling `mta-sts.dmarc.mx` helper worker.
 
 ## 3. Entry points & trust boundaries
 
+The diagram shows where untrusted input crosses into the Worker's trusted
+execution context. Each labelled edge maps to an entry point (E1–E11) in the
+table below.
+
+```mermaid
+flowchart LR
+    subgraph internet["Untrusted internet"]
+        unauth["Unauthenticated client<br/>?domain, /mcp, /badge"]
+        prouser["Authenticated Pro user<br/>session / API key"]
+        stripe_in["Stripe webhook sender"]
+        evildomain["Attacker-named scan target"]
+    end
+
+    subgraph worker["dmarcheck Worker — trust boundary (Cloudflare edge)"]
+        rl["Rate limiter / cache (E9)"]
+        scan["Scan API + orchestrator (E1, E2)"]
+        auth["Auth & session (E5)"]
+        dash["Dashboard / history CRUD (E6)"]
+        whverify["Stripe webhook verify (E7)"]
+        render["HTML report render (E8)"]
+        fetchout["Analyzer outbound fetch (E3)"]
+        whout["Outbound webhook dispatch (E4)"]
+    end
+
+    subgraph backends["Backends &amp; secrets"]
+        dns["DNS resolvers"]
+        upstream["Attacker-named upstream HTTPS"]
+        d1[("D1: users, keys, history, billing")]
+        email["Email binding (alerts@)"]
+        stripeapi["Stripe API"]
+    end
+
+    subgraph supply["CI/CD — supply chain"]
+        gha["GitHub Actions (E10)"]
+        routine["Autonomous routine merge (E11)"]
+        prod["Cloudflare prod deploy / D1"]
+    end
+
+    unauth --> rl --> scan
+    prouser --> auth --> dash --> d1
+    scan --> render
+    scan --> fetchout --> dns
+    fetchout --> upstream
+    dash --> whout --> upstream
+    evildomain -. controls target name .-> fetchout
+    stripe_in --> whverify --> d1
+    whverify --> stripeapi
+    dash --> email
+    routine --> gha --> prod
+```
+
 | entry_point | description | trust_boundary | reachable_assets |
 |---|---|---|---|
 | E1 — Public scan API (`/check`, `/api/check`, `/api/check/stream`, `/badge`, `/mx/:slug`) | Attacker controls `?domain`, `?selectors`, `?format`, `Accept`; drives DNS lookups + HTML/JSON/CSV/SSE rendering | unauth HTTP → app logic; Worker → upstream DNS | grade integrity, service availability |

--- a/docs/OSPS-DEVIATIONS.md
+++ b/docs/OSPS-DEVIATIONS.md
@@ -1,0 +1,71 @@
+# OSPS Baseline — declared deviations
+
+This document records where dmarcheck intentionally deviates from the
+[Open Source Project Security (OSPS) Baseline](https://baseline.openssf.org/)
+and the compensating controls that manage the residual risk. Declaring
+deviations explicitly is itself an OSPS expectation; this file is the canonical
+home for them.
+
+## QA-07.01 — Code change review before merge
+
+**Control:** Changes to the project's source code should be reviewed by a second
+person (someone other than the author) before being merged to the primary
+branch.
+
+**Deviation:** The `main` branch sets `required_approving_review_count = 0`. The
+`main-protection` ruleset does **not** require a blanket approving review on
+every PR. This is deliberate: autonomous [Claude Code Routines](routine-pipeline.md)
+open and merge low-risk PRs unattended (sourced from triaged, `spec-approved`
+issues), and a blanket two-person review requirement would make that pipeline
+impossible for a single-maintainer project.
+
+**Why we accept it:** dmarcheck is maintained by one person. A hard
+second-reviewer requirement on every change would either halt the autonomous
+routine pipeline entirely or reduce "review" to self-approval theater. Instead
+of a blanket-but-hollow gate, we run a **path-scoped** human-review gate plus
+deterministic automated gating, so review effort concentrates on the
+security-sensitive minority of changes.
+
+### Compensating controls
+
+1. **Path-scoped human review (CODEOWNERS).** Any PR whose diff touches a
+   security-sensitive path — CI/workflows, `package.json`/lockfile,
+   `wrangler.toml`, `SECURITY.md`, `CLAUDE.md`, input validation
+   (`src/index.ts`), rate limiting, DB migrations, analyzer modules,
+   orchestration, or scoring — requires an approving review from a code owner
+   via [`.github/CODEOWNERS`](../.github/CODEOWNERS) and
+   `require_code_owner_review`. The riskiest changes always get a human.
+
+2. **Deterministic fail-closed trust gate.** Before any routine auto-merge, a
+   six-condition gate (`scripts/routine-gate/`) must pass: issue author in
+   allowlist, `spec-approved` label, resolvable `Closes #N`, no risk-path hit,
+   ≤250 lines / ≤8 files, and CI green with no scope drift. It fails closed —
+   ambiguity escalates to the maintainer, never auto-merges. The gate is always
+   executed from `main`, so a PR cannot weaken its own judge.
+
+3. **Required CI status.** Every PR must pass the `check` status (lint,
+   typecheck, tests, and a `npm audit --audit-level=high --omit=dev`
+   supply-chain gate) before merge. The ruleset also blocks force-pushes and
+   branch deletion on `main`.
+
+4. **Per-merge audit trail.** Each auto-merged PR receives a comment containing
+   the full gate verdict JSON, giving an immutable record of why each PR was
+   allowed to merge.
+
+### Residual risk and the path to closing it
+
+The CODEOWNERS gate is only *enforcing* once the autonomous routine runs as a
+distinct **non-admin** identity. Today the routines run with the maintainer's
+admin credentials, and the repo Admin role bypasses the ruleset — so for
+automation the CODEOWNERS gate is currently **advisory**. Closing this is
+tracked as the bot-identity split,
+[#299](https://github.com/schmug/dmarcheck/issues/299). The deterministic gate
+(control 2) and required CI (control 3) apply regardless of identity and are the
+active controls until #299 lands.
+
+## Adding a new deviation
+
+When a future change knowingly deviates from an OSPS criterion, add a section
+here (criterion ID + control + deviation + why + compensating controls) rather
+than leaving it undocumented. Reference this file from
+[SECURITY.md](../SECURITY.md).

--- a/docs/OSPS-DEVIATIONS.md
+++ b/docs/OSPS-DEVIATIONS.md
@@ -63,6 +63,20 @@ tracked as the bot-identity split,
 (control 2) and required CI (control 3) apply regardless of identity and are the
 active controls until #299 lands.
 
+## Related OSPS controls (passing)
+
+QA-07.01 is a deviation, not a posture. Several adjacent OSPS controls are met,
+which is part of why the path-scoped review model above is acceptable:
+
+- **BR-01.01 (input sanitization)** — user-supplied domains are constrained to
+  `[a-z0-9.-]` (`normalizeDomain`) and DKIM selectors to `[A-Za-z0-9._-]`; HTML
+  output never interpolates raw user input into inline `<script>` (see the
+  Input-validation notes in `CLAUDE.md` and [THREAT_MODEL.md](../THREAT_MODEL.md)).
+- **AC-04.01 (least-privilege CI)** — every GitHub Actions workflow declares an
+  explicit top-level `permissions:` block defaulting to `contents: read`, with
+  elevation only at the job level where required, and all actions are pinned by
+  full commit SHA.
+
 ## Adding a new deviation
 
 When a future change knowingly deviates from an OSPS criterion, add a section


### PR DESCRIPTION
Knocks out the OSPS-docs quick-win cluster surfaced by issue triage. All deliverables were verified specified-but-unwritten against the repo before authoring.

## What's in here
| Issue | Deliverable |
|---|---|
| Closes #381 | `CONTRIBUTING.md` — setup, the lint/typecheck/test gate, conventional-commit rule, report-bug-vs-security split |
| Closes #382 | `MAINTAINERS.md` — roster, roles, add/remove policy, automation-identity note pending #299 |
| Closes #385 | SECURITY.md **Vulnerability management** section — SCA (`npm audit --audit-level=high --omit=dev`) + SAST (CodeQL) remediation thresholds that match CI's gate |
| Closes #386 | SECURITY.md concrete **disclosure timeline** with day-counts (ack 3d / triage 7d / fix 30d crit-high / disclose ≤90d) |
| Closes #389 | README **Contributing & reporting** section linking Issues + SECURITY.md |
| Closes #390 | `docs/OSPS-DEVIATIONS.md` — declares + justifies the QA-07.01 auto-merge deviation and its compensating controls |
| Refs #387 | Mermaid trust-boundary diagram in THREAT_MODEL.md + README/SECURITY cross-links |

## #387 is `Refs`, not `Closes` — intentional
The threat model itself landed in #402. This PR closes the **cross-link gap** (README/SECURITY now link to it) and adds the **Mermaid diagram** the acceptance criteria allowed. Still open on #387: the issue named the path `docs/THREAT-MODEL.md` but the file lives at repo root as `THREAT_MODEL.md` (kept there to avoid breaking #402's internal references). Left for the owner to decide whether to relocate — so #387 stays open.

## Notes for review
- Touches `SECURITY.md`, so this PR is **CODEOWNERS-gated** and needs your approval to merge — by design.
- The disclosure-timeline day-counts are best-effort targets for a single-maintainer project; adjust if you'd prefer different numbers.
- Docs-only: lint (biome checks `src/`+`test/` only) and the pre-commit gate (typecheck + tests) pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)