### PR TITLE
build: attach CycloneDX SBOM to each GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+
       - name: Calculate CalVer
         id: version
         run: |
@@ -45,6 +49,17 @@ jobs:
             echo "CLIFF_EOF"
           } >> "$GITHUB_OUTPUT"
 
+      # Software Bill of Materials (CycloneDX) for each release. Generated from
+      # the lockfile only (no `npm ci` needed) and pinned to a specific tool
+      # version. The SBOM is attached as a release asset, never committed.
+      - name: Generate CycloneDX SBOM
+        run: |
+          npx --yes @cyclonedx/cyclonedx-npm@4.2.1 \
+            --package-lock-only \
+            --output-format JSON \
+            --spec-version 1.5 \
+            --output-file sbom.cdx.json
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -53,4 +68,4 @@ jobs:
         run: |
           git tag "$VERSION"
           git push origin "$VERSION"
-          gh release create "$VERSION" --title "$VERSION" --notes "$NOTES"
+          gh release create "$VERSION" --title "$VERSION" --notes "$NOTES" sbom.cdx.json

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ TRIAGE.json
 TRIAGE.md
 .triage-state/
 .threat-model-state/
+
+# CycloneDX SBOM is generated in CI per release and attached as a release
+# asset — never committed (release.yml builds it from the lockfile).
+sbom.cdx.json


### PR DESCRIPTION
Generates a CycloneDX Software Bill of Materials for each release and attaches it as a release asset (OSPS QA-02.02).

## What changed (`release.yml`)
- New **Generate CycloneDX SBOM** step: `npx --yes @cyclonedx/cyclonedx-npm@4.2.1 --package-lock-only --output-format JSON --spec-version 1.5 --output-file sbom.cdx.json`
- `sbom.cdx.json` added to the `gh release create` invocation as a release asset
- Pinned `actions/setup-node@v6.4.0` (same SHA as ci.yml) at Node 22 — the tool needs Node ≥20.18.0
- `.gitignore`: `sbom.cdx.json` (generated in CI, never committed)

## Design choices (per issue #383)
- **Lockfile-only** (`--package-lock-only`) so the step needs no `npm ci` — faster and avoids the node_modules/native-dep surface
- **Version-pinned** tool, **not** added to `package.json` devDeps (uses `npx --yes`)
- SBOM **not committed** — it's a release artifact only

## Verification
Ran the exact command against the current lockfile locally: **valid CycloneDX 1.5 JSON, 183 components, exit 0.** The step otherwise only executes at release time, so I validated the flags against the tool's `--help` and the output against `jq`.

## Note for review
Touches `.github/`, so this PR is **CODEOWNERS-gated** and needs your approval to merge. This is the SBOM half of the release-hardening work; Sigstore signing + SHA256SUMS remains as #384.

🤖 Generated with [Claude Code](https://claude.com/claude-code)