### PR TITLE
fix: isolate analyzer failures so one rejection can't abort the scan (#378)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Live at dmarc.mx | Repo: github.com/schmug/dmarcheck
 - `src/index.ts` — Hono routes, content negotiation, rate limiting middleware
 - `src/dns/client.ts` — DNS abstraction over node:dns (NXDOMAIN returns null)
 - `src/analyzers/` — One module per protocol (dmarc, spf, dkim, bimi, mta-sts)
-- `src/orchestrator.ts` — Runs all analyzers in parallel via Promise.allSettled
+- `src/orchestrator.ts` — Runs all analyzers in parallel and isolates each one: a single analyzer rejection surfaces as a synthetic `status: "fail"` result instead of aborting the whole scan (per-analyzer `settle` wrapper, for both `scan` and `scanStreaming` — #378)
 - `src/shared/scoring.ts` — Grade computation (F if no DMARC or p=none)
 - `src/cache.ts` — SSE result caching
 - `src/csv.ts` — CSV export for scan results

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Live at dmarc.mx | Repo: github.com/schmug/dmarcheck
 - `src/index.ts` — Hono routes, content negotiation, rate limiting middleware
 - `src/dns/client.ts` — DNS abstraction over node:dns (NXDOMAIN returns null)
 - `src/analyzers/` — One module per protocol (dmarc, spf, dkim, bimi, mta-sts, mx, security-txt)
-- `src/orchestrator.ts` — Runs all analyzers in parallel via Promise.allSettled
+- `src/orchestrator.ts` — Runs all analyzers in parallel and isolates each one: a single analyzer rejection surfaces as a synthetic `status: "fail"` result (with an `analyzer_error` validation; `lookup_error.code` on the types that carry it) instead of aborting the whole scan. Implemented via a per-analyzer `settle` wrapper so one failure never takes down its siblings, for both `scan` and `scanStreaming` (#378).
 - `src/shared/scoring.ts` — Grade computation (F if no DMARC or p=none). Knobs are configurable per-deploy via the `SCORING_CONFIG` env var (`src/shared/scoring-config.ts` parses/validates it; absent/invalid → shipped defaults, so hosted dmarc.mx is unaffected). `computeGrade`/`computeGradeBreakdown` take an optional `Partial<ScoringConfig>`; `scan`/`scanStreaming` require it (compile-time enforcement that every call site threads the active config)
 - `src/cache.ts` — SSE result caching
 - `src/csv.ts` — CSV export for scan results

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -18,6 +18,7 @@ import type {
   SecurityTxtResult,
   SpfResult,
   TlsRptResult,
+  Validation,
 } from "./analyzers/types.js";
 import { queryTxt } from "./dns/client.js";
 import { computeGradeBreakdown, type ScoringConfig } from "./shared/scoring.js";
@@ -40,6 +41,128 @@ export type ProtocolResult =
   | MtaStsResult
   | SecurityTxtResult
   | TlsRptResult;
+
+const PROTOCOL_LABEL: Record<ProtocolId, string> = {
+  mx: "MX",
+  dmarc: "DMARC",
+  spf: "SPF",
+  dkim: "DKIM",
+  bimi: "BIMI",
+  mta_sts: "MTA-STS",
+  security_txt: "security.txt",
+  tls_rpt: "TLS-RPT",
+};
+
+function analyzerErrorValidation(id: ProtocolId, message: string): Validation {
+  return {
+    status: "fail",
+    message: `${PROTOCOL_LABEL[id]} analysis could not be completed (analyzer_error): ${message}`,
+  };
+}
+
+// Synthetic "this analyzer threw" results. A single analyzer rejecting must not
+// abort the whole scan (#378) — instead each protocol's outcome is isolated and
+// a thrown error surfaces as a `status: "fail"` result with an explanatory
+// validation. Types that carry `lookup_error` also tag it `analyzer_error` so
+// scoring treats DMARC/SPF/MX/TLS-RPT as "could not verify" rather than "absent".
+const ERROR_RESULTS = {
+  dmarc: (m: string): DmarcResult => ({
+    status: "fail",
+    record: null,
+    tags: null,
+    validations: [analyzerErrorValidation("dmarc", m)],
+    lookup_error: { code: "analyzer_error", message: m },
+  }),
+  spf: (m: string): SpfResult => ({
+    status: "fail",
+    record: null,
+    lookups_used: 0,
+    lookup_limit: 10,
+    include_tree: null,
+    validations: [analyzerErrorValidation("spf", m)],
+    lookup_error: { code: "analyzer_error", message: m },
+  }),
+  dkim: (m: string): DkimResult => ({
+    status: "fail",
+    selectors: {},
+    validations: [analyzerErrorValidation("dkim", m)],
+  }),
+  bimi: (m: string): BimiResult => ({
+    status: "fail",
+    record: null,
+    tags: null,
+    validations: [analyzerErrorValidation("bimi", m)],
+  }),
+  mta_sts: (m: string): MtaStsResult => ({
+    status: "fail",
+    dns_record: null,
+    policy: null,
+    validations: [analyzerErrorValidation("mta_sts", m)],
+  }),
+  mx: (m: string): MxResult => ({
+    status: "fail",
+    records: [],
+    providers: [],
+    validations: [analyzerErrorValidation("mx", m)],
+    lookup_error: { code: "analyzer_error", message: m },
+  }),
+  security_txt: (m: string): SecurityTxtResult => ({
+    status: "fail",
+    source_url: null,
+    signed: false,
+    fields: null,
+    validations: [analyzerErrorValidation("security_txt", m)],
+  }),
+  tls_rpt: (m: string): TlsRptResult => ({
+    status: "fail",
+    record: null,
+    tags: null,
+    validations: [analyzerErrorValidation("tls_rpt", m)],
+    lookup_error: { code: "analyzer_error", message: m },
+  }),
+} as const;
+
+// Turn a possibly-rejecting analyzer promise into one that always resolves —
+// to its real result, or to a synthetic fail result if it threw. Logs a Sentry
+// breadcrumb so the failure is observable even though the scan continues.
+function settle<T extends ProtocolResult>(
+  id: ProtocolId,
+  promise: Promise<T>,
+  fallback: (message: string) => T,
+): Promise<T> {
+  return promise.catch((err) => {
+    const message = err instanceof Error ? err.message : String(err);
+    Sentry.addBreadcrumb({
+      category: "analyzer.error",
+      message: `${id}: ${message}`,
+      data: { protocol: id, error: message },
+      level: "error",
+    });
+    return fallback(message);
+  });
+}
+
+// Streaming variant: settle the analyzer, then emit a completion breadcrumb and
+// stream the result (real or synthetic) exactly once. Because it builds on the
+// never-rejecting `settle`, a thrown analyzer streams a fail card instead of
+// leaking an unhandled rejection from a bare `.then(onResult)` handler.
+function streamSettled<T extends ProtocolResult>(
+  id: ProtocolId,
+  promise: Promise<T>,
+  fallback: (message: string) => T,
+  onResult: (id: ProtocolId, result: ProtocolResult) => void,
+): Promise<T> {
+  return settle(id, promise, fallback).then((r) => {
+    Sentry.addBreadcrumb({
+      category: "analyzer.complete",
+      message: `${id}: ${r.status}`,
+      data: { protocol: id, status: r.status },
+      level: "info",
+    });
+    onResult(id, r);
+    return r;
+  });
+}
 
 async function buildScanResult(
   domain: string,
@@ -135,6 +258,9 @@ export async function scan(
     },
   );
 
+  // Isolate each analyzer: one rejection surfaces as a synthetic fail result
+  // instead of aborting the whole scan (#378). This is the contract the docs
+  // describe ("partial results, never abort on a single analyzer error").
   const [
     dmarcResult,
     spfResult,
@@ -145,14 +271,14 @@ export async function scan(
     securityTxtResult,
     tlsRptResult,
   ] = await Promise.all([
-    dmarcPromise,
-    spfPromise,
-    dkimPromise,
-    mtaStsPromise,
-    bimiPromise,
-    mxPromise,
-    securityTxtPromise,
-    tlsRptPromise,
+    settle("dmarc", dmarcPromise, ERROR_RESULTS.dmarc),
+    settle("spf", spfPromise, ERROR_RESULTS.spf),
+    settle("dkim", dkimPromise, ERROR_RESULTS.dkim),
+    settle("mta_sts", mtaStsPromise, ERROR_RESULTS.mta_sts),
+    settle("bimi", bimiPromise, ERROR_RESULTS.bimi),
+    settle("mx", mxPromise, ERROR_RESULTS.mx),
+    settle("security_txt", securityTxtPromise, ERROR_RESULTS.security_txt),
+    settle("tls_rpt", tlsRptPromise, ERROR_RESULTS.tls_rpt),
   ]);
 
   Sentry.addBreadcrumb({
@@ -247,87 +373,12 @@ export async function scanStreaming(
     },
   );
 
-  // Attach streaming handlers immediately
-  mxPromise.then((r) => {
-    Sentry.addBreadcrumb({
-      category: "analyzer.complete",
-      message: `mx: ${r.status}`,
-      data: { protocol: "mx", status: r.status },
-      level: "info",
-    });
-    onResult("mx", r);
-  });
-
-  spfPromise.then((r) => {
-    Sentry.addBreadcrumb({
-      category: "analyzer.complete",
-      message: `spf: ${r.status}`,
-      data: { protocol: "spf", status: r.status },
-      level: "info",
-    });
-    onResult("spf", r);
-  });
-
-  mtaStsPromise.then((r) => {
-    Sentry.addBreadcrumb({
-      category: "analyzer.complete",
-      message: `mta_sts: ${r.status}`,
-      data: { protocol: "mta_sts", status: r.status },
-      level: "info",
-    });
-    onResult("mta_sts", r);
-  });
-
-  dmarcPromise.then((r) => {
-    Sentry.addBreadcrumb({
-      category: "analyzer.complete",
-      message: `dmarc: ${r.status}`,
-      data: { protocol: "dmarc", status: r.status },
-      level: "info",
-    });
-    onResult("dmarc", r);
-  });
-
-  dkimPromise.then((r) => {
-    Sentry.addBreadcrumb({
-      category: "analyzer.complete",
-      message: `dkim: ${r.status}`,
-      data: { protocol: "dkim", status: r.status },
-      level: "info",
-    });
-    onResult("dkim", r);
-  });
-
-  bimiPromise.then((r) => {
-    Sentry.addBreadcrumb({
-      category: "analyzer.complete",
-      message: `bimi: ${r.status}`,
-      data: { protocol: "bimi", status: r.status },
-      level: "info",
-    });
-    onResult("bimi", r);
-  });
-
-  securityTxtPromise.then((r) => {
-    Sentry.addBreadcrumb({
-      category: "analyzer.complete",
-      message: `security_txt: ${r.status}`,
-      data: { protocol: "security_txt", status: r.status },
-      level: "info",
-    });
-    onResult("security_txt", r);
-  });
-
-  tlsRptPromise.then((r) => {
-    Sentry.addBreadcrumb({
-      category: "analyzer.complete",
-      message: `tls_rpt: ${r.status}`,
-      data: { protocol: "tls_rpt", status: r.status },
-      level: "info",
-    });
-    onResult("tls_rpt", r);
-  });
-
+  // Stream each protocol as it settles. Each analyzer is isolated: a rejection
+  // streams a synthetic fail card (via streamSettled) instead of leaking an
+  // unhandled rejection, and never aborts the others (#378). Because the
+  // streamSettled promises never reject, this Promise.all always resolves with
+  // the full set of results. Handlers attach synchronously here, before the
+  // await, so fast protocols still stream the moment they complete.
   const [
     dmarcResult,
     spfResult,
@@ -338,14 +389,19 @@ export async function scanStreaming(
     securityTxtResult,
     tlsRptResult,
   ] = await Promise.all([
-    dmarcPromise,
-    spfPromise,
-    dkimPromise,
-    mtaStsPromise,
-    bimiPromise,
-    mxPromise,
-    securityTxtPromise,
-    tlsRptPromise,
+    streamSettled("dmarc", dmarcPromise, ERROR_RESULTS.dmarc, onResult),
+    streamSettled("spf", spfPromise, ERROR_RESULTS.spf, onResult),
+    streamSettled("dkim", dkimPromise, ERROR_RESULTS.dkim, onResult),
+    streamSettled("mta_sts", mtaStsPromise, ERROR_RESULTS.mta_sts, onResult),
+    streamSettled("bimi", bimiPromise, ERROR_RESULTS.bimi, onResult),
+    streamSettled("mx", mxPromise, ERROR_RESULTS.mx, onResult),
+    streamSettled(
+      "security_txt",
+      securityTxtPromise,
+      ERROR_RESULTS.security_txt,
+      onResult,
+    ),
+    streamSettled("tls_rpt", tlsRptPromise, ERROR_RESULTS.tls_rpt, onResult),
   ]);
 
   return await buildScanResult(

--- a/test/orchestrator-partial-failure.test.ts
+++ b/test/orchestrator-partial-failure.test.ts
@@ -1,0 +1,170 @@
+/**
+ * #378 — a single analyzer rejection must not abort the whole scan. The
+ * orchestrator isolates each analyzer: a thrown error surfaces as a synthetic
+ * `status: "fail"` result for that protocol while every sibling still resolves,
+ * for both scan() and scanStreaming(). The analyzer layer is mocked to a fixed
+ * passing domain; individual tests override one analyzer to reject.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { ProtocolId, ProtocolResult } from "../src/orchestrator.js";
+
+vi.mock("../src/analyzers/dmarc.js", () => ({
+  analyzeDmarc: vi.fn().mockResolvedValue({
+    status: "pass",
+    record: "v=DMARC1; p=reject; rua=mailto:dmarc@example.com",
+    tags: { v: "DMARC1", p: "reject", rua: "mailto:dmarc@example.com" },
+    validations: [],
+  }),
+}));
+vi.mock("../src/analyzers/spf.js", () => ({
+  analyzeSpf: vi.fn().mockResolvedValue({
+    status: "pass",
+    record: "v=spf1 -all",
+    lookups_used: 3,
+    lookup_limit: 10,
+    include_tree: null,
+    validations: [],
+  }),
+}));
+vi.mock("../src/analyzers/dkim.js", () => ({
+  analyzeDkim: vi.fn().mockResolvedValue({
+    status: "pass",
+    selectors: { google: { found: true, key_type: "rsa", key_bits: 2048 } },
+    validations: [],
+  }),
+}));
+vi.mock("../src/analyzers/bimi.js", () => ({
+  prefetchBimiDns: vi.fn().mockResolvedValue(null),
+  analyzeBimi: vi.fn().mockResolvedValue({
+    status: "warn",
+    record: null,
+    tags: null,
+    validations: [],
+  }),
+}));
+vi.mock("../src/analyzers/mta-sts.js", () => ({
+  analyzeMtaSts: vi.fn().mockResolvedValue({
+    status: "pass",
+    dns_record: "v=STSv1; id=20260101",
+    policy: {
+      version: "STSv1",
+      mode: "enforce",
+      mx: ["*.example.com"],
+      max_age: 86400,
+    },
+    validations: [],
+  }),
+}));
+vi.mock("../src/analyzers/mx.js", () => ({
+  analyzeMx: vi.fn().mockResolvedValue({
+    status: "info",
+    records: [],
+    providers: [],
+    validations: [],
+  }),
+}));
+vi.mock("../src/analyzers/mx-mta-sts-consistency.js", () => ({
+  checkMxMtaStsConsistency: vi.fn().mockReturnValue([]),
+}));
+vi.mock("../src/analyzers/security-txt.js", () => ({
+  analyzeSecurityTxt: vi.fn().mockResolvedValue({
+    status: "info",
+    source_url: null,
+    signed: false,
+    fields: null,
+    validations: [],
+  }),
+}));
+vi.mock("../src/analyzers/tls-rpt.js", () => ({
+  analyzeTlsRpt: vi.fn().mockResolvedValue({
+    status: "info",
+    record: null,
+    tags: null,
+    validations: [],
+  }),
+}));
+vi.mock("../src/dns/client.js", () => ({
+  queryTxt: vi.fn().mockResolvedValue(null),
+  queryMx: vi.fn().mockResolvedValue(null),
+}));
+
+import { analyzeDmarc } from "../src/analyzers/dmarc.js";
+import { analyzeMtaSts } from "../src/analyzers/mta-sts.js";
+import { analyzeSpf } from "../src/analyzers/spf.js";
+import { scan, scanStreaming } from "../src/orchestrator.js";
+
+describe("scan() isolates a single analyzer failure (#378)", () => {
+  it("surfaces a synthetic fail for the crashed analyzer while siblings resolve", async () => {
+    vi.mocked(analyzeSpf).mockRejectedValueOnce(
+      new Error("SPF analyzer crashed"),
+    );
+
+    // Must not throw — the whole scan no longer aborts on one rejection.
+    const result = await scan("example.com", [], {});
+
+    // The crashed analyzer is reported as a synthetic failure...
+    expect(result.protocols.spf.status).toBe("fail");
+    expect(
+      result.protocols.spf.validations.some((v) => v.status === "fail"),
+    ).toBe(true);
+    // ...while every sibling still has its real result.
+    expect(result.protocols.dmarc.status).toBe("pass");
+    expect(result.protocols.mta_sts.status).toBe("pass");
+    // A grade is still produced from partial results.
+    expect(result.grade).toBeTruthy();
+    expect(result.summary.spf_result).toBe("fail");
+  });
+
+  it("routes a dmarc analyzer crash through the lookup-failure scoring path", async () => {
+    vi.mocked(analyzeDmarc).mockRejectedValueOnce(
+      new Error("DMARC analyzer crashed"),
+    );
+
+    const result = await scan("example.com", [], {});
+
+    expect(result.protocols.dmarc.status).toBe("fail");
+    expect(result.protocols.dmarc.lookup_error?.code).toBe("analyzer_error");
+    // scoring.ts maps a dmarc lookup_error to D ("policy could not be verified"),
+    // not a false F, and an independent sibling is unaffected.
+    expect(result.grade).toBe("D");
+    expect(result.protocols.spf.status).toBe("pass");
+  });
+});
+
+describe("scanStreaming() isolates a single analyzer failure (#378)", () => {
+  it("streams a synthetic fail card for the crashed analyzer and still completes", async () => {
+    vi.mocked(analyzeMtaSts).mockRejectedValueOnce(
+      new Error("MTA-STS analyzer crashed"),
+    );
+
+    const streamed = new Map<ProtocolId, ProtocolResult>();
+    const result = await scanStreaming(
+      "example.com",
+      [],
+      (id, r) => {
+        streamed.set(id, r);
+      },
+      {},
+    );
+
+    // Every protocol streamed exactly once, including the crashed one.
+    for (const id of [
+      "mx",
+      "dmarc",
+      "spf",
+      "dkim",
+      "bimi",
+      "mta_sts",
+      "security_txt",
+      "tls_rpt",
+    ] as ProtocolId[]) {
+      expect(streamed.has(id)).toBe(true);
+    }
+    // The crashed analyzer streamed a synthetic fail...
+    expect(streamed.get("mta_sts")?.status).toBe("fail");
+    // ...and the final aggregate agrees, with siblings intact.
+    expect(result.protocols.mta_sts.status).toBe("fail");
+    expect(result.protocols.dmarc.status).toBe("pass");
+    expect(result.grade).toBeTruthy();
+  });
+});

--- a/test/orchestrator-partial-failure.test.ts
+++ b/test/orchestrator-partial-failure.test.ts
@@ -90,6 +90,7 @@ vi.mock("../src/dns/client.js", () => ({
 
 import { analyzeDmarc } from "../src/analyzers/dmarc.js";
 import { analyzeMtaSts } from "../src/analyzers/mta-sts.js";
+import { analyzeMx } from "../src/analyzers/mx.js";
 import { analyzeSpf } from "../src/analyzers/spf.js";
 import { scan, scanStreaming } from "../src/orchestrator.js";
 
@@ -128,6 +129,24 @@ describe("scan() isolates a single analyzer failure (#378)", () => {
     // not a false F, and an independent sibling is unaffected.
     expect(result.grade).toBe("D");
     expect(result.protocols.spf.status).toBe("pass");
+  });
+
+  it("cascades an MX crash to its dependent DKIM without aborting siblings", async () => {
+    // DKIM is chained off MX (dkimPromise = mxPromise.then(...)), so when MX
+    // rejects, dkimPromise rejects too. Both must be isolated independently —
+    // each surfaces a synthetic fail — while unrelated analyzers stay intact.
+    vi.mocked(analyzeMx).mockRejectedValueOnce(
+      new Error("MX analyzer crashed"),
+    );
+
+    const result = await scan("example.com", [], {});
+
+    expect(result.protocols.mx.status).toBe("fail");
+    expect(result.protocols.dkim.status).toBe("fail");
+    // Independent siblings are untouched by the MX→DKIM cascade.
+    expect(result.protocols.dmarc.status).toBe("pass");
+    expect(result.protocols.spf.status).toBe("pass");
+    expect(result.grade).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
## The bug
CLAUDE.md/AGENTS.md claimed the orchestrator ran analyzers via `Promise.allSettled`, but `scan()` (orchestrator.ts:147) and `scanStreaming()` (orchestrator.ts:340) used `Promise.all`. So a **single analyzer rejection aborted the entire scan**, and the streaming path additionally **leaked an unhandled rejection** from its bare `.then(onResult)` handlers (reproduced in the new test before the fix).

Per #378's acceptance criteria, the *documented* allSettled/partial-results behavior is correct, so the **code** changes to match the contract.

## The fix (`src/orchestrator.ts`)
- **`ERROR_RESULTS`** — typed per-protocol synthetic-error factories. Each produces a `status:"fail"` result with an `analyzer_error` validation. The four types that carry `lookup_error` (DMARC/SPF/MX/TLS-RPT) also set `lookup_error.code:"analyzer_error"`, so scoring treats a crashed DMARC analyzer as **"could not verify" → grade D** (the existing lookup-failure path), not a false F.
- **`settle`** — wraps a rejecting analyzer promise into one that always resolves (real result or synthetic fail) and logs a Sentry breadcrumb.
- **`scan()`** aggregates the eight analyzers through `settle`.
- **`scanStreaming()`** routes handlers through **`streamSettled`** (built on `settle`) so a crashed analyzer **streams a fail card** instead of leaking an unhandled rejection — also collapses eight repetitive handler blocks into one.
- Reconciled CLAUDE.md + AGENTS.md. THREAT_MODEL.md's `Promise.allSettled` references are now behaviorally accurate, so untouched (and avoids conflicting with #407).

## Consumers verified (per the "don't break the result shape" guard)
The 8 result types in `types.ts` (synthetic results fill every field accessed by `buildScanResult`, the summary, and the MX↔MTA-STS consistency check), the **SSE stream** (now emits a fail card for the crashed protocol), **Sentry breadcrumbs** (success + new `analyzer.error`), and **scoring** (dmarc `lookup_error` → D early-return; other synthetic fails hit safe `status==="fail"` branches). CSV/scoring read no new fields.

## Verification
- TDD: new `test/orchestrator-partial-failure.test.ts` **failed** against `Promise.all` (incl. the unhandled rejection), **passes** after the fix.
- **Full suite: 1107 passing, 0 failing** (67 files); `typecheck` + `lint` clean.

## Note for review
Touches `src/orchestrator.ts` and `CLAUDE.md`, so this PR is **CODEOWNERS-gated** and needs your approval to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)