### PR TITLE
feat: reflect SCORING_CONFIG in /scoring JSON-LD and markdown rubric (#404)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -981,7 +981,10 @@ app.get("/", (c) => {
 
 app.get("/scoring", (c) => {
   if (wantsMarkdown(c))
-    return markdownResponse(c, renderScoringRubricMarkdown());
+    return markdownResponse(
+      c,
+      renderScoringRubricMarkdown(parseScoringConfig(c.env?.SCORING_CONFIG)),
+    );
   return c.html(renderScoringRubric(parseScoringConfig(c.env?.SCORING_CONFIG)));
 });
 

--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -591,60 +591,69 @@ export function renderScoreBreakdown(result: ScanResult): string {
   });
 }
 
-const SCORING_JSON_LD = JSON.stringify({
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  mainEntity: [
-    {
-      "@type": "Question",
-      name: "What is DMARC?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Domain-based Message Authentication, Reporting & Conformance. The policy layer that ties SPF and DKIM together and tells receivers what to do with unauthenticated mail. This is the most important factor in your grade.",
+// The /scoring FAQ JSON-LD reflects the active scoring rubric. When
+// SCORING_CONFIG is unset (the hosted dmarc.mx default), the output is
+// byte-identical to the shipped constant because DEFAULT_SCORING_CONFIG's
+// dkimKeyMinBits is 2048 — guarded by a test.
+export function buildScoringJsonLd(
+  config: Partial<ScoringConfig> = {},
+): string {
+  const cfg = { ...DEFAULT_SCORING_CONFIG, ...config };
+  return JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: [
+      {
+        "@type": "Question",
+        name: "What is DMARC?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Domain-based Message Authentication, Reporting & Conformance. The policy layer that ties SPF and DKIM together and tells receivers what to do with unauthenticated mail. This is the most important factor in your grade.",
+        },
       },
-    },
-    {
-      "@type": "Question",
-      name: "What is SPF?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Sender Policy Framework. A DNS record listing which IP addresses are authorized to send mail for your domain. Receivers check the sending server's IP against this list.",
+      {
+        "@type": "Question",
+        name: "What is SPF?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Sender Policy Framework. A DNS record listing which IP addresses are authorized to send mail for your domain. Receivers check the sending server's IP against this list.",
+        },
       },
-    },
-    {
-      "@type": "Question",
-      name: "What is DKIM?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "DomainKeys Identified Mail. Adds a cryptographic signature to outgoing messages, proving they haven't been tampered with in transit. Key strength of 2048 bits or more and multiple selectors improve your score.",
+      {
+        "@type": "Question",
+        name: "What is DKIM?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: `DomainKeys Identified Mail. Adds a cryptographic signature to outgoing messages, proving they haven't been tampered with in transit. Key strength of ${cfg.dkimKeyMinBits} bits or more and multiple selectors improve your score.`,
+        },
       },
-    },
-    {
-      "@type": "Question",
-      name: "What is BIMI?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Brand Indicators for Message Identification. Displays your brand logo next to authenticated messages in supporting email clients. Requires DMARC p=reject.",
+      {
+        "@type": "Question",
+        name: "What is BIMI?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Brand Indicators for Message Identification. Displays your brand logo next to authenticated messages in supporting email clients. Requires DMARC p=reject.",
+        },
       },
-    },
-    {
-      "@type": "Question",
-      name: "What is MTA-STS?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Mail Transfer Agent Strict Transport Security. Forces TLS encryption for inbound mail delivery, preventing downgrade attacks. Modes: testing (report only) and enforce (reject unencrypted).",
+      {
+        "@type": "Question",
+        name: "What is MTA-STS?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Mail Transfer Agent Strict Transport Security. Forces TLS encryption for inbound mail delivery, preventing downgrade attacks. Modes: testing (report only) and enforce (reject unencrypted).",
+        },
       },
-    },
-    {
-      "@type": "Question",
-      name: "How is the dmarcheck grade calculated?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "The grade has two parts: a base tier determined by your DMARC policy and authentication setup (F through A+), and modifiers that adjust the grade up (+) or down (-) based on reporting, SPF lookup budget, DKIM key length, BIMI, and MTA-STS.",
+      {
+        "@type": "Question",
+        name: "How is the dmarcheck grade calculated?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "The grade has two parts: a base tier determined by your DMARC policy and authentication setup (F through A+), and modifiers that adjust the grade up (+) or down (-) based on reporting, SPF lookup budget, DKIM key length, BIMI, and MTA-STS.",
+        },
       },
-    },
-  ],
-});
+    ],
+  });
+}
 
 export function renderScoringRubric(
   config: Partial<ScoringConfig> = {},
@@ -743,7 +752,7 @@ export function renderScoringRubric(
       </div>
       <div class="rubric-protocol">
         <h3><a href="/learn/dkim">DKIM</a></h3>
-        <p>DomainKeys Identified Mail. Adds a cryptographic signature to outgoing messages, proving they haven't been tampered with in transit. Key strength (2048+ bits) and multiple selectors improve your score.</p>
+        <p>DomainKeys Identified Mail. Adds a cryptographic signature to outgoing messages, proving they haven't been tampered with in transit. Key strength (${cfg.dkimKeyMinBits}+ bits) and multiple selectors improve your score.</p>
       </div>
       <div class="rubric-protocol">
         <h3><a href="/learn/bimi">BIMI</a></h3>
@@ -775,7 +784,7 @@ export function renderScoringRubric(
     path: "/scoring",
     description:
       "How dmarcheck grades email security: DMARC policy tiers, SPF/DKIM requirements, and the modifiers that push grades up or down.",
-    jsonLd: SCORING_JSON_LD,
+    jsonLd: buildScoringJsonLd(config),
     body,
   });
 }

--- a/src/views/markdown.ts
+++ b/src/views/markdown.ts
@@ -9,6 +9,10 @@ import {
   MX_PROVIDERS,
   type MxProvider,
 } from "../data/mx-providers.js";
+import {
+  DEFAULT_SCORING_CONFIG,
+  type ScoringConfig,
+} from "../shared/scoring.js";
 
 // Markdown renderings for agent consumers that send `Accept: text/markdown`.
 // Output is plain markdown with no HTML fragments — agents are expected to
@@ -291,7 +295,18 @@ See \`ScanResult\` in <${MD_SITE}/openapi.json>. Summary:
 `;
 }
 
-export function renderScoringRubricMarkdown(): string {
+export function renderScoringRubricMarkdown(
+  config: Partial<ScoringConfig> = {},
+): string {
+  const cfg = { ...DEFAULT_SCORING_CONFIG, ...config };
+  const aplusExtras =
+    cfg.requireBimiForAPlus && cfg.requireMtaStsForAPlus
+      ? "both BIMI and enforcing MTA-STS"
+      : cfg.requireBimiForAPlus
+        ? "BIMI"
+        : cfg.requireMtaStsForAPlus
+          ? "enforcing MTA-STS"
+          : "no additional extras";
   return `# dmarcheck scoring rubric
 
 The grade (S, A+, A, B, C, D, F) is computed from a tier + modifier model. Full logic: <https://github.com/schmug/dmarcheck/blob/main/src/shared/scoring.ts>.
@@ -301,6 +316,16 @@ The grade (S, A+, A, B, C, D, F) is computed from a tier + modifier model. Full 
 - **B** — DMARC enforced (quarantine/reject) with SPF + DKIM aligned.
 - **A / A+** — Full DMARC enforcement, SPF + DKIM correct, MTA-STS enforced.
 - **S** — All of the above plus BIMI with a valid VMC.
+
+## Active scoring thresholds
+
+These reflect this deployment's \`SCORING_CONFIG\` (the values below are dmarc.mx's defaults):
+
+- DKIM keys below **${cfg.dkimKeyMinBits} bits** lose a modifier point.
+- **${cfg.dkimRotationSelectorCount} or more** DKIM selectors earn a modifier point.
+- SPF using **≤ ${cfg.spfEfficientLookupThreshold} DNS lookups** earns a modifier point.
+- DMARC \`pct\` below **${cfg.lowPctDowngradeThreshold}%** downgrades the effective policy one tier.
+- A+ requires ${aplusExtras} (in addition to the A-tier requirements).
 
 Run a scan: \`${MD_SITE}/check?domain=example.com\` (add \`Accept: text/markdown\` for this format).
 `;

--- a/test/scoring-discovery-surfaces.test.ts
+++ b/test/scoring-discovery-surfaces.test.ts
@@ -1,0 +1,67 @@
+/**
+ * #404 — the /scoring FAQ JSON-LD and the markdown rubric must reflect the
+ * active SCORING_CONFIG, while staying byte-identical to the shipped output
+ * when the config is unset (so hosted dmarc.mx is unaffected).
+ */
+import { describe, expect, it } from "vitest";
+import { DEFAULT_SCORING_CONFIG } from "../src/shared/scoring.js";
+import { buildScoringJsonLd } from "../src/views/html.js";
+import { renderScoringRubricMarkdown } from "../src/views/markdown.js";
+
+// The exact DKIM answer that shipped before #404. dkimKeyMinBits is the only
+// config-dependent value in the JSON-LD, so pinning this sentence (with the
+// default 2048) guards the byte-identical-when-unset invariant.
+const SHIPPED_DKIM_ANSWER =
+  "DomainKeys Identified Mail. Adds a cryptographic signature to outgoing messages, proving they haven't been tampered with in transit. Key strength of 2048 bits or more and multiple selectors improve your score.";
+
+describe("buildScoringJsonLd (#404)", () => {
+  it("is byte-identical to the shipped JSON-LD when config is unset", () => {
+    const def = buildScoringJsonLd();
+    expect(def).toBe(buildScoringJsonLd({}));
+    expect(def).toBe(buildScoringJsonLd(DEFAULT_SCORING_CONFIG));
+    // Structurally intact: FAQPage with the original six questions.
+    const parsed = JSON.parse(def);
+    expect(parsed["@type"]).toBe("FAQPage");
+    expect(parsed.mainEntity).toHaveLength(6);
+    // The default DKIM answer is unchanged, character for character.
+    expect(def).toContain(JSON.stringify(SHIPPED_DKIM_ANSWER).slice(1, -1));
+  });
+
+  it("reflects a non-default dkimKeyMinBits", () => {
+    const custom = buildScoringJsonLd({ dkimKeyMinBits: 4096 });
+    expect(custom).toContain("Key strength of 4096 bits or more");
+    expect(custom).not.toContain("2048 bits or more");
+    // Still valid, still six questions — only the number moved.
+    expect(JSON.parse(custom).mainEntity).toHaveLength(6);
+  });
+});
+
+describe("renderScoringRubricMarkdown (#404)", () => {
+  it("renders the default thresholds when config is unset", () => {
+    const md = renderScoringRubricMarkdown();
+    expect(md).toContain("## Active scoring thresholds");
+    expect(md).toContain("below **2048 bits**");
+    expect(md).toContain("**2 or more** DKIM selectors");
+    expect(md).toContain("≤ 5 DNS lookups");
+    expect(md).toContain("below **10%**");
+    expect(md).toContain("both BIMI and enforcing MTA-STS");
+  });
+
+  it("reflects non-default thresholds from the active config", () => {
+    const md = renderScoringRubricMarkdown({
+      dkimKeyMinBits: 4096,
+      dkimRotationSelectorCount: 3,
+      spfEfficientLookupThreshold: 3,
+      lowPctDowngradeThreshold: 20,
+      requireBimiForAPlus: false,
+      requireMtaStsForAPlus: true,
+    });
+    expect(md).toContain("below **4096 bits**");
+    expect(md).toContain("**3 or more** DKIM selectors");
+    expect(md).toContain("≤ 3 DNS lookups");
+    expect(md).toContain("below **20%**");
+    // With BIMI no longer required, the A+ extra prose narrows to MTA-STS.
+    expect(md).toContain("A+ requires enforcing MTA-STS");
+    expect(md).not.toContain("below **2048 bits**");
+  });
+});


### PR DESCRIPTION
Closes the deliberate boundary left by #25: `renderScoringRubric()` (HTML) was made config-aware, but the `/scoring` FAQ JSON-LD and the markdown rubric stayed on canonical defaults. Now all three surfaces reflect a self-hosted deploy's active `SCORING_CONFIG`.

## Changes
- **`html.ts`** — replaced the module-level `SCORING_JSON_LD` constant with an exported **`buildScoringJsonLd(config)`** that interpolates `dkimKeyMinBits` into the DKIM answer; `renderScoringRubric()` feeds it the active config (html.ts:787). Also drove the rubric's DKIM protocol blurb off `dkimKeyMinBits` (was a hardcoded `2048+`).
- **`markdown.ts`** — `renderScoringRubricMarkdown(config)` gains an **"Active scoring thresholds"** section reflecting `dkimKeyMinBits`, `dkimRotationSelectorCount`, `spfEfficientLookupThreshold`, `lowPctDowngradeThreshold`, and the A+ extras knobs. Existing prose untouched (minimal additive diff).
- **`index.ts`** — the `/scoring` **markdown branch** now threads `parseScoringConfig(c.env?.SCORING_CONFIG)`, matching the HTML branch.

## The byte-identical invariant (held + tested)
When `SCORING_CONFIG` is unset, the JSON-LD is **byte-identical** to the shipped output — `DEFAULT_SCORING_CONFIG.dkimKeyMinBits` is 2048, so the DKIM answer still reads "Key strength of 2048 bits or more". The new test pins the **exact shipped DKIM sentence** and asserts `buildScoringJsonLd() === buildScoringJsonLd({}) === buildScoringJsonLd(DEFAULT_SCORING_CONFIG)`. **Hosted dmarc.mx is unaffected.**

## Verification
- New `test/scoring-discovery-surfaces.test.ts`: byte-identical default + config reflection for both JSON-LD and markdown (4 tests).
- Existing `/scoring` FAQ JSON-LD assertion (`index.test.ts`) still green.
- **Full suite: 1108 passing**; typecheck + lint clean. No snapshot files exist, so nothing was blanket-updated.

## Note for review
Touches `src/index.ts`, so this PR is **CODEOWNERS-gated** and needs your approval to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)