### PR TITLE
feat: surface changelog via footer link + filter deps/chore from release notes

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -36,6 +36,15 @@ commit_parsers = [
     { message = "^Pause", group = "Changed" },
     { message = "^Merge pull request", skip = true },
     { message = "^Merge branch", skip = true },
+    # Strip dependency bumps and routine chores from release-note *bodies* so the
+    # changelog lists real changes only. This filters note CONTENT, not release
+    # count — every push to main still cuts a CalVer release, so a deps-only push
+    # produces a release with a header but no bullets (harmless: git-cliff exits 0
+    # and notes stay non-empty, so `gh release create` does not break). The win is
+    # mixed releases (the norm here): the real change shows, the bumps drop out.
+    # Covers conventional `chore(deps)` / `chore:` and dependabot's raw "Bump X".
+    { message = "^chore", skip = true },
+    { message = "^[Bb]ump ", skip = true },
     { body = ".*", group = "Other" },
 ]
 filter_commits = false

--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -180,7 +180,7 @@ export function renderLandingPage(): string {
         <span>curl</span> https://dmarc.mx/api/check?domain=dmarc.mx
       </div>
       <div class="learn-link"><a href="/scoring">How is my score calculated?</a> &middot; <a href="https://www.cloudflare.com/learning/email-security/dmarc-dkim-spf/" target="_blank" rel="noopener">What is email security? &#8599;</a></div>
-      <div class="learn-link"><a href="/pricing">Pricing</a> &middot; <a href="/legal/privacy">Privacy</a></div>
+      <div class="learn-link"><a href="/pricing">Pricing</a> &middot; <a href="/legal/privacy">Privacy</a> &middot; <a href="https://github.com/schmug/dmarcheck/releases" target="_blank" rel="noopener">Changelog &#8599;</a></div>
       <div class="foss-callout">
         <a href="https://github.com/schmug/dmarcheck" class="foss-link">
           <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
@@ -396,7 +396,7 @@ function reportBody(result: ScanResult): string {
   ${tls_rpt ? renderTlsRptCard(tls_rpt) : ""}
   ${monitorSnapshotCard(result)}
   <div class="learn-link" style="margin-top:2.5rem">Analyze message headers: <a href="https://toolbox.googleapps.com/apps/messageheader/" target="_blank" rel="noopener">Google &#8599;</a> &middot; <a href="https://mha.azurewebsites.net/" target="_blank" rel="noopener">Microsoft &#8599;</a></div>
-  <div class="learn-link" style="margin-top:0.4rem;margin-bottom:1rem"><a href="/scoring">How is my score calculated?</a> &middot; <a href="https://www.cloudflare.com/learning/email-security/dmarc-dkim-spf/" target="_blank" rel="noopener">What is email security? &#8599;</a></div>
+  <div class="learn-link" style="margin-top:0.4rem;margin-bottom:1rem"><a href="/scoring">How is my score calculated?</a> &middot; <a href="https://www.cloudflare.com/learning/email-security/dmarc-dkim-spf/" target="_blank" rel="noopener">What is email security? &#8599;</a> &middot; <a href="https://github.com/schmug/dmarcheck/releases" target="_blank" rel="noopener">Changelog &#8599;</a></div>
   <div class="foss-callout">
     <a href="https://github.com/schmug/dmarcheck" class="foss-link">
       <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
@@ -435,7 +435,7 @@ export function renderReportHeader(result: ScanResult): string {
 export function renderReportFooter(result: ScanResult): string {
   return `${monitorSnapshotCard(result)}
   <div class="learn-link" style="margin-top:2.5rem">Analyze message headers: <a href="https://toolbox.googleapps.com/apps/messageheader/" target="_blank" rel="noopener">Google &#8599;</a> &middot; <a href="https://mha.azurewebsites.net/" target="_blank" rel="noopener">Microsoft &#8599;</a></div>
-  <div class="learn-link" style="margin-top:0.4rem;margin-bottom:1rem"><a href="/scoring">How is my score calculated?</a> &middot; <a href="https://www.cloudflare.com/learning/email-security/dmarc-dkim-spf/" target="_blank" rel="noopener">What is email security? &#8599;</a></div>
+  <div class="learn-link" style="margin-top:0.4rem;margin-bottom:1rem"><a href="/scoring">How is my score calculated?</a> &middot; <a href="https://www.cloudflare.com/learning/email-security/dmarc-dkim-spf/" target="_blank" rel="noopener">What is email security? &#8599;</a> &middot; <a href="https://github.com/schmug/dmarcheck/releases" target="_blank" rel="noopener">Changelog &#8599;</a></div>
   <div class="foss-callout">
     <a href="https://github.com/schmug/dmarcheck" class="foss-link">
       <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
@@ -587,7 +587,7 @@ export function renderScoreBreakdown(result: ScanResult): string {
   ${scoringFactorsTable(breakdown.factors, breakdown.modifier, breakdown.modifierLabel)}
   ${protocolContributionGrid(breakdown.protocolSummaries)}
   ${recommendationList(breakdown.recommendations)}
-  <div class="learn-link" style="margin-top:2rem;margin-bottom:1rem"><a href="/scoring">How is my score calculated?</a> &middot; <a href="https://www.cloudflare.com/learning/email-security/dmarc-dkim-spf/" target="_blank" rel="noopener">What is email security? &#8599;</a></div>
+  <div class="learn-link" style="margin-top:2rem;margin-bottom:1rem"><a href="/scoring">How is my score calculated?</a> &middot; <a href="https://www.cloudflare.com/learning/email-security/dmarc-dkim-spf/" target="_blank" rel="noopener">What is email security? &#8599;</a> &middot; <a href="https://github.com/schmug/dmarcheck/releases" target="_blank" rel="noopener">Changelog &#8599;</a></div>
 </main>`;
 
   return page({


### PR DESCRIPTION
## Summary

Incorporates the project changelog on both the GitHub repo and the website, the lean way:

- **Website:** adds a **`Changelog ↗`** link to the site footer — landing page plus all three post-scan footers (static report, SSE done-event, and the `/check/score` breakdown) — pointing at `github.com/schmug/dmarcheck/releases`. Matches the existing external-link styling (`target="_blank"`, `rel="noopener"`, ↗ glyph).
- **GitHub:** the Releases page is *already* the automatic changelog (git-cliff + CalVer release per push to `main`). This PR also updates `cliff.toml` to skip `chore` / `chore(deps)` / `Bump` commits so dependency bumps and routine chores drop out of release-note **bodies**.

This was deliberately scoped down from a native `/changelog` page after discussion — a footer link to the existing Releases page is zero-maintenance and avoids a runtime GitHub-API dependency, a `CHANGELOG.md` commit-back loop, and bundled-artifact churn.

## What the cliff.toml change does (and doesn't)

Verified empirically with git-cliff 2.13.1:
- **Mixed releases (the norm here):** deps lines are stripped, real changes remain. Clear win.
- **Deps-only releases:** render a header with no bullets — `git-cliff` exits 0 and notes stay non-empty, so `gh release create` does **not** break.
- It filters note **content, not release count.** Reducing the ~66 releases/month volume is a release-*cadence* change in `release.yml`, tracked separately in #411.

## Testing

- `npm test` — **1113 passing, 0 failing** (69 files)
- `npm run lint` — clean (biome, 146 files)
- `npm run typecheck` — clean (`tsc --noEmit`, exit 0)
- `cliff.toml` validated as parseable; `git-cliff --latest` renders the latest release cleanly with deps commits filtered
- Footer link verified rendering live (dev server) in all four code paths: landing (DOM), `/check?domain=…&_direct=1` (static report), `/api/check/stream` (SSE done-event), `/check/score` (breakdown)

## Follow-up

- #411 — skip cutting a release for deps-only / chore-only pushes (the actual Releases-page volume lever; touches the fragile, CODEOWNERS-gated `release.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)