### PR TITLE
🎨 Palette: Actionable Empty States

### DIFF
--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -2290,7 +2290,12 @@ export function renderDomainDetailPage({
   const historySection =
     scanHistory.length > 0
       ? `<ul class="history-list">${historyItems}</ul>`
-      : `<p style="color:var(--clr-text-muted);font-size:0.875rem;padding:0.75rem 0">No scan history yet. Use 'Scan Now' above to generate your first grade.</p>`;
+      : `<div class="empty-state" style="padding: 1.5rem 0; text-align: left;">
+  <p style="margin-bottom: 0.75rem;">No scan history yet. Generate your first grade to see history and trends.</p>
+  <form method="POST" action="/dashboard/domain/${encodeURIComponent(domain)}/scan" style="display:inline">
+    <button type="submit" class="btn btn-secondary">Scan Now</button>
+  </form>
+</div>`;
 
   const body = `<div class="domain-detail-header">
   <span class="grade-badge ${gradeClass(grade)}">${esc(grade)}</span>
@@ -2940,7 +2945,10 @@ export function renderApiKeysPage({
 
   let table: string;
   if (keys.length === 0) {
-    table = `<p style="color:var(--clr-text-muted);font-size:0.875rem">No API keys yet. Generate your first one above to authenticate API requests.</p>`;
+    table = `<div class="empty-state" style="padding: 2rem 0;">
+  <p>No API keys yet. Bearer tokens are required to authenticate API requests.</p>
+  <button type="button" class="btn btn-secondary" onclick="document.getElementById('api-key-name')?.focus()">Create your first key</button>
+</div>`;
   } else {
     const rows = keys
       .map((k) => {

--- a/src/views/scripts.ts
+++ b/src/views/scripts.ts
@@ -1163,7 +1163,14 @@ if (typeof navigator !== 'undefined' && navigator.modelContext && typeof navigat
     children.push(sectionTitle('Recent scans'));
     var hist = data.history || [];
     if (hist.length === 0) {
-      children.push(el('p', { class: 'drawer-history-empty', text: 'No scan history yet. Use Scan Now below to generate your first grade.' }));
+      var emptyContainer = el('div', { class: 'empty-state', style: 'padding: 1.5rem 0; text-align: left;' });
+      var emptyText = el('p', { text: 'No scan history yet. Generate your first grade to see history and trends.', style: 'margin-bottom: 0.75rem;' });
+      var scanFormEmpty = el('form', { method: 'POST', action: '/dashboard/domain/' + encodeURIComponent(data.domain) + '/scan', style: 'display: inline;' });
+      var scanBtnEmpty = el('button', { type: 'submit', class: 'btn btn-secondary', text: 'Scan Now' });
+      scanFormEmpty.appendChild(scanBtnEmpty);
+      emptyContainer.appendChild(emptyText);
+      emptyContainer.appendChild(scanFormEmpty);
+      children.push(emptyContainer);
     } else {
       var histList = el('div', { class: 'drawer-history-list' });
       hist.slice(0, 8).forEach(function(h) { histList.appendChild(historyRowEl(h)); });


### PR DESCRIPTION
### 💡 What
This PR updates the empty states on the API Keys page, Domain Detail history view, and Client-Side Drawer history view to be fully actionable. Instead of passive text that points users to find a button "above" or "below", the empty states now contain inline forms and buttons to execute the primary action directly.

### 🎯 Why
As noted in our `.Jules/palette.md` UX learnings, generic "No X found" empty states create dead ends for users. Providing a clear "Next Step" or Call-to-Action directly inside the empty state message drastically reduces friction and improves usability by keeping the user flow uninterrupted.

### 📸 Before/After
- **API Keys:** Before: Text "No API keys yet. Generate your first one above...". After: Distinct box with a "Create your first key" button that seamlessly focuses the name input.
- **Scan History:** Before: Text "Use 'Scan Now' above to generate...". After: Inline `<form>` submitting the scan, right inside the empty state.

### ♿ Accessibility
The empty states leverage existing CSS and layout classes for sufficient contrast and text size. For the API Keys list, the inline button triggers a focus event onto the native input field, ensuring that screen readers properly announce the input label when the CTA is triggered, preserving keyboard flow.

---
*PR created automatically by Jules for task [12276830578970475691](https://jules.google.com/task/12276830578970475691) started by @schmug*