### PR TITLE
chore: sign releases with Sigstore and publish SHA256SUMS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -69,3 +70,37 @@ jobs:
           git tag "$VERSION"
           git push origin "$VERSION"
           gh release create "$VERSION" --title "$VERSION" --notes "$NOTES" sbom.cdx.json
+
+      - name: Generate SHA256SUMS
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          SLUG="schmug/dmarcheck"
+          # Download the auto-generated source archives GitHub creates for each release tag.
+          # These may take a few seconds to appear; retry once if the first attempt fails.
+          gh release download "$VERSION" --repo "$SLUG" --archive=tar.gz \
+            --output "dmarcheck-${VERSION}.tar.gz" || \
+          gh release download "$VERSION" --repo "$SLUG" --archive=tar.gz \
+            --output "dmarcheck-${VERSION}.tar.gz"
+          gh release download "$VERSION" --repo "$SLUG" --archive=zip \
+            --output "dmarcheck-${VERSION}.zip" || \
+          gh release download "$VERSION" --repo "$SLUG" --archive=zip \
+            --output "dmarcheck-${VERSION}.zip"
+          sha256sum sbom.cdx.json \
+            "dmarcheck-${VERSION}.tar.gz" \
+            "dmarcheck-${VERSION}.zip" > SHA256SUMS
+
+      - name: Install cosign (Sigstore)
+        uses: sigstore/cosign-installer@11606fdb78ecbf8504a2bf72df938fc4c43bfedd # v3.8.1
+
+      - name: Sign SHA256SUMS with Sigstore keyless signing
+        run: |
+          cosign sign-blob --yes SHA256SUMS --bundle SHA256SUMS.bundle
+
+      - name: Upload SHA256SUMS and signature bundle
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          gh release upload "$VERSION" SHA256SUMS SHA256SUMS.bundle

--- a/README.md
+++ b/README.md
@@ -213,6 +213,48 @@ Cloudflare Web Analytics dashboard.
 Security posture is documented in [SECURITY.md](SECURITY.md) and the
 [threat model](THREAT_MODEL.md).
 
+## Verifying a release
+
+Every release ships a `SHA256SUMS` manifest (covering the SBOM and the
+GitHub-generated source archives) and a Sigstore keyless signature bundle
+(`SHA256SUMS.bundle`). The signing identity is the GitHub Actions workflow
+itself — no long-lived private key is involved.
+
+### Prerequisites
+
+Install [cosign](https://docs.sigstore.dev/cosign/system_config/installation/):
+
+```bash
+# macOS / Linux with Homebrew
+brew install cosign
+
+# or via Go
+go install github.com/sigstore/cosign/v2/cmd/cosign@latest
+```
+
+### Verify a release
+
+Replace `vYYYY.M.N` with the tag you want to verify (e.g. `v2026.5.1`).
+
+```bash
+# 1. Download the manifest and signature bundle
+gh release download vYYYY.M.N -R schmug/dmarcheck --pattern 'SHA256SUMS*'
+
+# 2. Verify the Sigstore signature — confirms the bundle was signed by
+#    the release workflow running on the schmug/dmarcheck repository
+cosign verify-blob \
+  --bundle SHA256SUMS.bundle \
+  --certificate-identity-regexp "https://github.com/schmug/dmarcheck/.github/workflows/release.yml" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  SHA256SUMS
+
+# 3. Check file integrity
+sha256sum -c SHA256SUMS
+```
+
+A successful run of step 2 prints `Verified OK`. Step 3 confirms that the
+downloaded archives match the checksums signed in step 2.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

- Adds three new steps to the `release` job in `.github/workflows/release.yml`: generate `SHA256SUMS` (covering `sbom.cdx.json`, the GitHub-generated source `.tar.gz`, and `.zip`), sign it with `cosign sign-blob --yes` via the `sigstore/cosign-installer@11606fdb78ecbf8504a2bf72df938fc4c43bfedd` action (v3.8.1, pinned by SHA per repo convention), and upload `SHA256SUMS` + `SHA256SUMS.bundle` as release assets.
- Adds `id-token: write` at the **job level** on the `release` job (required for OIDC keyless signing); the top-level `permissions` block remains `contents: read`.
- Adds a "Verifying a release" section to `README.md` with copy-pasteable `cosign verify-blob` and `sha256sum -c` commands, including the expected OIDC issuer and signing identity regexp.

Closes #384

## Notes

- **`release.yml` is CODEOWNERS-gated** — a code-owner approval is required before this PR can merge.
- **End-to-end verification cannot be tested in a dry PR.** A manual end-to-end verification against a real release is needed after merge to confirm the bundle verifies correctly — this cannot be tested here.

## Test plan

- [x] `npm run lint` — 0 errors, 0 warnings (YAML/Markdown not in biome scope; TypeScript source unchanged)
- [x] `npm run typecheck` — clean
- [x] `npm test` — 1112/1113 pass; the 1 failure (`mta-sts-runtime.test.ts`) is a pre-existing live-network integration test unrelated to this change
- [ ] After merge: trigger a release and confirm `SHA256SUMS` and `SHA256SUMS.bundle` appear as release assets, then run the `cosign verify-blob` command from the README to confirm the bundle verifies correctly

https://claude.ai/code/session_012NJLeTjJRShAdZNHGztnU5

---
_Generated by [Claude Code](https://claude.ai/code/session_012NJLeTjJRShAdZNHGztnU5)_