### PR TITLE
chore: skip GitHub Release for deps-only / chore-only pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,48 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Detect whether all commits since the last tag are deps-only / chores.
+      # Skip patterns mirror cliff.toml commit_parsers with skip=true:
+      #   ^chore        covers chore:, chore(deps):, chore(deps-dev):, …
+      #   ^[Bb]ump      dependabot-style "Bump X from Y to Z"
+      #   ^Merge pull request / ^Merge branch  — merge commits
+      # If every commit since the last tag matches one of those patterns (or
+      # there are no new commits at all), set skip=true so the remaining steps
+      # are skipped and the job exits success without creating a tag or Release.
+      # Serial-number note: skipping a run leaves a gap in vYYYY.M.serial —
+      # that is acceptable; the counter always counts existing tags.
+      - name: Check for releasable commits
+        id: check
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -z "$LAST_TAG" ]; then
+            # No prior tag — this is the first release, never skip.
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          else
+            COMMITS=$(git log "${LAST_TAG}..HEAD" --format='%s')
+            if [ -z "$COMMITS" ]; then
+              # No new commits since last tag — nothing to release.
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+            else
+              NON_SKIP=$(echo "$COMMITS" | grep -vE '^(chore|[Bb]ump |Merge pull request|Merge branch)' || true)
+              if [ -z "$NON_SKIP" ]; then
+                echo "skip=true" >> "$GITHUB_OUTPUT"
+                echo "Skipping release — all commits since ${LAST_TAG} are deps/chore only:"
+                git log "${LAST_TAG}..HEAD" --format='  %s'
+              else
+                echo "skip=false" >> "$GITHUB_OUTPUT"
+              fi
+            fi
+          fi
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        if: steps.check.outputs.skip != 'true'
         with:
           node-version: "22"
 
       - name: Calculate CalVer
         id: version
+        if: steps.check.outputs.skip != 'true'
         run: |
           YEAR=$(date -u +%Y)
           MONTH=$(date -u +%-m)
@@ -35,12 +71,14 @@ jobs:
           echo "version=${PREFIX}${SERIAL}" >> "$GITHUB_OUTPUT"
 
       - name: Install git-cliff
+        if: steps.check.outputs.skip != 'true'
         uses: taiki-e/install-action@6ed6112eb9893c58dd600eebccdf6e77ab7bfa9c # v2.79.12
         with:
           tool: git-cliff
 
       - name: Generate changelog
         id: changelog
+        if: steps.check.outputs.skip != 'true'
         run: |
           NOTES=$(git-cliff --config cliff.toml --latest --strip header 2>/dev/null || echo "No notable changes.")
           {
@@ -53,6 +91,7 @@ jobs:
       # the lockfile only (no `npm ci` needed) and pinned to a specific tool
       # version. The SBOM is attached as a release asset, never committed.
       - name: Generate CycloneDX SBOM
+        if: steps.check.outputs.skip != 'true'
         run: |
           npx --yes @cyclonedx/cyclonedx-npm@4.2.1 \
             --package-lock-only \
@@ -61,6 +100,7 @@ jobs:
             --output-file sbom.cdx.json
 
       - name: Create GitHub Release
+        if: steps.check.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Summary

- Adds a `Check for releasable commits` step in `release.yml` that runs after checkout and inspects `git log` since the last tag.
- If every commit subject matches a `cliff.toml` skip pattern (`^chore`, `^[Bb]ump `, `^Merge pull request`, `^Merge branch`), sets `skip=true`.
- All subsequent steps (`setup-node`, `Calculate CalVer`, `Install git-cliff`, `Generate changelog`, `Generate CycloneDX SBOM`, `Create GitHub Release`) are gated with `if: steps.check.outputs.skip != 'true'` — the job exits **success** without creating a new tag or GitHub Release.
- A push with ≥1 `feat`/`fix`/etc. commit still creates a release as before, with deps/chore lines filtered from notes by the existing `cliff.toml` configuration.
- Serial numbers may have gaps when releases are skipped (the counter counts existing tags, not workflow runs) — this is documented in a comment and is acceptable per the issue.

Closes #411

## Notes

- `.github/workflows/release.yml` is CODEOWNERS-gated — this PR will require code-owner approval before merge.
- The `workflow_run` trigger chain is unchanged; the job always exits success (no failed-workflow regressions).
- No changes to `cliff.toml`, CalVer scheme, SBOM generation, or any source files.

## Test plan

- [ ] Verify detection logic: deps-only commits (`chore(deps): bump …`, `Bump X from Y to Z`, merge commits) → `skip=true`, no tag, no Release, job green.
- [ ] Verify mixed push: ≥1 `feat`/`fix` commit in the range → `skip=false`, release created with deps lines filtered from notes.
- [ ] Verify first-release edge case: no prior tag → `skip=false`, release always created.
- [ ] Verify no-new-commits edge case: `LAST_TAG..HEAD` is empty → `skip=true`, job exits success.
- [ ] Confirm SBOM (`sbom.cdx.json`) is still attached as a release asset for real releases.

https://claude.ai/code/session_012NJLeTjJRShAdZNHGztnU5

---
_Generated by [Claude Code](https://claude.ai/code/session_012NJLeTjJRShAdZNHGztnU5)_