### PR TITLE
feat: add DoH transport and DNSSEC status analyzer (#414)

### DIFF
--- a/src/analyzers/dnssec.ts
+++ b/src/analyzers/dnssec.ts
@@ -1,0 +1,61 @@
+import { DnsLookupError, queryDoh } from "../dns/client.js";
+import type { DnssecResult, Validation } from "./types.js";
+
+export async function analyzeDnssec(domain: string): Promise<DnssecResult> {
+  const validations: Validation[] = [];
+
+  let response: Awaited<ReturnType<typeof queryDoh>>;
+  try {
+    // Query DS records for the domain. DS records live in the parent zone and
+    // signal that the parent has signed the delegation — the presence of DS
+    // records (plus the AD flag from a validating resolver) is the standard
+    // way to determine DNSSEC status without doing a full chain-of-trust walk.
+    response = await queryDoh(domain, "DS");
+  } catch (err) {
+    if (err instanceof DnsLookupError) {
+      validations.push({
+        status: "fail",
+        message: `DNSSEC lookup failed: ${err.message}`,
+      });
+      return {
+        status: "fail",
+        signed: false,
+        validated: false,
+        validations,
+        lookup_error: { code: err.code, message: err.message },
+      };
+    }
+    throw err;
+  }
+
+  if (!response) {
+    // NXDOMAIN or no DS records — zone is unsigned
+    validations.push({
+      status: "info",
+      message: "DNSSEC not configured — no DS records in the parent zone",
+    });
+    return { status: "info", signed: false, validated: false, validations };
+  }
+
+  const ad = response.AD;
+
+  if (ad) {
+    validations.push({
+      status: "pass",
+      message:
+        "DNSSEC signed and validated — DS records present, AD flag set by resolver",
+    });
+    return { status: "pass", signed: true, validated: true, validations };
+  }
+
+  // DS records exist but the resolver did not set the AD flag — the zone has
+  // DNSSEC configured but validation failed or the resolving path is not
+  // DNSSEC-aware. Surface as warn rather than pass so the user knows to check
+  // their DNSSEC signing chain.
+  validations.push({
+    status: "warn",
+    message:
+      "DNSSEC signed but not validated — DS records present but resolver AD flag not set (check zone signing chain)",
+  });
+  return { status: "warn", signed: true, validated: false, validations };
+}

--- a/src/analyzers/types.ts
+++ b/src/analyzers/types.ts
@@ -124,6 +124,14 @@ export interface ScanSummary {
   mta_sts_mode: string | null;
 }
 
+export interface DnssecResult {
+  status: Status;
+  signed: boolean;
+  validated: boolean;
+  validations: Validation[];
+  lookup_error?: { code: string; message: string };
+}
+
 export interface ScanResult {
   domain: string;
   timestamp: string;
@@ -139,5 +147,6 @@ export interface ScanResult {
     mta_sts: MtaStsResult;
     security_txt: SecurityTxtResult;
     tls_rpt?: TlsRptResult;
+    dnssec?: DnssecResult;
   };
 }

--- a/src/dns/client.ts
+++ b/src/dns/client.ts
@@ -122,6 +122,67 @@ export async function queryTxt(name: string): Promise<TxtRecord | null> {
   }
 }
 
+// Shape of the Cloudflare 1.1.1.1 DoH JSON API response.
+// Status 0 = NOERROR, 3 = NXDOMAIN. AD = Authenticated Data flag (DNSSEC).
+export interface DohResponse {
+  Status: number;
+  AD: boolean;
+  Answer?: Array<{ name: string; type: number; TTL: number; data: string }>;
+}
+
+// DNS-over-HTTPS query via the Cloudflare 1.1.1.1 DoH JSON API.
+// Returns null for NXDOMAIN / no answer; throws DnsLookupError for SERVFAIL
+// or timeout — matching the semantics of queryTxt and queryMx.
+// The URL is hardcoded (not user-supplied), so this is not an SSRF risk.
+export async function queryDoh(
+  name: string,
+  type: string,
+): Promise<DohResponse | null> {
+  Sentry.addBreadcrumb({
+    category: "dns.query",
+    message: `DoH ${type} ${name}`,
+    data: { type, hostname: name },
+    level: "info",
+  });
+  const url = `https://cloudflare-dns.com/dns-query?name=${encodeURIComponent(name)}&type=${encodeURIComponent(type)}`;
+  try {
+    const resp = await withTimeout(
+      fetch(url, {
+        headers: { Accept: "application/dns-json" },
+        redirect: "follow",
+      }),
+      DNS_TIMEOUT_MS,
+    );
+    if (!resp.ok) {
+      throw new DnsLookupError(
+        "ESERVFAIL",
+        `DoH query returned HTTP ${resp.status}`,
+      );
+    }
+    const data = (await resp.json()) as DohResponse;
+    // NXDOMAIN or NOERROR with no answers → record absent
+    if (data.Status === 3 || !data.Answer || data.Answer.length === 0) {
+      Sentry.addBreadcrumb({
+        category: "dns.nxdomain",
+        message: `DoH ${type} ${name} not found (Status ${data.Status})`,
+        data: { type, hostname: name, status: data.Status },
+        level: "info",
+      });
+      return null;
+    }
+    return data;
+  } catch (err: unknown) {
+    if (err instanceof DnsLookupError) throw err;
+    if (err instanceof Error && err.message === "DNS timeout") {
+      throw new DnsLookupError("DNS_TIMEOUT", "DoH query timed out");
+    }
+    throw new DnsLookupError(
+      "ESERVFAIL",
+      `DoH query failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
 export async function queryMx(name: string): Promise<MxRecord[] | null> {
   Sentry.addBreadcrumb({
     category: "dns.query",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import type {
   BimiResult,
   DkimResult,
   DmarcResult,
+  DnssecResult,
   MtaStsResult,
   MxResult,
   ScanResult,
@@ -71,6 +72,7 @@ import {
   renderBimiCard,
   renderDkimCard,
   renderDmarcCard,
+  renderDnssecCard,
   renderError,
   renderLandingPage,
   renderMtaStsCard,
@@ -537,6 +539,7 @@ const protocolRenderers: Record<
   mta_sts: (r) => renderMtaStsCard(r as MtaStsResult),
   security_txt: (r) => renderSecurityTxtCard(r as SecurityTxtResult),
   tls_rpt: (r) => renderTlsRptCard(r as TlsRptResult),
+  dnssec: (r) => renderDnssecCard(r as DnssecResult),
 };
 
 function tagScanResult(result: ScanResult): void {

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -2,6 +2,7 @@ import * as Sentry from "@sentry/cloudflare";
 import { analyzeBimi, prefetchBimiDns } from "./analyzers/bimi.js";
 import { analyzeDkim } from "./analyzers/dkim.js";
 import { analyzeDmarc } from "./analyzers/dmarc.js";
+import { analyzeDnssec } from "./analyzers/dnssec.js";
 import { analyzeMtaSts } from "./analyzers/mta-sts.js";
 import { analyzeMx } from "./analyzers/mx.js";
 import { checkMxMtaStsConsistency } from "./analyzers/mx-mta-sts-consistency.js";
@@ -12,6 +13,7 @@ import type {
   BimiResult,
   DkimResult,
   DmarcResult,
+  DnssecResult,
   MtaStsResult,
   MxResult,
   ScanResult,
@@ -31,7 +33,8 @@ export type ProtocolId =
   | "bimi"
   | "mta_sts"
   | "security_txt"
-  | "tls_rpt";
+  | "tls_rpt"
+  | "dnssec";
 export type ProtocolResult =
   | MxResult
   | DmarcResult
@@ -40,7 +43,8 @@ export type ProtocolResult =
   | BimiResult
   | MtaStsResult
   | SecurityTxtResult
-  | TlsRptResult;
+  | TlsRptResult
+  | DnssecResult;
 
 const PROTOCOL_LABEL: Record<ProtocolId, string> = {
   mx: "MX",
@@ -51,6 +55,7 @@ const PROTOCOL_LABEL: Record<ProtocolId, string> = {
   mta_sts: "MTA-STS",
   security_txt: "security.txt",
   tls_rpt: "TLS-RPT",
+  dnssec: "DNSSEC",
 };
 
 function analyzerErrorValidation(id: ProtocolId, message: string): Validation {
@@ -118,6 +123,13 @@ const ERROR_RESULTS = {
     record: null,
     tags: null,
     validations: [analyzerErrorValidation("tls_rpt", m)],
+    lookup_error: { code: "analyzer_error", message: m },
+  }),
+  dnssec: (m: string): DnssecResult => ({
+    status: "fail",
+    signed: false,
+    validated: false,
+    validations: [analyzerErrorValidation("dnssec", m)],
     lookup_error: { code: "analyzer_error", message: m },
   }),
 } as const;
@@ -237,6 +249,7 @@ export async function scan(
   const mxPromise = analyzeMx(domain);
   const securityTxtPromise = analyzeSecurityTxt(domain);
   const tlsRptPromise = analyzeTlsRpt(domain);
+  const dnssecPromise = analyzeDnssec(domain);
 
   // Chain DKIM off MX so it starts as soon as MX resolves
   // without blocking on unrelated queries
@@ -270,6 +283,7 @@ export async function scan(
     mxResult,
     securityTxtResult,
     tlsRptResult,
+    dnssecResult,
   ] = await Promise.all([
     settle("dmarc", dmarcPromise, ERROR_RESULTS.dmarc),
     settle("spf", spfPromise, ERROR_RESULTS.spf),
@@ -279,6 +293,7 @@ export async function scan(
     settle("mx", mxPromise, ERROR_RESULTS.mx),
     settle("security_txt", securityTxtPromise, ERROR_RESULTS.security_txt),
     settle("tls_rpt", tlsRptPromise, ERROR_RESULTS.tls_rpt),
+    settle("dnssec", dnssecPromise, ERROR_RESULTS.dnssec),
   ]);
 
   Sentry.addBreadcrumb({
@@ -323,6 +338,12 @@ export async function scan(
     data: { protocol: "tls_rpt", status: tlsRptResult.status },
     level: "info",
   });
+  Sentry.addBreadcrumb({
+    category: "analyzer.complete",
+    message: `dnssec: ${dnssecResult.status}`,
+    data: { protocol: "dnssec", status: dnssecResult.status },
+    level: "info",
+  });
 
   return await buildScanResult(
     domain,
@@ -335,6 +356,7 @@ export async function scan(
       mta_sts: mtaStsResult,
       security_txt: securityTxtResult,
       tls_rpt: tlsRptResult,
+      dnssec: dnssecResult,
     },
     config,
   );
@@ -358,6 +380,7 @@ export async function scanStreaming(
   const mxPromise = analyzeMx(domain);
   const securityTxtPromise = analyzeSecurityTxt(domain);
   const tlsRptPromise = analyzeTlsRpt(domain);
+  const dnssecPromise = analyzeDnssec(domain);
 
   // Chain DKIM off MX so it starts as soon as MX resolves
   const dkimPromise = mxPromise.then((mxResult) => {
@@ -394,6 +417,7 @@ export async function scanStreaming(
     mxResult,
     securityTxtResult,
     tlsRptResult,
+    dnssecResult,
   ] = await Promise.all([
     streamSettled("dmarc", dmarcPromise, ERROR_RESULTS.dmarc, onResult),
     streamSettled("spf", spfPromise, ERROR_RESULTS.spf, onResult),
@@ -408,6 +432,7 @@ export async function scanStreaming(
       onResult,
     ),
     streamSettled("tls_rpt", tlsRptPromise, ERROR_RESULTS.tls_rpt, onResult),
+    streamSettled("dnssec", dnssecPromise, ERROR_RESULTS.dnssec, onResult),
   ]);
 
   const result = await buildScanResult(
@@ -421,6 +446,7 @@ export async function scanStreaming(
       mta_sts: mtaStsResult,
       security_txt: securityTxtResult,
       tls_rpt: tlsRptResult,
+      dnssec: dnssecResult,
     },
     config,
   );

--- a/src/shared/scoring.ts
+++ b/src/shared/scoring.ts
@@ -2,6 +2,7 @@ import type {
   BimiResult,
   DkimResult,
   DmarcResult,
+  DnssecResult,
   MtaStsResult,
   SecurityTxtResult,
   SpfResult,
@@ -22,6 +23,9 @@ interface Protocols {
   security_txt?: SecurityTxtResult;
   // Optional for same reason — older fixtures don't include tls_rpt.
   tls_rpt?: TlsRptResult;
+  // Optional — informational only; does not affect grades unless
+  // DNSSEC scoring is explicitly enabled in SCORING_CONFIG.
+  dnssec?: DnssecResult;
   [key: string]: unknown;
 }
 
@@ -432,7 +436,8 @@ function dkimFactors(dkim: DkimResult, config: ScoringConfig): ScoringFactor[] {
 function buildProtocolSummaries(
   protocols: Protocols,
 ): GradeBreakdown["protocolSummaries"] {
-  const { dmarc, spf, dkim, bimi, mta_sts, security_txt, tls_rpt } = protocols;
+  const { dmarc, spf, dkim, bimi, mta_sts, security_txt, tls_rpt, dnssec } =
+    protocols;
   const dmarcPolicy = dmarc.tags?.p ?? null;
   const dkimFound = Object.values(dkim.selectors).filter((s) => s.found);
 
@@ -486,6 +491,16 @@ function buildProtocolSummaries(
         ? tls_rpt.tags?.rua
           ? tls_rpt.tags.rua.split(",")[0].trim()
           : "Record found (no rua)"
+        : "Not configured",
+    };
+  }
+  if (dnssec) {
+    summaries.dnssec = {
+      status: dnssec.status,
+      summary: dnssec.signed
+        ? dnssec.validated
+          ? "Signed and validated"
+          : "Signed (not validated)"
         : "Not configured",
     };
   }

--- a/src/views/components.ts
+++ b/src/views/components.ts
@@ -466,6 +466,8 @@ const PROTO_LABELS: Record<string, string> = {
   bimi: "BIMI",
   mta_sts: "MTA-STS",
   security_txt: "security.txt",
+  tls_rpt: "TLS-RPT",
+  dnssec: "DNSSEC",
 };
 
 export function scoreSnippet(result: ScanResult): string {

--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -2,6 +2,7 @@ import type {
   BimiResult,
   DkimResult,
   DmarcResult,
+  DnssecResult,
   MtaStsResult,
   MxResult,
   ScanResult,
@@ -363,8 +364,18 @@ export function renderMxCard(mx: MxResult): string {
   return protocolCard("MX", mx.status, subtitle, body);
 }
 
+export function renderDnssecCard(d: DnssecResult): string {
+  const subtitle = d.signed
+    ? d.validated
+      ? "Signed and validated"
+      : "Signed (not validated)"
+    : "Not configured";
+  const body = validationList(d.validations);
+  return protocolCard("DNSSEC", d.status, subtitle, body, false, "dnssec");
+}
+
 function reportBody(result: ScanResult): string {
-  const { mx, dmarc, spf, dkim, bimi, mta_sts, security_txt, tls_rpt } =
+  const { mx, dmarc, spf, dkim, bimi, mta_sts, security_txt, tls_rpt, dnssec } =
     result.protocols;
 
   return `<main class="report">
@@ -394,6 +405,7 @@ function reportBody(result: ScanResult): string {
   ${renderMtaStsCard(mta_sts)}
   ${security_txt ? renderSecurityTxtCard(security_txt) : ""}
   ${tls_rpt ? renderTlsRptCard(tls_rpt) : ""}
+  ${dnssec ? renderDnssecCard(dnssec) : ""}
   ${monitorSnapshotCard(result)}
   <div class="learn-link" style="margin-top:2.5rem">Analyze message headers: <a href="https://toolbox.googleapps.com/apps/messageheader/" target="_blank" rel="noopener">Google &#8599;</a> &middot; <a href="https://mha.azurewebsites.net/" target="_blank" rel="noopener">Microsoft &#8599;</a></div>
   <div class="learn-link" style="margin-top:0.4rem;margin-bottom:1rem"><a href="/scoring">How is my score calculated?</a> &middot; <a href="https://www.cloudflare.com/learning/email-security/dmarc-dkim-spf/" target="_blank" rel="noopener">What is email security? &#8599;</a> &middot; <a href="https://github.com/schmug/dmarcheck/releases" target="_blank" rel="noopener">Changelog &#8599;</a></div>

--- a/src/views/markdown.ts
+++ b/src/views/markdown.ts
@@ -1,4 +1,5 @@
 import type {
+  DnssecResult,
   ScanResult,
   SecurityTxtResult,
   TlsRptResult,
@@ -74,6 +75,19 @@ ${t.record}
 ${ruaLine}
 
 ${validationLines(t.validations)}`;
+}
+
+function renderDnssecMarkdown(d: DnssecResult): string {
+  const subtitle = d.signed
+    ? d.validated
+      ? "Signed and validated"
+      : "Signed (not validated)"
+    : "Not configured";
+  return `## DNSSEC — ${d.status}
+
+${subtitle}
+
+${validationLines(d.validations)}`;
 }
 
 export function renderLandingMarkdown(): string {
@@ -191,6 +205,8 @@ ${validationLines(protocols.mx.validations)}
 ${protocols.security_txt ? renderSecurityTxtMarkdown(protocols.security_txt) : ""}
 
 ${protocols.tls_rpt ? renderTlsRptMarkdown(protocols.tls_rpt) : ""}
+
+${protocols.dnssec ? renderDnssecMarkdown(protocols.dnssec) : ""}
 
 ---
 

--- a/test/dnssec.test.ts
+++ b/test/dnssec.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { analyzeDnssec } from "../src/analyzers/dnssec.js";
+
+vi.mock("../src/dns/client.js", () => ({
+  queryDoh: vi.fn(),
+  DnsLookupError: class DnsLookupError extends Error {
+    code: string;
+    constructor(code: string, message: string) {
+      super(message);
+      this.name = "DnsLookupError";
+      this.code = code;
+    }
+  },
+}));
+
+import { DnsLookupError, queryDoh } from "../src/dns/client.js";
+
+const mockQueryDoh = vi.mocked(queryDoh);
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("analyzeDnssec", () => {
+  it("returns info when no DS records exist (unsigned zone)", async () => {
+    mockQueryDoh.mockResolvedValue(null);
+    const result = await analyzeDnssec("example.com");
+    expect(result.status).toBe("info");
+    expect(result.signed).toBe(false);
+    expect(result.validated).toBe(false);
+    expect(result.lookup_error).toBeUndefined();
+    expect(
+      result.validations.some(
+        (v) =>
+          v.status === "info" && v.message.includes("DNSSEC not configured"),
+      ),
+    ).toBe(true);
+  });
+
+  it("queries DS records for the domain", async () => {
+    mockQueryDoh.mockResolvedValue(null);
+    await analyzeDnssec("example.com");
+    expect(mockQueryDoh).toHaveBeenCalledWith("example.com", "DS");
+  });
+
+  it("returns pass when DS records present and AD flag set", async () => {
+    mockQueryDoh.mockResolvedValue({
+      Status: 0,
+      AD: true,
+      Answer: [
+        { name: "example.com", type: 43, TTL: 3600, data: "12345 13 2 abc123" },
+      ],
+    });
+    const result = await analyzeDnssec("example.com");
+    expect(result.status).toBe("pass");
+    expect(result.signed).toBe(true);
+    expect(result.validated).toBe(true);
+    expect(
+      result.validations.some(
+        (v) => v.status === "pass" && v.message.includes("AD flag"),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns warn when DS records present but AD flag not set", async () => {
+    mockQueryDoh.mockResolvedValue({
+      Status: 0,
+      AD: false,
+      Answer: [
+        { name: "example.com", type: 43, TTL: 3600, data: "12345 13 2 abc123" },
+      ],
+    });
+    const result = await analyzeDnssec("example.com");
+    expect(result.status).toBe("warn");
+    expect(result.signed).toBe(true);
+    expect(result.validated).toBe(false);
+    expect(
+      result.validations.some(
+        (v) => v.status === "warn" && v.message.includes("AD flag not set"),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns fail + lookup_error on DnsLookupError", async () => {
+    mockQueryDoh.mockRejectedValue(
+      new DnsLookupError("ESERVFAIL", "DNS server failure (SERVFAIL)"),
+    );
+    const result = await analyzeDnssec("example.com");
+    expect(result.status).toBe("fail");
+    expect(result.signed).toBe(false);
+    expect(result.validated).toBe(false);
+    expect(result.lookup_error).toEqual({
+      code: "ESERVFAIL",
+      message: "DNS server failure (SERVFAIL)",
+    });
+    expect(
+      result.validations.some(
+        (v) =>
+          v.status === "fail" && v.message.includes("DNSSEC lookup failed"),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns fail + lookup_error on DNS timeout", async () => {
+    mockQueryDoh.mockRejectedValue(
+      new DnsLookupError("DNS_TIMEOUT", "DNS query timed out"),
+    );
+    const result = await analyzeDnssec("example.com");
+    expect(result.status).toBe("fail");
+    expect(result.lookup_error?.code).toBe("DNS_TIMEOUT");
+  });
+
+  it("re-throws non-DnsLookupError errors", async () => {
+    mockQueryDoh.mockRejectedValue(new Error("unexpected network error"));
+    await expect(analyzeDnssec("example.com")).rejects.toThrow(
+      "unexpected network error",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #414.

Adds a DNS-over-HTTPS (DoH) transport layer and a full DNSSEC status analyzer. DNSSEC status is surfaced in the HTML report, the JSON API, and the markdown report format.

- **`src/dns/client.ts`** — new `queryDoh(name, type)` function using the Cloudflare DoH JSON API (`cloudflare-dns.com/dns-query`); returns `null` on NXDOMAIN, throws `DnsLookupError` on SERVFAIL/timeout
- **`src/analyzers/dnssec.ts`** — new analyzer querying DS records via DoH; result status: `pass` (DS present + AD flag set), `warn` (DS present, AD not set — check zone signing chain), `info` (no DS = unsigned), `fail` (lookup error)
- **`src/analyzers/types.ts`** — `DnssecResult` interface; `ScanResult.protocols` gains optional `dnssec?` field
- **`src/orchestrator.ts`** — `analyzeDnssec` wired into both `scan()` and `scanStreaming()` via `settle()`/`streamSettled()` — a DNSSEC failure never aborts the scan
- **`src/shared/scoring.ts`** — optional `dnssec` in `Protocols`; `buildProtocolSummaries` emits a DNSSEC summary block (same conditional pattern as `tls_rpt`, `security_txt`)
- **`src/views/html.ts`** — `renderDnssecCard` added; wired into `reportBody`
- **`src/views/markdown.ts`** — `renderDnssecMarkdown` added; wired into scan report
- **`src/views/components.ts`** — `dnssec` (and missing `tls_rpt`) added to `PROTO_LABELS` so score snippet renders "DNSSEC" not the raw key
- **`test/dnssec.test.ts`** — 7 unit tests covering: unsigned zone (info), DS+AD=true (pass), DS+AD=false (warn), `DnsLookupError` fail, DNS timeout fail, non-`DnsLookupError` rethrow, correct DNS name queried

## Test plan

- [ ] `npm test` — all tests pass (7 new DNSSEC tests green)
- [ ] `npm run typecheck` — no errors
- [ ] `npm run lint` — no errors
- [ ] Scan a DNSSEC-signed domain (e.g. `cloudflare.com`) — expect `pass` card in HTML report and `"dnssec": {"status":"pass","signed":true,"validated":true}` in JSON API
- [ ] Scan an unsigned domain (e.g. `example.com`) — expect `info` card ("Not configured")
- [ ] Confirm DNSSEC card appears in score snippet dot row

https://claude.ai/code/session_012NJLeTjJRShAdZNHGztnU5

---
_Generated by [Claude Code](https://claude.ai/code/session_012NJLeTjJRShAdZNHGztnU5)_