### PR TITLE
fix: DKIM analyzer — accept Ed25519 keys as valid modern keys

### DIFF
--- a/src/analyzers/dkim.ts
+++ b/src/analyzers/dkim.ts
@@ -84,6 +84,7 @@ export async function analyzeDkim(
   // which reduces GC pressure on this hot path.
   let foundCount = 0;
   const weakKeyNames: string[] = [];
+  const ed25519Names: string[] = [];
   const revokedNames: string[] = [];
   const testingNames: string[] = [];
 
@@ -91,7 +92,11 @@ export async function analyzeDkim(
     const v = selectors[name];
     if (v.found) {
       foundCount++;
-      if (v.key_bits && v.key_bits < 2048) weakKeyNames.push(name);
+      if (v.key_type === "ed25519") {
+        ed25519Names.push(name);
+      } else if (v.key_bits && v.key_bits < 2048) {
+        weakKeyNames.push(name);
+      }
       if (v.revoked) revokedNames.push(name);
       if (v.testing) testingNames.push(name);
     }
@@ -109,6 +114,14 @@ export async function analyzeDkim(
       status: "fail",
       message:
         "No DKIM selectors found among common selectors — try specifying a custom selector",
+    });
+  }
+
+  // Explicitly acknowledge Ed25519 keys as modern and strong
+  if (ed25519Names.length > 0) {
+    validations.push({
+      status: "pass",
+      message: `${ed25519Names.join(", ")} — Ed25519 key — modern curve, strong by construction`,
     });
   }
 

--- a/test/dkim.test.ts
+++ b/test/dkim.test.ts
@@ -118,6 +118,38 @@ describe("analyzeDkim", () => {
     ).toBe(true);
   });
 
+  it("accepts Ed25519 key as valid modern key with no weak-key warning", async () => {
+    mockQueryTxt.mockImplementation(async (name: string) => {
+      if (name === "google._domainkey.example.com") {
+        const fakeKey = btoa("x".repeat(32));
+        return {
+          entries: [`v=DKIM1; k=ed25519; p=${fakeKey}`],
+          raw: `v=DKIM1; k=ed25519; p=${fakeKey}`,
+        };
+      }
+      return null;
+    });
+
+    const result = await analyzeDkim("example.com");
+    expect(result.status).toBe("pass");
+    expect(result.selectors.google.found).toBe(true);
+    expect(result.selectors.google.key_type).toBe("ed25519");
+    expect(result.selectors.google.key_bits).toBeUndefined();
+    expect(
+      result.validations.some(
+        (v) => v.status === "warn" && v.message.includes("weak"),
+      ),
+    ).toBe(false);
+    expect(
+      result.validations.some(
+        (v) =>
+          v.status === "pass" &&
+          v.message.includes("Ed25519 key") &&
+          v.message.includes("modern curve"),
+      ),
+    ).toBe(true);
+  });
+
   it("merges custom selectors with common selectors (deduplication)", async () => {
     mockQueryTxt.mockImplementation(async (name: string) => {
       if (name === "myselector._domainkey.example.com") {


### PR DESCRIPTION
## Summary

- Track `k=ed25519` selectors separately from RSA in `analyzeDkim()` — they are emitted as a `pass` validation: `"<selector> — Ed25519 key — modern curve, strong by construction"` instead of falling through with no note.
- Restructure the weak-key check to `else if` so Ed25519 selectors are never evaluated against the RSA key-length guard.
- Add one test verifying `k=ed25519` yields `status: "pass"`, `key_bits: undefined`, no weak-key warn, and the explicit Ed25519 pass message.

Closes #426

## Test plan

- [x] `npx vitest run test/dkim.test.ts` — 19 passing, 0 failing (1 new test)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean

## Deferred

None — full Ed25519 signature verification and other non-RSA key types (OKP etc.) are explicitly out of scope per the issue.

https://claude.ai/code/session_01G53ejN3oYcdSRFMEjW8C1Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01G53ejN3oYcdSRFMEjW8C1Q)_