### PR TITLE
⚡ Bolt: [performance improvement] Pre-allocate Uint8Array when fetching BIMI certificates

### DIFF
--- a/src/analyzers/bimi.ts
+++ b/src/analyzers/bimi.ts
@@ -120,14 +120,15 @@ async function fetchCert(
       }
     }
 
-    const body = new TextDecoder().decode(
-      chunks.reduce((acc, chunk) => {
-        const merged = new Uint8Array(acc.length + chunk.length);
-        merged.set(acc, 0);
-        merged.set(chunk, acc.length);
-        return merged;
-      }, new Uint8Array(0)),
-    );
+    // ⚡ Bolt Optimization: Pre-allocate the entire Uint8Array using bytesRead
+    // instead of creating O(n^2) allocations with .reduce().
+    const merged = new Uint8Array(bytesRead);
+    let offset = 0;
+    for (const chunk of chunks) {
+      merged.set(chunk, offset);
+      offset += chunk.length;
+    }
+    const body = new TextDecoder().decode(merged);
 
     if (!body.includes("-----BEGIN CERTIFICATE-----")) {
       // Could be DER-encoded — report fetch success but skip expiry check.


### PR DESCRIPTION
💡 **What**: Replaced the `.reduce()` method used to accumulate `Uint8Array` stream chunks with a pre-allocated single `Uint8Array` populated via a `for...of` loop.
🎯 **Why**: Using `reduce` creates a new array on every single iteration, leading to $O(N^2)$ memory and time complexity due to redundant data copying. Pre-allocating the target array using the already-tracked `bytesRead` drops this to $O(N)$, saving CPU time and avoiding heavy garbage collection pressure.
📊 **Impact**: Prevents potential latency spikes and GC thrashing when the Cloudflare Worker pulls BIMI HTTPS certificates from remote servers over potentially chunked/slow connections.
🔬 **Measurement**: Validated logic and typings by running the codebase's existing `bimi` test suite (27 tests), which cleanly passed without failure or regression.

---
*PR created automatically by Jules for task [557499762471483358](https://jules.google.com/task/557499762471483358) started by @schmug*