### PR TITLE
🎨 Palette: [UX improvement] Improve accessibility of SPF tree accordions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,6 @@
 ## 2025-05-19 - Inline Workflows for Empty States
 **Learning:** Forcing users to navigate to a new page from an empty state can break flow and feel disjointed.
 **Action:** When empty states provide a CTA, prefer triggering inline components (like modals or wizards) over full page navigations to reduce friction.
+## 2026-05-31 - Custom Accordion A11y Pattern
+**Learning:** In dmarc.mx, the SPF tree components use custom spans functioning as buttons. While they correctly employed `role="button"`, `tabindex="0"`, and `aria-controls`, the target collapsible elements lacked the required `role="region"` and `aria-labelledby` properties to complete the WAI-ARIA Accordion pattern.
+**Action:** When implementing or auditing custom accordions (like `.spf-node.include` controls or `.card` headers), verify that the control has an `id`, `role="button"`, `aria-expanded`, and `aria-controls`, and that the target container has an `id`, `role="region"`, and `aria-labelledby` pointing back to the control.

--- a/src/views/components.ts
+++ b/src/views/components.ts
@@ -310,13 +310,15 @@ export function spfTree(node: SpfIncludeNode): string {
     const isExpandable = inner !== "";
     const safeId = child.domain.replace(/[^a-z0-9]+/g, "-");
     const listId = `spf-list-${safeId}-${i}`;
+    const btnId = `${listId}-btn`;
     const attrs = isExpandable
-      ? ' role="button" tabindex="0" aria-expanded="true" aria-controls="' +
-        listId +
-        '"'
+      ? ` id="${btnId}" role="button" tabindex="0" aria-expanded="true" aria-controls="${listId}"`
       : "";
     const innerWithId = isExpandable
-      ? inner.replace("<ul>", `<ul id="${listId}">`)
+      ? inner.replace(
+          "<ul>",
+          `<ul id="${listId}" role="region" aria-labelledby="${btnId}">`,
+        )
       : inner;
     includes +=
       '<li><span class="spf-node include"' +
@@ -350,13 +352,15 @@ function spfTreeInner(node: SpfIncludeNode): string {
     const isExpandable = inner !== "";
     const safeId = child.domain.replace(/[^a-z0-9]+/g, "-");
     const listId = `spf-list-${safeId}-${i}`;
+    const btnId = `${listId}-btn`;
     const attrs = isExpandable
-      ? ' role="button" tabindex="0" aria-expanded="true" aria-controls="' +
-        listId +
-        '"'
+      ? ` id="${btnId}" role="button" tabindex="0" aria-expanded="true" aria-controls="${listId}"`
       : "";
     const innerWithId = isExpandable
-      ? inner.replace("<ul>", `<ul id="${listId}">`)
+      ? inner.replace(
+          "<ul>",
+          `<ul id="${listId}" role="region" aria-labelledby="${btnId}">`,
+        )
       : inner;
     includes +=
       '<li><span class="spf-node include"' +


### PR DESCRIPTION
### 💡 What
Added missing ARIA attributes (`id` on toggle buttons, `role="region"`, and `aria-labelledby` on content containers) to the SPF tree expandable nodes in the dashboard views.

### 🎯 Why
This ensures the custom tree-view component adheres strictly to the WAI-ARIA Accordion pattern, making it robust and fully accessible to screen reader users navigating the complex nested DNS rules. 

### 📸 Before/After
*(No visual changes, purely semantic DOM updates)*

### ♿ Accessibility
- Provides explicit semantic structure (`role="region"`) for collapsible content.
- Connects the region with its toggling button using `aria-labelledby`.
- Fulfills the WAI-ARIA Accordion spec requirements for the components rendering SPF includes.

---
*PR created automatically by Jules for task [4387304705390433733](https://jules.google.com/task/4387304705390433733) started by @schmug*