### PR TITLE
fix: DMARC analyzer — explain aspf/adkim alignment and fo failure-reporting

### DIFF
--- a/src/analyzers/dmarc.ts
+++ b/src/analyzers/dmarc.ts
@@ -236,13 +236,33 @@ export async function analyzeDmarc(domain: string): Promise<DmarcResult> {
         : "SPF alignment is relaxed (aspf=r, the default) — organizational-domain match is sufficient",
   });
 
-  // Failure-reporting options (fo). Only meaningful when ruf is configured.
-  if (tags.fo) {
+  // Failure-reporting options (fo). Default is "0" when absent.
+  // Only meaningful when ruf is configured.
+  const foSuffix = tags.ruf ? "" : " (no effect without a ruf address)";
+  if (!tags.fo || tags.fo === "0") {
     validations.push({
       status: "info",
-      message: `Failure-reporting options fo=${tags.fo} configured${
-        tags.ruf ? "" : " (no effect without a ruf address)"
-      }`,
+      message: `Failure-reporting option fo=0 (the default) — a forensic report is generated only when all authentication mechanisms fail${foSuffix}`,
+    });
+  } else if (tags.fo === "1") {
+    validations.push({
+      status: "info",
+      message: `Failure-reporting option fo=1 — a forensic report is generated when any authentication mechanism fails (SPF or DKIM)${foSuffix}`,
+    });
+  } else if (tags.fo === "d") {
+    validations.push({
+      status: "info",
+      message: `Failure-reporting option fo=d — a forensic report is generated when DKIM evaluation fails, regardless of SPF${foSuffix}`,
+    });
+  } else if (tags.fo === "s") {
+    validations.push({
+      status: "info",
+      message: `Failure-reporting option fo=s — a forensic report is generated when SPF evaluation fails, regardless of DKIM${foSuffix}`,
+    });
+  } else {
+    validations.push({
+      status: "info",
+      message: `Failure-reporting options fo=${tags.fo} configured${foSuffix}`,
     });
   }
 

--- a/test/dmarc.test.ts
+++ b/test/dmarc.test.ts
@@ -324,6 +324,37 @@ describe("analyzeDmarc — alignment and failure-reporting tags", () => {
     ).toBe(true);
   });
 
+  it("explains strict DKIM and SPF alignment plus fo=1 when all three are set", async () => {
+    mockQueryTxt.mockResolvedValueOnce({
+      entries: [
+        "v=DMARC1; p=reject; adkim=s; aspf=s; fo=1; ruf=mailto:f@mydomain.com; rua=mailto:r@mydomain.com",
+      ],
+      raw: "v=DMARC1; p=reject; adkim=s; aspf=s; fo=1; ruf=mailto:f@mydomain.com; rua=mailto:r@mydomain.com",
+    });
+
+    const result = await analyzeDmarc("mydomain.com");
+    expect(
+      result.validations.some(
+        (v) =>
+          v.message.includes("DKIM alignment") && v.message.includes("strict"),
+      ),
+    ).toBe(true);
+    expect(
+      result.validations.some(
+        (v) =>
+          v.message.includes("SPF alignment") && v.message.includes("strict"),
+      ),
+    ).toBe(true);
+    // fo=1 should explain what it means, not just mention the value
+    expect(
+      result.validations.some(
+        (v) =>
+          v.message.includes("fo=1") &&
+          v.message.includes("any authentication mechanism fails"),
+      ),
+    ).toBe(true);
+  });
+
   it("explains the relaxed default alignment when adkim/aspf are absent", async () => {
     mockQueryTxt.mockResolvedValueOnce({
       entries: ["v=DMARC1; p=reject; rua=mailto:r@mydomain.com"],
@@ -339,9 +370,17 @@ describe("analyzeDmarc — alignment and failure-reporting tags", () => {
           v.message.includes("default"),
       ),
     ).toBe(true);
+    expect(
+      result.validations.some(
+        (v) =>
+          v.message.includes("SPF alignment") &&
+          v.message.includes("relaxed") &&
+          v.message.includes("default"),
+      ),
+    ).toBe(true);
   });
 
-  it("explains the fo failure-reporting options when present", async () => {
+  it("explains the fo=1 failure-reporting option when present", async () => {
     mockQueryTxt.mockResolvedValueOnce({
       entries: [
         "v=DMARC1; p=reject; fo=1; ruf=mailto:f@mydomain.com; rua=mailto:r@mydomain.com",
@@ -350,8 +389,83 @@ describe("analyzeDmarc — alignment and failure-reporting tags", () => {
     });
 
     const result = await analyzeDmarc("mydomain.com");
-    expect(result.validations.some((v) => v.message.includes("fo=1"))).toBe(
-      true,
-    );
+    expect(
+      result.validations.some(
+        (v) =>
+          v.message.includes("fo=1") &&
+          v.message.includes("any authentication mechanism fails"),
+      ),
+    ).toBe(true);
+  });
+
+  it("explains the fo=0 default when fo tag is absent", async () => {
+    mockQueryTxt.mockResolvedValueOnce({
+      entries: ["v=DMARC1; p=reject; rua=mailto:r@mydomain.com"],
+      raw: "v=DMARC1; p=reject; rua=mailto:r@mydomain.com",
+    });
+
+    const result = await analyzeDmarc("mydomain.com");
+    expect(
+      result.validations.some(
+        (v) =>
+          v.message.includes("fo=0") &&
+          v.message.includes("the default") &&
+          v.message.includes("all authentication mechanisms fail"),
+      ),
+    ).toBe(true);
+  });
+
+  it("explains the fo=d DKIM-specific failure-reporting option", async () => {
+    mockQueryTxt.mockResolvedValueOnce({
+      entries: [
+        "v=DMARC1; p=reject; fo=d; ruf=mailto:f@mydomain.com; rua=mailto:r@mydomain.com",
+      ],
+      raw: "v=DMARC1; p=reject; fo=d; ruf=mailto:f@mydomain.com; rua=mailto:r@mydomain.com",
+    });
+
+    const result = await analyzeDmarc("mydomain.com");
+    expect(
+      result.validations.some(
+        (v) =>
+          v.message.includes("fo=d") &&
+          v.message.includes("DKIM") &&
+          v.message.includes("fails"),
+      ),
+    ).toBe(true);
+  });
+
+  it("explains the fo=s SPF-specific failure-reporting option", async () => {
+    mockQueryTxt.mockResolvedValueOnce({
+      entries: [
+        "v=DMARC1; p=reject; fo=s; ruf=mailto:f@mydomain.com; rua=mailto:r@mydomain.com",
+      ],
+      raw: "v=DMARC1; p=reject; fo=s; ruf=mailto:f@mydomain.com; rua=mailto:r@mydomain.com",
+    });
+
+    const result = await analyzeDmarc("mydomain.com");
+    expect(
+      result.validations.some(
+        (v) =>
+          v.message.includes("fo=s") &&
+          v.message.includes("SPF") &&
+          v.message.includes("fails"),
+      ),
+    ).toBe(true);
+  });
+
+  it("notes that fo has no effect without a ruf address", async () => {
+    mockQueryTxt.mockResolvedValueOnce({
+      entries: ["v=DMARC1; p=reject; fo=1; rua=mailto:r@mydomain.com"],
+      raw: "v=DMARC1; p=reject; fo=1; rua=mailto:r@mydomain.com",
+    });
+
+    const result = await analyzeDmarc("mydomain.com");
+    expect(
+      result.validations.some(
+        (v) =>
+          v.message.includes("fo=1") &&
+          v.message.includes("no effect without a ruf address"),
+      ),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- DMARC analyzer now produces validation messages for aspf, adkim, and fo tags
- Strict alignment (s) produces a distinct message; relaxed (r/default) explains that too
- fo values 0/1/d/s each produce a short explanatory message
- Does not change scoring thresholds or p= logic

Closes #422

## Test plan
- [ ] adkim=s; aspf=s; fo=1 produces strict-alignment messages + fo explanation
- [ ] Default (absent) alignment produces relaxed-default messages
- [ ] `npm test` passes
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_01WoHD5hwj2ENLykorR6x4Xp

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoHD5hwj2ENLykorR6x4Xp)_