### PR TITLE
feat: per-user watchlist cap override (max_domains_override)

### DIFF
--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -40,6 +40,7 @@ import {
 import { getPlanForUser } from "../db/subscriptions.js";
 import {
   acknowledgeApiKeyRetirement,
+  getMaxDomainsOverrideForUser,
   getUserById,
   setEmailAlertsEnabled,
   setNotifyOnChangeOnly,
@@ -47,7 +48,7 @@ import {
 import { getRecentDeliveriesForUser } from "../db/webhook-deliveries.js";
 import { scan } from "../orchestrator.js";
 import { normalizeDomain } from "../shared/domain.js";
-import { PRO_WATCHLIST_CAP, watchlistCapForPlan } from "../shared/limits.js";
+import { PRO_WATCHLIST_CAP, watchlistCapFor } from "../shared/limits.js";
 import {
   computeGradeBreakdown,
   type ScoringConfig,
@@ -424,7 +425,7 @@ dashboardRoutes.get("/", async (c) => {
         usage: {
           plan,
           current: domains.length,
-          cap: watchlistCapForPlan(plan),
+          cap: watchlistCapFor(plan, user?.max_domains_override),
         },
       }),
     );
@@ -485,7 +486,7 @@ dashboardRoutes.get("/", async (c) => {
       usage: {
         plan,
         current: totalForUser,
-        cap: watchlistCapForPlan(plan),
+        cap: watchlistCapFor(plan, user?.max_domains_override),
       },
     }),
   );
@@ -716,15 +717,16 @@ dashboardRoutes.post("/alerts/:id/acknowledge", async (c) => {
 dashboardRoutes.get("/domain/add", async (c) => {
   const session = c.get("user" as never) as SessionPayload;
   const db = (c.env as { DB: D1Database }).DB;
-  const [plan, current] = await Promise.all([
+  const [plan, current, override] = await Promise.all([
     getPlanForUser(db, session.sub),
     countDomainsByUser(db, session.sub),
+    getMaxDomainsOverrideForUser(db, session.sub),
   ]);
   return c.html(
     renderAddDomainPage({
       email: session.email,
       error: null,
-      usage: { plan, current, cap: watchlistCapForPlan(plan) },
+      usage: { plan, current, cap: watchlistCapFor(plan, override) },
     }),
   );
 });
@@ -734,11 +736,12 @@ dashboardRoutes.post("/domain/add", async (c) => {
   const db = (c.env as { DB: D1Database }).DB;
   const body = await c.req.parseBody();
   const normalized = normalizeDomain(body.domain as string | undefined);
-  const [plan, currentCount] = await Promise.all([
+  const [plan, currentCount, override] = await Promise.all([
     getPlanForUser(db, session.sub),
     countDomainsByUser(db, session.sub),
+    getMaxDomainsOverrideForUser(db, session.sub),
   ]);
-  const cap = watchlistCapForPlan(plan);
+  const cap = watchlistCapFor(plan, override);
   const usage = { plan, current: currentCount, cap };
   if (!normalized) {
     return c.html(
@@ -765,11 +768,15 @@ dashboardRoutes.post("/domain/add", async (c) => {
   if (currentCount >= cap) {
     const overCap = currentCount > cap;
     const error =
-      plan === "pro"
+      override != null
         ? overCap
-          ? `Pro plan includes ${cap} domains and you already have ${currentCount} (grandfathered). Email support@dmarc.mx to add more.`
-          : `You've reached the Pro plan limit of ${cap} domains. Email support@dmarc.mx if you need more.`
-        : `Free plan limit reached (${cap} domains). Upgrade to Pro for up to ${PRO_WATCHLIST_CAP}.`;
+          ? `Domain limit is ${cap} and you already have ${currentCount} (grandfathered). Email support@dmarc.mx to add more.`
+          : `You've reached your domain limit of ${cap}. Email support@dmarc.mx to add more.`
+        : plan === "pro"
+          ? overCap
+            ? `Pro plan includes ${cap} domains and you already have ${currentCount} (grandfathered). Email support@dmarc.mx to add more.`
+            : `You've reached the Pro plan limit of ${cap} domains. Email support@dmarc.mx if you need more.`
+          : `Free plan limit reached (${cap} domains). Upgrade to Pro for up to ${PRO_WATCHLIST_CAP}.`;
     return c.html(
       renderAddDomainPage({ email: session.email, error, usage }),
       400,
@@ -807,7 +814,10 @@ dashboardRoutes.get("/bulk", async (c) => {
 dashboardRoutes.post("/bulk", async (c) => {
   const session = c.get("user" as never) as SessionPayload;
   const db = (c.env as { DB: D1Database }).DB;
-  const plan = await getPlanForUser(db, session.sub);
+  const [plan, override] = await Promise.all([
+    getPlanForUser(db, session.sub),
+    getMaxDomainsOverrideForUser(db, session.sub),
+  ]);
   if (plan !== "pro") {
     return c.html(
       renderBulkScanPage({
@@ -832,7 +842,7 @@ dashboardRoutes.post("/bulk", async (c) => {
     db,
     userId: session.sub,
     rawDomains: lines,
-    watchlistCap: watchlistCapForPlan(plan),
+    watchlistCap: watchlistCapFor(plan, override),
     scoringConfig: parseScoringConfig(
       (c.env as { SCORING_CONFIG?: string }).SCORING_CONFIG,
     ),

--- a/src/db/migrations/0009_user_domain_override.sql
+++ b/src/db/migrations/0009_user_domain_override.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN max_domains_override INTEGER;

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -7,6 +7,7 @@ CREATE TABLE IF NOT EXISTS users (
   email_alerts_enabled INTEGER NOT NULL DEFAULT 1,
   notify_on_change_only INTEGER NOT NULL DEFAULT 0,
   api_key_retirement_acknowledged_at INTEGER,
+  max_domains_override INTEGER,
   created_at INTEGER NOT NULL DEFAULT (unixepoch())
 );
 

--- a/src/db/users.ts
+++ b/src/db/users.ts
@@ -6,6 +6,7 @@ export interface User {
   email_alerts_enabled: number;
   notify_on_change_only: number;
   api_key_retirement_acknowledged_at: number | null;
+  max_domains_override: number | null;
   created_at: number;
 }
 
@@ -83,6 +84,17 @@ export async function setNotifyOnChangeOnly(
     .prepare("UPDATE users SET notify_on_change_only = ? WHERE id = ?")
     .bind(enabled ? 1 : 0, userId)
     .run();
+}
+
+export async function getMaxDomainsOverrideForUser(
+  db: D1Database,
+  userId: string,
+): Promise<number | null> {
+  const row = await db
+    .prepare("SELECT max_domains_override FROM users WHERE id = ?")
+    .bind(userId)
+    .first<{ max_domains_override: number | null }>();
+  return row?.max_domains_override ?? null;
 }
 
 // Dismisses the one-time "your old cleartext API key was retired" banner by

--- a/src/shared/limits.ts
+++ b/src/shared/limits.ts
@@ -14,3 +14,14 @@ export const PRO_WATCHLIST_CAP = 25;
 export function watchlistCapForPlan(plan: PlanTier): number {
   return plan === "pro" ? PRO_WATCHLIST_CAP : FREE_WATCHLIST_CAP;
 }
+
+// Returns the effective watchlist cap for a user, respecting a per-user
+// override when set. The override wins regardless of plan tier, so comped /
+// enterprise accounts can hold more than PRO_WATCHLIST_CAP domains without
+// a new billing tier. When override is null/undefined the plan-based cap applies.
+export function watchlistCapFor(
+  plan: PlanTier,
+  overrideMaxDomains?: number | null,
+): number {
+  return overrideMaxDomains ?? watchlistCapForPlan(plan);
+}

--- a/test/bulk-scan.test.ts
+++ b/test/bulk-scan.test.ts
@@ -422,6 +422,37 @@ describe("processBulkScan", () => {
       // No new row inserted.
       expect(domainStore).toHaveLength(1);
     });
+
+    it("accepts the 26th domain when watchlistCap is raised via per-user override", async () => {
+      // Simulate a Pro user already at their default 25-domain limit.
+      for (let i = 0; i < 25; i++) {
+        domainStore.push({
+          id: i + 1,
+          user_id: "user_1",
+          domain: `d${i}.example`,
+          is_free: 0,
+          scan_frequency: "weekly",
+          last_scanned_at: 1700000000,
+          last_grade: "A",
+        });
+      }
+      const scanFn = vi.fn(async (d: string) => okScan(d));
+      const out = await processBulkScan({
+        db: makeDb(),
+        userId: "user_1",
+        rawDomains: ["new26.example"],
+        scanFn,
+        watchlistCap: 50, // raised by max_domains_override via watchlistCapFor
+      });
+      if (isCapExceeded(out)) throw new Error("unexpected cap");
+      const scanned = out.results.filter((r) => r.status === "scanned");
+      const rejected = out.results.filter(
+        (r) => r.status === "error" && r.error === "Watchlist limit reached",
+      );
+      expect(scanned.map((r) => r.domain)).toEqual(["new26.example"]);
+      expect(rejected).toHaveLength(0);
+      expect(domainStore).toHaveLength(26);
+    });
   });
 
   it("returns empty results for an empty submission", async () => {

--- a/test/limits.test.ts
+++ b/test/limits.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  FREE_WATCHLIST_CAP,
+  PRO_WATCHLIST_CAP,
+  watchlistCapFor,
+  watchlistCapForPlan,
+} from "../src/shared/limits.js";
+
+describe("watchlistCapForPlan", () => {
+  it("returns PRO_WATCHLIST_CAP for pro", () => {
+    expect(watchlistCapForPlan("pro")).toBe(PRO_WATCHLIST_CAP);
+  });
+  it("returns FREE_WATCHLIST_CAP for free", () => {
+    expect(watchlistCapForPlan("free")).toBe(FREE_WATCHLIST_CAP);
+  });
+});
+
+describe("watchlistCapFor — override logic", () => {
+  it("returns plan cap when override is null", () => {
+    expect(watchlistCapFor("pro", null)).toBe(PRO_WATCHLIST_CAP);
+    expect(watchlistCapFor("free", null)).toBe(FREE_WATCHLIST_CAP);
+  });
+
+  it("returns plan cap when override is undefined", () => {
+    expect(watchlistCapFor("pro", undefined)).toBe(PRO_WATCHLIST_CAP);
+    expect(watchlistCapFor("free", undefined)).toBe(FREE_WATCHLIST_CAP);
+  });
+
+  it("override wins over pro plan cap", () => {
+    expect(watchlistCapFor("pro", 50)).toBe(50);
+  });
+
+  it("override wins over free plan cap (override applies regardless of plan)", () => {
+    expect(watchlistCapFor("free", 50)).toBe(50);
+  });
+
+  it("override of 0 wins (edge case: explicitly zero)", () => {
+    expect(watchlistCapFor("pro", 0)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds nullable `max_domains_override INTEGER` column to `users` table via migration `0009_user_domain_override.sql`
- New `watchlistCapFor(plan, override?)` in `limits.ts`: override takes precedence over plan-based cap (free or pro); when NULL, behavior is identical to today
- New `getMaxDomainsOverrideForUser()` in `db/users.ts` for handlers that don't already have the full user row
- All five dashboard cap enforcement points updated to thread the override through (domain list × 2, add-domain GET, add-domain POST, bulk-scan POST)
- Error messages on the add-domain POST handler distinguish override-gated accounts from standard plan-gated ones

Closes #439

## Test plan
- [ ] New `test/limits.test.ts`: `watchlistCapFor("pro", null)` → 25, `("free", null)` → 3, `("pro", 50)` → 50, `("free", 50)` → 50 (override wins regardless of plan), `("pro", 0)` → 0
- [ ] New test in `test/bulk-scan.test.ts`: 25 existing domains + cap=50 → 26th domain accepted (not rejected as "Watchlist limit reached")
- [ ] `npm test`: 1148 passing, 1 pre-existing network-integration failure (unrelated)
- [ ] `npm run typecheck`: clean
- [ ] `npm run lint`: clean

## Out of scope (per issue)
- Admin UI / API to set the override — for v1 it's set manually via SQL/wrangler
- Changing default pagination or adding "show all" UI

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoHD5hwj2ENLykorR6x4Xp)_