### PR TITLE
feat: add "Dismiss all" bulk alert acknowledgement

### DIFF
--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -12,6 +12,7 @@ import { dashboardBillingRoutes } from "../billing/routes.js";
 import { escapeCsvField } from "../csv.js";
 import {
   acknowledgeAlert,
+  acknowledgeAllAlertsForUser,
   countUnacknowledgedByDomain,
   listUnacknowledgedForUser,
 } from "../db/alerts.js";
@@ -693,6 +694,15 @@ dashboardRoutes.get("/export", async (c) => {
       "Cache-Control": "no-store",
     },
   });
+});
+
+// Bulk-acknowledge route — registered BEFORE /alerts/:id/acknowledge so Hono
+// does not treat "acknowledge-all" as the :id param.
+dashboardRoutes.post("/alerts/acknowledge-all", async (c) => {
+  const session = c.get("user" as never) as SessionPayload;
+  const db = (c.env as { DB: D1Database }).DB;
+  await acknowledgeAllAlertsForUser(db, session.sub);
+  return c.redirect("/dashboard", 303);
 });
 
 dashboardRoutes.post("/alerts/:id/acknowledge", async (c) => {

--- a/src/db/alerts.ts
+++ b/src/db/alerts.ts
@@ -148,6 +148,25 @@ export async function acknowledgeAlert(
   return (result.meta?.changes ?? 0) > 0;
 }
 
+// IDOR-safe bulk acknowledge: only touches alerts whose owning domain belongs
+// to the supplied userId. Returns the number of rows updated.
+export async function acknowledgeAllAlertsForUser(
+  db: D1Database,
+  userId: string,
+  now: number = Math.floor(Date.now() / 1000),
+): Promise<number> {
+  const result = await db
+    .prepare(
+      `UPDATE alerts
+       SET acknowledged_at = ?
+       WHERE acknowledged_at IS NULL
+         AND domain_id IN (SELECT id FROM domains WHERE user_id = ?)`,
+    )
+    .bind(now, userId)
+    .run();
+  return result.meta?.changes ?? 0;
+}
+
 interface UnacknowledgedCountRow {
   domain_id: number;
   count: number;

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -201,6 +201,21 @@ const DASHBOARD_CSS = `
   border-color: var(--clr-fail);
   color: var(--clr-fail);
 }
+.alerts-needs-attention .alerts-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+.alerts-needs-attention .alerts-header h2 {
+  margin: 0;
+}
+.alerts-needs-attention .alerts-header .dismiss-all-form {
+  margin-left: auto;
+}
+.alerts-needs-attention .btn-dismiss-all {
+  font-size: 0.75rem;
+}
 .grade-badge {
   display: inline-flex;
   align-items: center;
@@ -1467,8 +1482,17 @@ export function renderAlertsSection(
 </li>`;
     })
     .join("");
+  const dismissAll =
+    alerts.length >= 2
+      ? `<form method="post" action="/dashboard/alerts/acknowledge-all" class="dismiss-all-form">
+    <button type="submit" class="btn-dismiss btn-dismiss-all">Dismiss all</button>
+  </form>`
+      : "";
   return `<section class="alerts-needs-attention" aria-label="Domain regressions needing attention">
-  <h2>Needs attention</h2>
+  <div class="alerts-header">
+    <h2>Needs attention</h2>
+    ${dismissAll}
+  </div>
   <ul>${items}</ul>
 </section>`;
 }

--- a/test/db-alerts.test.ts
+++ b/test/db-alerts.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import {
   type AlertRow,
   acknowledgeAlert,
+  acknowledgeAllAlertsForUser,
   countUnacknowledgedByDomain,
   listUnacknowledgedForUser,
   listUnsentAlerts,
@@ -46,6 +47,21 @@ function makeD1Mock(): D1Database {
           return { success: true, meta: { changes: row ? 1 : 0 } };
         }
         if (/^\s*UPDATE alerts\s+SET acknowledged_at/i.test(sql)) {
+          // Bulk acknowledge: UPDATE ... WHERE acknowledged_at IS NULL AND domain_id IN (...)
+          // has 2 params (now, userId); single acknowledge has 3 (now, alertId, userId).
+          if (params.length === 2) {
+            const [now, userId] = params as [number, string];
+            let changes = 0;
+            for (const [id, row] of alertStore.entries()) {
+              if (row.acknowledged_at !== null) continue;
+              const d = domainStore.get(row.domain_id);
+              if (!d || d.user_id !== userId) continue;
+              alertStore.set(id, { ...row, acknowledged_at: now });
+              changes++;
+            }
+            return { success: true, meta: { changes } };
+          }
+          // Single acknowledge: UPDATE ... WHERE id = ? AND acknowledged_at IS NULL AND domain_id IN (...)
           const [now, alertId, userId] = params as [number, number, string];
           const row = alertStore.get(alertId);
           if (!row || row.acknowledged_at !== null) {
@@ -381,6 +397,61 @@ describe("db/alerts", () => {
     it("returns false for a nonexistent alert id", async () => {
       const ok = await acknowledgeAlert(db, "user_1", 999, 555);
       expect(ok).toBe(false);
+    });
+  });
+
+  describe("acknowledgeAllAlertsForUser", () => {
+    beforeEach(async () => {
+      // Seed two alerts for user_1 and one for user_2
+      await recordAlert(db, {
+        domainId: 7, // user_1
+        type: "grade_drop",
+        previousValue: "A",
+        newValue: "C",
+        createdAt: 100,
+      });
+      await recordAlert(db, {
+        domainId: 7, // user_1
+        type: "protocol_regression",
+        previousValue: "dmarc:pass",
+        newValue: "dmarc:fail",
+        createdAt: 200,
+      });
+      await recordAlert(db, {
+        domainId: 9, // user_2 — must NOT be touched
+        type: "grade_drop",
+        previousValue: "B",
+        newValue: "F",
+        createdAt: 300,
+      });
+    });
+
+    it("sets acknowledged_at on all of the caller's unacknowledged alerts", async () => {
+      const count = await acknowledgeAllAlertsForUser(db, "user_1", 999);
+      expect(count).toBe(2);
+      expect(alertStore.get(1)?.acknowledged_at).toBe(999);
+      expect(alertStore.get(2)?.acknowledged_at).toBe(999);
+    });
+
+    it("does not touch another user's alerts (IDOR safety)", async () => {
+      await acknowledgeAllAlertsForUser(db, "user_1", 999);
+      // user_2's alert must remain unacknowledged
+      expect(alertStore.get(3)?.acknowledged_at).toBeNull();
+    });
+
+    it("skips already-acknowledged alerts and returns only newly-updated count", async () => {
+      // Pre-acknowledge alert 1
+      await acknowledgeAlert(db, "user_1", 1, 555);
+      const count = await acknowledgeAllAlertsForUser(db, "user_1", 999);
+      expect(count).toBe(1);
+      expect(alertStore.get(1)?.acknowledged_at).toBe(555); // unchanged
+      expect(alertStore.get(2)?.acknowledged_at).toBe(999); // newly acknowledged
+    });
+
+    it("returns 0 when the user has no unacknowledged alerts", async () => {
+      await acknowledgeAllAlertsForUser(db, "user_1", 500);
+      const count = await acknowledgeAllAlertsForUser(db, "user_1", 999);
+      expect(count).toBe(0);
     });
   });
 


### PR DESCRIPTION
## Summary
- New `acknowledgeAllAlertsForUser(db, userId, now)` in `src/db/alerts.ts` — IDOR-safe bulk acknowledge via `domain_id IN (SELECT id FROM domains WHERE user_id = ?)`
- New `POST /alerts/acknowledge-all` route in `src/dashboard/routes.ts` — auth-gated, registered BEFORE `/alerts/:id/acknowledge` to avoid Hono param collision, redirects 303 to `/dashboard`
- "Dismiss all" button added to the "Needs attention" section header in `src/views/dashboard.ts` — only rendered when `alerts.length >= 2`, using a plain `<form method="post">` for progressive enhancement
- CSS styles for `.alerts-header`, `.dismiss-all-form`, and `.btn-dismiss-all` in `src/views/dashboard.ts`

Closes #438

## Test plan
- [x] `acknowledgeAllAlertsForUser` sets `acknowledged_at` on all of the user's unack'd alerts
- [x] Cross-user IDOR: other users' alerts are untouched
- [x] Skips already-acknowledged alerts and returns only newly-updated count
- [x] Returns 0 when user has no unacknowledged alerts
- [x] `npm test` passes (1144/1145 — single pre-existing live network flake in `mta-sts-runtime.test.ts`, unrelated)
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes

https://claude.ai/code/session_01WoHD5hwj2ENLykorR6x4Xp

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoHD5hwj2ENLykorR6x4Xp)_