### PR TITLE
feat: DANE/TLSA analyzer (#415)

### DIFF
--- a/src/analyzers/dane.ts
+++ b/src/analyzers/dane.ts
@@ -1,0 +1,127 @@
+import { DnsLookupError, queryDoh } from "../dns/client.js";
+import type {
+  DaneHostResult,
+  DaneResult,
+  DaneTlsaRecord,
+  Validation,
+} from "./types.js";
+
+// TLSA record data arrives as "<usage> <selector> <matching-type> <hex-data>"
+// e.g. "3 1 1 abcdef1234..."
+function parseTlsaRecord(data: string): DaneTlsaRecord | null {
+  const parts = data.trim().split(/\s+/);
+  if (parts.length < 4) return null;
+  const usage = parseInt(parts[0], 10);
+  const selector = parseInt(parts[1], 10);
+  const matchingType = parseInt(parts[2], 10);
+  if (
+    Number.isNaN(usage) ||
+    Number.isNaN(selector) ||
+    Number.isNaN(matchingType)
+  )
+    return null;
+  return { usage, selector, matchingType, data: parts.slice(3).join("") };
+}
+
+export async function analyzeDane(
+  _domain: string,
+  mxExchanges: string[],
+): Promise<DaneResult> {
+  const validations: Validation[] = [];
+
+  if (mxExchanges.length === 0) {
+    validations.push({
+      status: "info",
+      message: "DANE/TLSA not applicable — no MX records configured",
+    });
+    return { status: "info", hosts: [], validations };
+  }
+
+  const hosts: DaneHostResult[] = [];
+  let anyTlsaAdValidated = false;
+  let anyTlsaUnvalidated = false;
+  let successfulQueries = 0;
+  let firstLookupError: { code: string; message: string } | undefined;
+
+  await Promise.all(
+    mxExchanges.map(async (exchange) => {
+      try {
+        const response = await queryDoh(`_25._tcp.${exchange}`, "TLSA");
+        successfulQueries++;
+        if (!response) {
+          hosts.push({ exchange, tlsaRecords: [], dnssecValidated: false });
+          return;
+        }
+        const tlsaRecords = (response.Answer ?? [])
+          .map((a) => parseTlsaRecord(a.data))
+          .filter((r): r is DaneTlsaRecord => r !== null);
+        const dnssecValidated = response.AD;
+        hosts.push({ exchange, tlsaRecords, dnssecValidated });
+        if (tlsaRecords.length > 0) {
+          if (dnssecValidated) anyTlsaAdValidated = true;
+          else anyTlsaUnvalidated = true;
+        }
+      } catch (err) {
+        if (err instanceof DnsLookupError) {
+          if (!firstLookupError)
+            firstLookupError = { code: err.code, message: err.message };
+          hosts.push({ exchange, tlsaRecords: [], dnssecValidated: false });
+          return;
+        }
+        throw err;
+      }
+    }),
+  );
+
+  if (anyTlsaAdValidated) {
+    const validatedHosts = hosts
+      .filter((h) => h.tlsaRecords.length > 0 && h.dnssecValidated)
+      .map((h) => h.exchange)
+      .join(", ");
+    validations.push({
+      status: "pass",
+      message: `DANE/TLSA configured and DNSSEC-validated on: ${validatedHosts}`,
+    });
+    const unvalidatedHosts = hosts.filter(
+      (h) => h.tlsaRecords.length > 0 && !h.dnssecValidated,
+    );
+    if (unvalidatedHosts.length > 0) {
+      validations.push({
+        status: "warn",
+        message: `TLSA records present but DNSSEC not validated on: ${unvalidatedHosts.map((h) => h.exchange).join(", ")}`,
+      });
+    }
+    return { status: "pass", hosts, validations };
+  }
+
+  if (anyTlsaUnvalidated) {
+    const tlsaHosts = hosts
+      .filter((h) => h.tlsaRecords.length > 0)
+      .map((h) => h.exchange)
+      .join(", ");
+    validations.push({
+      status: "warn",
+      message: `TLSA records found but DNSSEC not validated — DANE enforcement requires DNSSEC (${tlsaHosts})`,
+    });
+    return { status: "warn", hosts, validations };
+  }
+
+  if (successfulQueries === 0 && firstLookupError) {
+    validations.push({
+      status: "fail",
+      message: `DANE/TLSA lookup failed: ${firstLookupError.message}`,
+    });
+    return {
+      status: "fail",
+      hosts,
+      validations,
+      lookup_error: firstLookupError,
+    };
+  }
+
+  validations.push({
+    status: "info",
+    message: "DANE/TLSA not configured — no TLSA records found for MX hosts",
+  });
+  return { status: "info", hosts, validations };
+}

--- a/src/analyzers/types.ts
+++ b/src/analyzers/types.ts
@@ -132,6 +132,26 @@ export interface DnssecResult {
   lookup_error?: { code: string; message: string };
 }
 
+export interface DaneTlsaRecord {
+  usage: number;
+  selector: number;
+  matchingType: number;
+  data: string;
+}
+
+export interface DaneHostResult {
+  exchange: string;
+  tlsaRecords: DaneTlsaRecord[];
+  dnssecValidated: boolean;
+}
+
+export interface DaneResult {
+  status: Status;
+  hosts: DaneHostResult[];
+  validations: Validation[];
+  lookup_error?: { code: string; message: string };
+}
+
 export interface ScanResult {
   domain: string;
   timestamp: string;
@@ -148,5 +168,6 @@ export interface ScanResult {
     security_txt: SecurityTxtResult;
     tls_rpt?: TlsRptResult;
     dnssec?: DnssecResult;
+    dane?: DaneResult;
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { dispatchPendingAlerts } from "./alerts/dispatcher.js";
 import { validateUnsubscribeToken } from "./alerts/unsubscribe.js";
 import type {
   BimiResult,
+  DaneResult,
   DkimResult,
   DmarcResult,
   DnssecResult,
@@ -70,6 +71,7 @@ import {
 import {
   renderApiDocs,
   renderBimiCard,
+  renderDaneCard,
   renderDkimCard,
   renderDmarcCard,
   renderDnssecCard,
@@ -540,6 +542,7 @@ const protocolRenderers: Record<
   security_txt: (r) => renderSecurityTxtCard(r as SecurityTxtResult),
   tls_rpt: (r) => renderTlsRptCard(r as TlsRptResult),
   dnssec: (r) => renderDnssecCard(r as DnssecResult),
+  dane: (r) => renderDaneCard(r as DaneResult),
 };
 
 function tagScanResult(result: ScanResult): void {
@@ -593,6 +596,8 @@ app.get("/api/check/stream", async (c) => {
         "mta_sts",
         "security_txt",
         "tls_rpt",
+        "dnssec",
+        "dane",
       ];
       for (const id of protocolIds) {
         const protocolResult = cached.protocols[id];

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/cloudflare";
 import { analyzeBimi, prefetchBimiDns } from "./analyzers/bimi.js";
+import { analyzeDane } from "./analyzers/dane.js";
 import { analyzeDkim } from "./analyzers/dkim.js";
 import { analyzeDmarc } from "./analyzers/dmarc.js";
 import { analyzeDnssec } from "./analyzers/dnssec.js";
@@ -11,6 +12,7 @@ import { analyzeSpf } from "./analyzers/spf.js";
 import { analyzeTlsRpt } from "./analyzers/tls-rpt.js";
 import type {
   BimiResult,
+  DaneResult,
   DkimResult,
   DmarcResult,
   DnssecResult,
@@ -34,7 +36,8 @@ export type ProtocolId =
   | "mta_sts"
   | "security_txt"
   | "tls_rpt"
-  | "dnssec";
+  | "dnssec"
+  | "dane";
 export type ProtocolResult =
   | MxResult
   | DmarcResult
@@ -44,7 +47,8 @@ export type ProtocolResult =
   | MtaStsResult
   | SecurityTxtResult
   | TlsRptResult
-  | DnssecResult;
+  | DnssecResult
+  | DaneResult;
 
 const PROTOCOL_LABEL: Record<ProtocolId, string> = {
   mx: "MX",
@@ -56,6 +60,7 @@ const PROTOCOL_LABEL: Record<ProtocolId, string> = {
   security_txt: "security.txt",
   tls_rpt: "TLS-RPT",
   dnssec: "DNSSEC",
+  dane: "DANE/TLSA",
 };
 
 function analyzerErrorValidation(id: ProtocolId, message: string): Validation {
@@ -130,6 +135,12 @@ const ERROR_RESULTS = {
     signed: false,
     validated: false,
     validations: [analyzerErrorValidation("dnssec", m)],
+    lookup_error: { code: "analyzer_error", message: m },
+  }),
+  dane: (m: string): DaneResult => ({
+    status: "fail",
+    hosts: [],
+    validations: [analyzerErrorValidation("dane", m)],
     lookup_error: { code: "analyzer_error", message: m },
   }),
 } as const;
@@ -269,6 +280,14 @@ export async function scan(
     return analyzeDkim(domain, customSelectors, providerNames);
   });
 
+  // Chain DANE off MX — TLSA records are queried per MX exchange
+  const danePromise = mxPromise.then((mxResult) =>
+    analyzeDane(
+      domain,
+      mxResult.records.map((r) => r.exchange),
+    ),
+  );
+
   const bimiPromise = Promise.all([dmarcPromise, bimiDnsPromise]).then(
     ([dmarcResult, bimiDns]) => {
       const dmarcPolicy = dmarcResult.tags?.p?.toLowerCase() ?? null;
@@ -289,6 +308,7 @@ export async function scan(
     securityTxtResult,
     tlsRptResult,
     dnssecResult,
+    daneResult,
   ] = await Promise.all([
     settle("dmarc", dmarcPromise, ERROR_RESULTS.dmarc),
     settle("spf", spfPromise, ERROR_RESULTS.spf),
@@ -299,6 +319,7 @@ export async function scan(
     settle("security_txt", securityTxtPromise, ERROR_RESULTS.security_txt),
     settle("tls_rpt", tlsRptPromise, ERROR_RESULTS.tls_rpt),
     settle("dnssec", dnssecPromise, ERROR_RESULTS.dnssec),
+    settle("dane", danePromise, ERROR_RESULTS.dane),
   ]);
 
   Sentry.addBreadcrumb({
@@ -349,6 +370,12 @@ export async function scan(
     data: { protocol: "dnssec", status: dnssecResult.status },
     level: "info",
   });
+  Sentry.addBreadcrumb({
+    category: "analyzer.complete",
+    message: `dane: ${daneResult.status}`,
+    data: { protocol: "dane", status: daneResult.status },
+    level: "info",
+  });
 
   return await buildScanResult(
     domain,
@@ -362,6 +389,7 @@ export async function scan(
       security_txt: securityTxtResult,
       tls_rpt: tlsRptResult,
       dnssec: dnssecResult,
+      dane: daneResult,
     },
     config,
   );
@@ -393,6 +421,14 @@ export async function scanStreaming(
     return analyzeDkim(domain, customSelectors, providerNames);
   });
 
+  // Chain DANE off MX — TLSA records are queried per MX exchange
+  const danePromise = mxPromise.then((mxResult) =>
+    analyzeDane(
+      domain,
+      mxResult.records.map((r) => r.exchange),
+    ),
+  );
+
   // Chain BIMI off DMARC and BIMI DNS
   const bimiPromise = Promise.all([dmarcPromise, bimiDnsPromise]).then(
     ([dmarcResult, bimiDns]) => {
@@ -423,6 +459,7 @@ export async function scanStreaming(
     securityTxtResult,
     tlsRptResult,
     dnssecResult,
+    daneResult,
   ] = await Promise.all([
     streamSettled("dmarc", dmarcPromise, ERROR_RESULTS.dmarc, onResult),
     streamSettled("spf", spfPromise, ERROR_RESULTS.spf, onResult),
@@ -438,6 +475,7 @@ export async function scanStreaming(
     ),
     streamSettled("tls_rpt", tlsRptPromise, ERROR_RESULTS.tls_rpt, onResult),
     streamSettled("dnssec", dnssecPromise, ERROR_RESULTS.dnssec, onResult),
+    streamSettled("dane", danePromise, ERROR_RESULTS.dane, onResult),
   ]);
 
   const result = await buildScanResult(
@@ -452,6 +490,7 @@ export async function scanStreaming(
       security_txt: securityTxtResult,
       tls_rpt: tlsRptResult,
       dnssec: dnssecResult,
+      dane: daneResult,
     },
     config,
   );

--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -1,5 +1,6 @@
 import type {
   BimiResult,
+  DaneResult,
   DkimResult,
   DmarcResult,
   DnssecResult,
@@ -378,9 +379,43 @@ export function renderDnssecCard(d: DnssecResult): string {
   return protocolCard("DNSSEC", d.status, subtitle, body, false, "dnssec");
 }
 
+export function renderDaneCard(d: DaneResult): string {
+  const hostsWithTlsa = d.hosts.filter((h) => h.tlsaRecords.length > 0);
+  const subtitle =
+    hostsWithTlsa.length > 0
+      ? `${hostsWithTlsa.length} host${hostsWithTlsa.length !== 1 ? "s" : ""} with TLSA records`
+      : "Not configured";
+  let body = "";
+  if (hostsWithTlsa.length > 0) {
+    body += `<div class="tag-grid">`;
+    for (const host of hostsWithTlsa) {
+      const badge = host.dnssecValidated
+        ? `<span class="tag-pass">DNSSEC ✓</span>`
+        : `<span class="tag-warn">DNSSEC ?</span>`;
+      const records = host.tlsaRecords
+        .map((r) => `<code>${r.usage} ${r.selector} ${r.matchingType} …</code>`)
+        .join("<br>");
+      body += `<div><strong>${esc(host.exchange)}</strong></div><div>${records} ${badge}</div>`;
+    }
+    body += `</div>`;
+  }
+  body += validationList(d.validations);
+  return protocolCard("DANE/TLSA", d.status, subtitle, body, false, "dane");
+}
+
 function reportBody(result: ScanResult): string {
-  const { mx, dmarc, spf, dkim, bimi, mta_sts, security_txt, tls_rpt, dnssec } =
-    result.protocols;
+  const {
+    mx,
+    dmarc,
+    spf,
+    dkim,
+    bimi,
+    mta_sts,
+    security_txt,
+    tls_rpt,
+    dnssec,
+    dane,
+  } = result.protocols;
 
   return `<main class="report">
   <div class="report-nav">
@@ -410,6 +445,7 @@ function reportBody(result: ScanResult): string {
   ${security_txt ? renderSecurityTxtCard(security_txt) : ""}
   ${tls_rpt ? renderTlsRptCard(tls_rpt) : ""}
   ${dnssec ? renderDnssecCard(dnssec) : ""}
+  ${dane ? renderDaneCard(dane) : ""}
   ${monitorSnapshotCard(result)}
   <div class="learn-link" style="margin-top:2.5rem">Analyze message headers: <a href="https://toolbox.googleapps.com/apps/messageheader/" target="_blank" rel="noopener">Google &#8599;</a> &middot; <a href="https://mha.azurewebsites.net/" target="_blank" rel="noopener">Microsoft &#8599;</a></div>
   <div class="learn-link" style="margin-top:0.4rem;margin-bottom:1rem"><a href="/scoring">How is my score calculated?</a> &middot; <a href="https://www.cloudflare.com/learning/email-security/dmarc-dkim-spf/" target="_blank" rel="noopener">What is email security? &#8599;</a> &middot; <a href="https://github.com/schmug/dmarcheck/releases" target="_blank" rel="noopener">Changelog &#8599;</a></div>
@@ -518,6 +554,7 @@ export function renderStreamingLoading(
     ${skeletonCard("MTA-STS", false)}
     ${skeletonCard("security.txt", false, "security_txt")}
     ${skeletonCard("TLS-RPT", false, "tls_rpt")}
+    ${skeletonCard("DANE/TLSA", false, "dane")}
   </div>
   <noscript><meta http-equiv="refresh" content="0;url=/check?${esc(qs)}&_direct=1"></noscript>
 </main>

--- a/src/views/markdown.ts
+++ b/src/views/markdown.ts
@@ -1,4 +1,5 @@
 import type {
+  DaneResult,
   DnssecResult,
   ScanResult,
   SecurityTxtResult,
@@ -86,6 +87,24 @@ function renderDnssecMarkdown(d: DnssecResult): string {
   return `## DNSSEC — ${d.status}
 
 ${subtitle}
+
+${validationLines(d.validations)}`;
+}
+
+function renderDaneMarkdown(d: DaneResult): string {
+  const hostsWithTlsa = d.hosts.filter((h) => h.tlsaRecords.length > 0);
+  const hostLines =
+    hostsWithTlsa.length > 0
+      ? hostsWithTlsa
+          .map(
+            (h) =>
+              `- ${h.exchange}: ${h.tlsaRecords.length} TLSA record${h.tlsaRecords.length !== 1 ? "s" : ""}${h.dnssecValidated ? " (DNSSEC validated)" : " (DNSSEC not validated)"}`,
+          )
+          .join("\n")
+      : "_No TLSA records found._";
+  return `## DANE/TLSA — ${d.status}
+
+${hostLines}
 
 ${validationLines(d.validations)}`;
 }
@@ -207,6 +226,8 @@ ${protocols.security_txt ? renderSecurityTxtMarkdown(protocols.security_txt) : "
 ${protocols.tls_rpt ? renderTlsRptMarkdown(protocols.tls_rpt) : ""}
 
 ${protocols.dnssec ? renderDnssecMarkdown(protocols.dnssec) : ""}
+
+${protocols.dane ? renderDaneMarkdown(protocols.dane) : ""}
 
 ---
 

--- a/test/dane.test.ts
+++ b/test/dane.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { analyzeDane } from "../src/analyzers/dane.js";
+
+// Mock the DNS client's queryDoh function
+vi.mock("../src/dns/client.js", () => ({
+  queryDoh: vi.fn(),
+  DnsLookupError: class DnsLookupError extends Error {
+    constructor(
+      public readonly code: string,
+      message: string,
+    ) {
+      super(message);
+      this.name = "DnsLookupError";
+    }
+  },
+}));
+
+const { queryDoh, DnsLookupError } = (await import("../src/dns/client.js")) as {
+  queryDoh: ReturnType<typeof vi.fn>;
+  DnsLookupError: new (
+    code: string,
+    message: string,
+  ) => Error & { code: string };
+};
+
+function makeTlsaAnswer(data: string) {
+  return { name: "_25._tcp.mx.example.com.", type: 52, TTL: 300, data };
+}
+
+describe("analyzeDane — no MX records", () => {
+  it("returns info when mxExchanges is empty", async () => {
+    const result = await analyzeDane("example.com", []);
+    expect(result.status).toBe("info");
+    expect(result.hosts).toHaveLength(0);
+    expect(result.validations[0].message).toMatch(/no MX records/i);
+  });
+});
+
+describe("analyzeDane — no TLSA records", () => {
+  beforeEach(() => {
+    queryDoh.mockResolvedValue(null);
+  });
+
+  it("returns info when no TLSA records exist", async () => {
+    const result = await analyzeDane("example.com", ["mx.example.com"]);
+    expect(result.status).toBe("info");
+    expect(result.hosts).toHaveLength(1);
+    expect(result.hosts[0].tlsaRecords).toHaveLength(0);
+    expect(result.validations[0].message).toMatch(/not configured/i);
+  });
+
+  it("queries _25._tcp.<exchange> for each MX host", async () => {
+    await analyzeDane("example.com", ["mx1.example.com", "mx2.example.com"]);
+    // URL-parse-safe: check the full name, not a substring
+    expect(queryDoh).toHaveBeenCalledWith("_25._tcp.mx1.example.com", "TLSA");
+    expect(queryDoh).toHaveBeenCalledWith("_25._tcp.mx2.example.com", "TLSA");
+  });
+});
+
+describe("analyzeDane — TLSA with DNSSEC validated (pass)", () => {
+  beforeEach(() => {
+    queryDoh.mockResolvedValue({
+      Status: 0,
+      AD: true,
+      Answer: [makeTlsaAnswer("3 1 1 abcdef1234")],
+    });
+  });
+
+  it("returns pass when TLSA present and AD=true", async () => {
+    const result = await analyzeDane("example.com", ["mx.example.com"]);
+    expect(result.status).toBe("pass");
+    expect(result.hosts[0].tlsaRecords).toHaveLength(1);
+    expect(result.hosts[0].dnssecValidated).toBe(true);
+  });
+
+  it("parses TLSA record fields correctly", async () => {
+    const result = await analyzeDane("example.com", ["mx.example.com"]);
+    const record = result.hosts[0].tlsaRecords[0];
+    expect(record.usage).toBe(3);
+    expect(record.selector).toBe(1);
+    expect(record.matchingType).toBe(1);
+    expect(record.data).toBe("abcdef1234");
+  });
+
+  it("includes validated host in pass validation message", async () => {
+    const result = await analyzeDane("example.com", ["mx.example.com"]);
+    expect(result.validations[0].status).toBe("pass");
+    expect(result.validations[0].message).toMatch(/mx\.example\.com/);
+  });
+});
+
+describe("analyzeDane — TLSA without DNSSEC (warn)", () => {
+  beforeEach(() => {
+    queryDoh.mockResolvedValue({
+      Status: 0,
+      AD: false,
+      Answer: [makeTlsaAnswer("3 1 1 abcdef1234")],
+    });
+  });
+
+  it("returns warn when TLSA present but AD=false", async () => {
+    const result = await analyzeDane("example.com", ["mx.example.com"]);
+    expect(result.status).toBe("warn");
+    expect(result.hosts[0].tlsaRecords).toHaveLength(1);
+    expect(result.hosts[0].dnssecValidated).toBe(false);
+  });
+
+  it("validation message explains DNSSEC requirement", async () => {
+    const result = await analyzeDane("example.com", ["mx.example.com"]);
+    expect(result.validations[0].status).toBe("warn");
+    expect(result.validations[0].message).toMatch(/DNSSEC/i);
+  });
+});
+
+describe("analyzeDane — lookup error", () => {
+  it("returns fail with lookup_error when all queries fail", async () => {
+    queryDoh.mockRejectedValue(
+      new DnsLookupError("ESERVFAIL", "DNS server failure (SERVFAIL)"),
+    );
+    const result = await analyzeDane("example.com", ["mx.example.com"]);
+    expect(result.status).toBe("fail");
+    expect(result.lookup_error).toBeDefined();
+    expect(result.lookup_error?.code).toBe("ESERVFAIL");
+  });
+
+  it("returns info when some queries succeed with no TLSA and others fail", async () => {
+    queryDoh
+      .mockResolvedValueOnce(null) // mx1 — no TLSA
+      .mockRejectedValueOnce(
+        new DnsLookupError("ESERVFAIL", "DNS server failure"),
+      ); // mx2 — error
+    const result = await analyzeDane("example.com", [
+      "mx1.example.com",
+      "mx2.example.com",
+    ]);
+    // At least one query succeeded (returned null = no TLSA), so status is info not fail
+    expect(result.status).toBe("info");
+  });
+});
+
+describe("analyzeDane — mixed validated and unvalidated", () => {
+  it("returns pass with warn validation when one host is validated and another is not", async () => {
+    queryDoh
+      .mockResolvedValueOnce({
+        Status: 0,
+        AD: true,
+        Answer: [makeTlsaAnswer("3 1 1 aabbcc")],
+      }) // mx1 — DNSSEC validated
+      .mockResolvedValueOnce({
+        Status: 0,
+        AD: false,
+        Answer: [makeTlsaAnswer("3 1 1 ddeeff")],
+      }); // mx2 — not validated
+    const result = await analyzeDane("example.com", [
+      "mx1.example.com",
+      "mx2.example.com",
+    ]);
+    expect(result.status).toBe("pass");
+    const warnValidation = result.validations.find((v) => v.status === "warn");
+    expect(warnValidation).toBeDefined();
+    expect(warnValidation?.message).toMatch(/mx2\.example\.com/);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/analyzers/dane.ts` — `analyzeDane(domain, mxExchanges)` queries `_25._tcp.<exchange>` TLSA records via Cloudflare DoH for each MX host; reports **pass** (DNSSEC-validated), **warn** (TLSA present, AD=false), **info** (no TLSA configured), or **fail** (all lookups errored)
- Adds `DaneTlsaRecord`, `DaneHostResult`, `DaneResult` types to `src/analyzers/types.ts`; adds `dane?: DaneResult` to `ScanResult.protocols`
- Wires DANE into `src/orchestrator.ts`: new `ProtocolId`, `ProtocolResult`, `PROTOCOL_LABEL`, `ERROR_RESULTS.dane`; chains `danePromise` off `mxPromise` in both `scan()` and `scanStreaming()`
- Adds `renderDaneCard()` to `src/views/html.ts` with per-host TLSA summary and DNSSEC badge; adds DANE skeleton to streaming loading state
- Adds `renderDaneMarkdown()` to `src/views/markdown.ts`
- Registers `dane` renderer in `src/index.ts` `protocolRenderers` and cached-replay `protocolIds`
- Adds `test/dane.test.ts` — 11 unit tests covering no-MX, no-TLSA, pass (AD=true), warn (AD=false), fail (all errors), partial success, mixed validated/unvalidated hosts, and `_25._tcp.*` query naming

## Test plan

- [x] `npm test` — 1151 passed, 1 pre-existing live-network failure (mta-sts-runtime.test.ts) unrelated to this change
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean

Closes #415

Signed-off-by: Claude <claude@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoHD5hwj2ENLykorR6x4Xp)_