### PR TITLE
🎨 Palette: Add WAI-ARIA accordion pattern to protocol cards

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -11,3 +11,7 @@
 ## 2026-05-31 - Custom Accordion A11y Pattern
 **Learning:** In dmarc.mx, the SPF tree components use custom spans functioning as buttons. While they correctly employed `role="button"`, `tabindex="0"`, and `aria-controls`, the target collapsible elements lacked the required `role="region"` and `aria-labelledby` properties to complete the WAI-ARIA Accordion pattern.
 **Action:** When implementing or auditing custom accordions (like `.spf-node.include` controls or `.card` headers), verify that the control has an `id`, `role="button"`, `aria-expanded`, and `aria-controls`, and that the target container has an `id`, `role="region"`, and `aria-labelledby` pointing back to the control.
+
+## 2024-05-18 - ARIA Accordion Pattern for Client-Rendered Elements
+**Learning:** When client-side scripts dynamically render interactive components like accordions (e.g. `protocolRowEl` in `src/views/scripts.ts`), you have to manually generate predictable IDs to wire up the WAI-ARIA `aria-controls`, `role="region"`, and `aria-labelledby` attributes, since you are generating the DOM elements directly without a framework like React.
+**Action:** When creating inline/JS-rendered expandable sections, always pass or generate unique IDs (e.g. `protocol-${name.toLowerCase()}`) to correctly wire the WAI-ARIA accordion pattern between the toggle button and the expanding content panel.

--- a/src/views/scripts.ts
+++ b/src/views/scripts.ts
@@ -1047,17 +1047,30 @@ if (typeof navigator !== 'undefined' && navigator.modelContext && typeof navigat
       chevron = el('span', { class: 'drawer-protocol-chevron', 'aria-hidden': 'true', text: '▸' });
       children.push(chevron);
     }
+    var safeId = 'protocol-' + name.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+    var btnId = safeId + '-btn';
+    var panelId = safeId + '-panel';
     var headBtnAttrs = {
       type: 'button',
       class: 'drawer-protocol-head',
-      'aria-expanded': 'false'
+      'aria-expanded': 'false',
+      id: btnId
     };
-    if (!hasRecord) headBtnAttrs.disabled = '';
+    if (hasRecord) {
+      headBtnAttrs['aria-controls'] = panelId;
+    } else {
+      headBtnAttrs.disabled = '';
+    }
     var head = el('button', headBtnAttrs, children);
     var detail = null;
     if (hasRecord) {
       var rec = el('div', { class: 'drawer-protocol-record', text: info.record });
-      detail = el('div', { class: 'drawer-protocol-detail' }, [
+      detail = el('div', {
+        class: 'drawer-protocol-detail',
+        id: panelId,
+        role: 'region',
+        'aria-labelledby': btnId
+      }, [
         rec,
         copyButton(info.record, { label: 'Copy' })
       ]);


### PR DESCRIPTION
💡 What: Implemented the WAI-ARIA Accordion pattern for the dynamically rendered protocol cards in the domain drawer.
🎯 Why: To improve accessibility for screen reader users, explicitly linking the toggle button to the expandable content panel.
📸 Before/After: Visual appearance remains identical, but the DOM now includes `aria-controls`, `role="region"`, and `aria-labelledby`.
♿ Accessibility: The protocol cards now adhere to the WAI-ARIA authoring practices for disclosure/accordion widgets, allowing screen readers to understand the structure and relationship of the elements.

---
*PR created automatically by Jules for task [13707750943754779139](https://jules.google.com/task/13707750943754779139) started by @schmug*