### PR TITLE
⚡ Bolt: Reduce array allocations in dashboard DKIM summary

### DIFF
--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -212,12 +212,22 @@ function buildDrawerDetail(
   const spfLookupLimit =
     typeof spf?.lookup_limit === "number" ? spf.lookup_limit : 10;
   const dkimSelectors = dkim?.selectors ?? {};
-  const dkimFound = Object.values(dkimSelectors).filter(
-    (s) => s?.found === true,
-  );
-  const dkimKeyBits = dkimFound
-    .map((s) => (typeof s.key_bits === "number" ? s.key_bits : 0))
-    .filter((n) => n > 0);
+  // ⚡ Bolt Optimization: Use a single-pass loop instead of Object.values().filter().map().filter()
+  // Reduces GC pressure on the dashboard view by avoiding multiple intermediate array allocations.
+  let dkimFoundCount = 0;
+  let minDkimKeyBits = Infinity;
+  for (const key in dkimSelectors) {
+    const s = dkimSelectors[key];
+    if (s?.found) {
+      dkimFoundCount++;
+      if (typeof s.key_bits === "number" && s.key_bits > 0) {
+        if (s.key_bits < minDkimKeyBits) {
+          minDkimKeyBits = s.key_bits;
+        }
+      }
+    }
+  }
+
   const bimiConfigured = !!(bimi?.tags && Object.keys(bimi.tags).length > 0);
   const mtaMode =
     typeof mta?.policy?.mode === "string" ? mta.policy.mode : null;
@@ -240,9 +250,9 @@ function buildDrawerDetail(
     dkim: {
       status: asProtocolStatus(dkim?.status),
       summary:
-        dkimFound.length > 0
-          ? `${dkimFound.length} selector${dkimFound.length === 1 ? "" : "s"}` +
-            (dkimKeyBits.length ? ` · ${Math.min(...dkimKeyBits)}-bit` : "")
+        dkimFoundCount > 0
+          ? `${dkimFoundCount} selector${dkimFoundCount === 1 ? "" : "s"}` +
+            (minDkimKeyBits !== Infinity ? ` · ${minDkimKeyBits}-bit` : "")
           : "no selectors found",
       record: null,
     },


### PR DESCRIPTION
### 💡 What
Replaced chained array operations (`Object.values()`, `.filter()`, `.map()`, and array spreading) with a single-pass `for...in` loop in `src/dashboard/routes.ts` when formatting the DKIM protocol summary for the dashboard drawer.

### 🎯 Why
The original code was creating up to 4 intermediate arrays on a hot code path (evaluating multiple DKIM selectors for a scanned domain):
1. `Object.values(dkimSelectors)`
2. `.filter(...)` for found selectors
3. `.map(...)` for extracting key bits
4. `.filter(...)` for extracting positive key bits
This creates unnecessary garbage collection (GC) pressure. The single-pass loop calculates the same aggregate statistics without any array allocations.

### 📊 Impact
Eliminates O(N) intermediate array allocations during dashboard rendering, directly lowering GC overhead and rendering latency for accounts monitoring multiple domains.

### 🔬 Measurement
Run `pnpm test` to verify the routing logic correctly handles domains with multiple, single, and no DKIM records. I have verified that 1169 tests pass.

---
*PR created automatically by Jules for task [9830035882329134440](https://jules.google.com/task/9830035882329134440) started by @schmug*