### PR TITLE
fix: render DNSSEC card on the streaming scan report

### DIFF
--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -50,7 +50,7 @@ export type ProtocolResult =
   | DnssecResult
   | DaneResult;
 
-const PROTOCOL_LABEL: Record<ProtocolId, string> = {
+export const PROTOCOL_LABEL: Record<ProtocolId, string> = {
   mx: "MX",
   dmarc: "DMARC",
   spf: "SPF",

--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -554,6 +554,7 @@ export function renderStreamingLoading(
     ${skeletonCard("MTA-STS", false)}
     ${skeletonCard("security.txt", false, "security_txt")}
     ${skeletonCard("TLS-RPT", false, "tls_rpt")}
+    ${skeletonCard("DNSSEC", false)}
     ${skeletonCard("DANE/TLSA", false, "dane")}
   </div>
   <noscript><meta http-equiv="refresh" content="0;url=/check?${esc(qs)}&_direct=1"></noscript>

--- a/test/streaming-skeleton.test.ts
+++ b/test/streaming-skeleton.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Regression guard for the streaming scan report (#451).
+ *
+ * The streaming loading view (`renderStreamingLoading`) pre-renders one
+ * skeleton card per protocol, each tagged `data-protocol="<id>"`. The client
+ * SSE handler swaps each streamed protocol card into the matching skeleton
+ * (see the inline script in `renderStreamingLoading`). If a protocol the
+ * stream emits has no skeleton placeholder, its card is silently dropped —
+ * exactly what happened to DNSSEC: the stream emitted a `dnssec` card, but the
+ * skeleton list had no `data-protocol="dnssec"`, so it never rendered.
+ *
+ * This pins the invariant: the skeleton set must cover every ProtocolId the
+ * orchestrator/stream can emit. `PROTOCOL_LABEL` is a
+ * `Record<ProtocolId, string>`, so adding a protocol to the union forces a new
+ * key here, which forces a matching skeleton — the next protocol can't drop.
+ */
+import { describe, expect, it } from "vitest";
+import { PROTOCOL_LABEL } from "../src/orchestrator.js";
+import { renderStreamingLoading } from "../src/views/html.js";
+
+describe("renderStreamingLoading — skeleton coverage", () => {
+  const html = renderStreamingLoading("example.com", "");
+
+  for (const id of Object.keys(PROTOCOL_LABEL)) {
+    it(`renders a skeleton placeholder for the ${id} protocol`, () => {
+      expect(
+        html.includes(`data-protocol="${id}"`),
+        `streaming skeleton is missing data-protocol="${id}" — its streamed card would be silently dropped`,
+      ).toBe(true);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Fixes #451 — the **DNSSEC card never rendered on the default (streaming) scan report**. The card was computed and streamed but silently dropped client-side because the loading skeleton had no placeholder for it.

## Root cause

`renderStreamingLoading` pre-renders one skeleton per protocol, each tagged `data-protocol="<id>"`. The client SSE handler swaps each streamed card into its matching skeleton:

```js
var skeleton = container.querySelector('[data-protocol="' + data.id + '"]');
if (skeleton) { ... skeleton.replaceWith(el); }   // no-op when skeleton is null
```

The stream emits a `dnssec` card (`protocolRenderers.dnssec` → `renderDnssecCard`, on both the cached-replay and live paths), but the skeleton list had placeholders for only 9 protocols — **not `dnssec`**. So the lookup returned `null`, `if (skeleton)` was false, and the card was discarded. Only the no-JS / `X-Scan-Fetch` / `_direct=1` fallback (`renderReport`) ever showed it.

## The fix

- **`src/views/html.ts`** — add the missing `${skeletonCard("DNSSEC", false)}` between TLS-RPT and DANE/TLSA, matching the orchestrator and `renderReport` order. `skeletonCard` auto-derives `data-protocol="dnssec"` from the name.
- **`test/streaming-skeleton.test.ts`** — new regression test asserting the skeleton set covers **every** `ProtocolId` the stream can emit. It iterates `PROTOCOL_LABEL` (a `Record<ProtocolId, string>`), so adding a protocol to the union forces a key here, which forces a matching skeleton — the next protocol can't silently drop.
- **`src/orchestrator.ts`** — export the existing `PROTOCOL_LABEL` so the test has a compile-enforced, exhaustive source of truth (visibility-only; no behavior change).

> ⚠️ **CODEOWNERS note:** this PR touches `src/orchestrator.ts`, which is gated to `@schmug` per `.github/CODEOWNERS` (orchestration / exfiltration risk). The change there is a **one-token `export` for test wiring** — no orchestration behavior changes. Flagging for the required code-owner review.

## Verification

- `npm test` — **1179 passing, 0 failing** (10 new assertions, one per protocol)
- `npm run lint` — clean · `npm run typecheck` — clean
- **Browser (dev server, streaming path):** scanned `cloudflare.com` → **10 loaded cards** (was 9), DNSSEC card present, `loaded`, subtitle "Signed and validated", green pass status, correct order (`…tls_rpt, dnssec, dane`), no console errors. DNSSEC also now appears in the score-snippet dots.

## TDD

Test written first; watched it fail on `dnssec` for the right reason ("streaming skeleton is missing `data-protocol="dnssec"`") while the other 9 passed, then added the skeleton to go green.

## Follow-ups (not in this PR)

- Shipping this widens exposure of #452: the DNSSEC card's "Learn about DNSSEC →" link (→ `/learn/dnssec`, currently 404) now renders on the **primary** path, not just `_direct=1`. Raises #452's priority.
- `api-check-stream.test.ts`'s `KNOWN_PROTOCOL_IDS` set and `CACHED_SCAN` fixture are stale (missing dnssec/dane); and the cached-replay `protocolIds` literal at `src/index.ts` is `ProtocolId[]`, not an exhaustive `Record`, so a future protocol could be omitted there and still typecheck. Worth a hardening follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
