### PR TITLE
fix: DANE analyzer — parse RFC 3597 generic TLSA format from Cloudflare DoH

### DIFF
--- a/src/analyzers/dane.ts
+++ b/src/analyzers/dane.ts
@@ -6,10 +6,38 @@ import type {
   Validation,
 } from "./types.js";
 
-// TLSA record data arrives as "<usage> <selector> <matching-type> <hex-data>"
-// e.g. "3 1 1 abcdef1234..."
+// TLSA record data can arrive in two shapes:
+//  1. Presentation format (RFC 6698 §2.2): "<usage> <selector> <matching-type>
+//     <hex-data>", e.g. "3 1 1 abcdef1234...".
+//  2. RFC 3597 §5 generic format: "\# <rdlength> <hex octets>", e.g.
+//     "\# 35 03 01 01 0f0c...". This is what Cloudflare's DoH JSON API returns
+//     for TLSA, since it predates a type-specific presentation in that API.
+// Both decode to the same RFC 6698 §2.1 RDATA: 1 octet certificate usage,
+// 1 octet selector, 1 octet matching type, then the certificate-association data.
 function parseTlsaRecord(data: string): DaneTlsaRecord | null {
-  const parts = data.trim().split(/\s+/);
+  const trimmed = data.trim();
+
+  if (trimmed.startsWith("\\#")) {
+    // Drop the "\#" marker and the leading rdlength token, then concatenate the
+    // remaining (possibly space-separated) hex octets into one lowercase string.
+    const hex = trimmed
+      .slice(2)
+      .trim()
+      .split(/\s+/)
+      .slice(1)
+      .join("")
+      .toLowerCase();
+    // Need at least the 3 header octets (6 hex chars); reject anything non-hex.
+    // After this guard every two-char slice is valid hex, so parseInt base-16
+    // can never return NaN — no further NaN check needed in this branch.
+    if (hex.length < 6 || !/^[0-9a-f]+$/.test(hex)) return null;
+    const usage = parseInt(hex.slice(0, 2), 16);
+    const selector = parseInt(hex.slice(2, 4), 16);
+    const matchingType = parseInt(hex.slice(4, 6), 16);
+    return { usage, selector, matchingType, data: hex.slice(6) };
+  }
+
+  const parts = trimmed.split(/\s+/);
   if (parts.length < 4) return null;
   const usage = parseInt(parts[0], 10);
   const selector = parseInt(parts[1], 10);

--- a/test/dane.test.ts
+++ b/test/dane.test.ts
@@ -138,6 +138,77 @@ describe("analyzeDane — lookup error", () => {
   });
 });
 
+describe("analyzeDane — Cloudflare DoH generic (RFC 3597) TLSA format", () => {
+  // Cloudflare's DoH JSON API returns TLSA rdata in RFC 3597 generic format
+  // ("\# <rdlength> <hex bytes>") rather than the "<usage> <selector>
+  // <matching-type> <hex>" presentation format. These fixtures are the actual
+  // records published for dmarc.mx's MX hosts (_25._tcp.route1.mx.cloudflare.net).
+  beforeEach(() => {
+    queryDoh.mockResolvedValue({
+      Status: 0,
+      AD: true,
+      Answer: [
+        makeTlsaAnswer(
+          "\\# 35 02 01 01 59 e7 38 e6 74 22 17 02 af 1e db 87 c5 20 0c 1a 4b 75 f6 4f ae 3d 2c 3d 26 51 24 c6 1b d8 3c 79",
+        ),
+        makeTlsaAnswer(
+          "\\# 35 03 01 01 0f 0c 6c 16 4a 36 f9 7e 7b 4c 5a 5b 69 d6 f4 f2 39 d4 22 fc 3e c2 59 20 72 ec fa b8 c2 71 c4 52",
+        ),
+      ],
+    });
+  });
+
+  it("parses generic-format TLSA records instead of dropping them", async () => {
+    const result = await analyzeDane("example.com", ["mx.example.com"]);
+    expect(result.status).toBe("pass");
+    expect(result.hosts[0].tlsaRecords).toHaveLength(2);
+    expect(result.hosts[0].dnssecValidated).toBe(true);
+  });
+
+  it("decodes usage/selector/matching-type/data from the hex octets", async () => {
+    const result = await analyzeDane("example.com", ["mx.example.com"]);
+    const [ta, ee] = result.hosts[0].tlsaRecords;
+    // First record: DANE-TA (usage 2), SPKI selector (1), SHA-256 (1)
+    expect(ta.usage).toBe(2);
+    expect(ta.selector).toBe(1);
+    expect(ta.matchingType).toBe(1);
+    expect(ta.data).toBe(
+      "59e738e674221702af1edb87c5200c1a4b75f64fae3d2c3d265124c61bd83c79",
+    );
+    // Second record: DANE-EE (usage 3)
+    expect(ee.usage).toBe(3);
+    expect(ee.selector).toBe(1);
+    expect(ee.matchingType).toBe(1);
+    expect(ee.data).toBe(
+      "0f0c6c164a36f97e7b4c5a5b69d6f4f239d422fc3ec2592072ecfab8c271c452",
+    );
+  });
+});
+
+describe("analyzeDane — malformed generic-format TLSA", () => {
+  it("drops a non-hex generic record and reports not configured", async () => {
+    queryDoh.mockResolvedValue({
+      Status: 0,
+      AD: true,
+      Answer: [makeTlsaAnswer("\\# 4 zz zz")],
+    });
+    const result = await analyzeDane("example.com", ["mx.example.com"]);
+    expect(result.hosts[0].tlsaRecords).toHaveLength(0);
+    expect(result.status).toBe("info");
+  });
+
+  it("drops a truncated generic record shorter than the 3-octet header", async () => {
+    queryDoh.mockResolvedValue({
+      Status: 0,
+      AD: true,
+      Answer: [makeTlsaAnswer("\\# 1 03")],
+    });
+    const result = await analyzeDane("example.com", ["mx.example.com"]);
+    expect(result.hosts[0].tlsaRecords).toHaveLength(0);
+    expect(result.status).toBe("info");
+  });
+});
+
 describe("analyzeDane — mixed validated and unvalidated", () => {
   it("returns pass with warn validation when one host is validated and another is not", async () => {
     queryDoh


### PR DESCRIPTION
## Summary

Fixes a **false negative** in the DANE/TLSA analyzer: every DANE-enabled domain — including dmarc.mx itself — was reported as "DANE/TLSA not configured" even when valid, DNSSEC-validated TLSA records exist.

## Root cause

`parseTlsaRecord` in `src/analyzers/dane.ts` only handled TLSA **presentation format** (`"3 1 1 abcdef…"`). But Cloudflare's DoH JSON API — the resolver behind `queryDoh` — returns TLSA rdata in **RFC 3597 §5 generic format** (`"\# 35 03 01 01 0f0c…"`). The parser did `parseInt("\#", 10)` → `NaN` → returned `null` → **every record was silently dropped**, so the analyzer fell through to "not configured".

### Live evidence (pre-fix)

```
$ curl -s -H 'accept: application/json' 'https://dmarc.mx/check?domain=dmarc.mx' | jq '.protocols.dane'
status: "info"  →  "DANE/TLSA not configured — no TLSA records found for MX hosts"
hosts: [
  { "exchange": "route1.mx.cloudflare.net", "tlsaRecords": [], "dnssecValidated": true },
  …
]
```

`dnssecValidated: true` with `tlsaRecords: []` is the smoking gun — DoH *did* return AD-validated TLSA records; they were discarded during parsing. dmarc.mx's MX hosts (Cloudflare Email Routing) publish DNSSEC-validated TLSA records at `_25._tcp.route{1,2,3}.mx.cloudflare.net`, and dmarc.mx's zone has DNSSEC — so the domain has always *had* working DANE; only the tool's report was wrong.

## Fix

`parseTlsaRecord` now decodes **both** wire shapes:

- **RFC 3597 generic** — strip the `\#` marker + rdlength token, concatenate the hex octets, read the first three as usage/selector/matching-type per **RFC 6698 §2.1**, remainder = certificate-association data.
- **RFC 6698 §2.2 presentation** — unchanged, for backward compatibility.

Malformed generic input (non-hex, or shorter than the 3-octet header) returns `null`.

After the fix, dmarc.mx's DANE card flips from `info — "not configured"` to `pass — "DANE/TLSA configured and DNSSEC-validated on: route1/2/3.mx.cloudflare.net"`.

## Scope / grade impact

**Grade-neutral.** DANE is not wired into scoring — `src/shared/scoring.ts` never reads `dane` (verified: `resolveScoring` and `buildProtocolSummaries` destructure named protocols only, neither includes `dane`). This change only corrects the informational DANE report card. dmarc.mx remains grade S.

The sibling `dnssec.ts` (the only other `queryDoh` caller) only inspects response presence + the `AD` flag and never parses the rdata `data` field, so it has no equivalent bug. The fix is isolated to DANE.

## Tests

`test/dane.test.ts`:
- **Generic-format parsing** using the *actual* TLSA records published for dmarc.mx's MX hosts — asserts `pass`, both records parsed, and exact usage/selector/matching-type/data decoding.
- **Malformed-generic guards** — non-hex and sub-header-length records are dropped (→ `info`).

The pre-existing presentation-format tests are untouched and still pass.

## Verification

- `npm test` — **1173 passing, 0 failing**
- `npm run typecheck` — clean
- `npm run lint` — clean (151 files)
- Reviewed by the `analyzer-reviewer` agent: no blocking issues; confirmed status taxonomy, null-on-NXDOMAIN, `Promise.allSettled`/orchestrator isolation, `lookup_error` handling, grade-neutrality, and RFC decode correctness. Acted on its one note (removed an unreachable `Number.isNaN` block in the generic branch).

## Reviewer note

Touches `src/analyzers/**`, which is CODEOWNERS-gated — needs a code-owner approval before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
