### PR TITLE
🎨 Palette: Add aria-sort to dashboard sortable headers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -15,3 +15,6 @@
 ## 2024-05-18 - ARIA Accordion Pattern for Client-Rendered Elements
 **Learning:** When client-side scripts dynamically render interactive components like accordions (e.g. `protocolRowEl` in `src/views/scripts.ts`), you have to manually generate predictable IDs to wire up the WAI-ARIA `aria-controls`, `role="region"`, and `aria-labelledby` attributes, since you are generating the DOM elements directly without a framework like React.
 **Action:** When creating inline/JS-rendered expandable sections, always pass or generate unique IDs (e.g. `protocol-${name.toLowerCase()}`) to correctly wire the WAI-ARIA accordion pattern between the toggle button and the expanding content panel.
+## 2026-06-01 - Add aria-sort to sortable headers
+**Learning:** Sortable headers should be marked with the aria-sort attribute so that screen readers are aware of the order.
+**Action:** When creating sortable headers, ensure that only the active sorting header is marked with the aria-sort attribute.

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -1581,7 +1581,12 @@ function renderSortableHeader(
     direction: nextDirection,
     page: 1,
   });
-  return `<th><a class="sort-link${isActive ? " active" : ""}" href="${esc(href)}">${esc(label)}<span class="sort-arrow">${arrow}</span></a></th>`;
+  const ariaAttr = isActive
+    ? controls.direction === "asc"
+      ? ' aria-sort="ascending"'
+      : ' aria-sort="descending"'
+    : "";
+  return `<th${ariaAttr}><a class="sort-link${isActive ? " active" : ""}" href="${esc(href)}">${esc(label)}<span class="sort-arrow">${arrow}</span></a></th>`;
 }
 
 function renderDomainToolbar(controls: DashboardControls): string {


### PR DESCRIPTION
💡 **What**: Added the `aria-sort` attribute to the dashboard domain list sortable headers. The active column will receive either `ascending` or `descending` values based on the dashboard control state, while inactive columns will correctly omit the attribute.

🎯 **Why**: To provide clear screen reader guidance indicating the direction in which data is sorted, avoiding confusion and adhering to WCAG and ARIA best practices for sortable data tables.

📸 **Before/After**: Visually, there is no change on the dashboard. The changes applied exclusively to semantic HTML `aria-*` attributes.

♿ **Accessibility**: Enhanced screen reader support for dynamic tables, specifically completing the memory criteria: *For sortable data tables, apply `aria-sort` (e.g., 'ascending' or 'descending') only to the currently active sorting header, and omit the attribute from inactive headers.*

---
*PR created automatically by Jules for task [3558495200779207014](https://jules.google.com/task/3558495200779207014) started by @schmug*