### PR TITLE
fix: give gh repo context in prod-smoke incident job

### DIFF
--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -138,6 +138,11 @@ jobs:
       - name: Open or update incident issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # This job has no actions/checkout, so gh has no git remote to infer
+          # the repo from. GH_REPO supplies it explicitly — without this every
+          # gh call dies with "fatal: not a git repository" and no incident is
+          # ever filed (prod-smoke failures were silent for that reason).
+          GH_REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           TRIGGER: ${{ github.event_name }}
         run: |


### PR DESCRIPTION
## Task

The `open-incident` job in `.github/workflows/prod-smoke.yml` is supposed to file/update a tracking issue when the prod smoke canary fails. It has **no `actions/checkout`**, so `gh` runs with no git remote to infer the repo from and dies every time with `fatal: not a git repository`. The error is swallowed on the `gh issue list ... || echo ""` call but fatal on the subsequent `gh issue create`, so **no incident issue is ever filed**.

Net effect: the prod smoke test has been failing since ~2026-05-29 and nobody was notified — `gh issue list --label incident` returns empty. This fixes the alerting itself.

## Change

`.github/workflows/prod-smoke.yml` (`open-incident` job env): add `GH_REPO: ${{ github.repository }}` — the documented `gh` repo override — instead of adding a checkout step.

## Acceptance criteria

- On a smoke failure (non-dispatch trigger), the `open-incident` job creates or comments on a single `Prod smoke test failing` issue labeled `incident`, with no `fatal: not a git repository` error.

## Out of scope

- **Why the smoke test fails in the first place** (Cloudflare Bot Fight Mode challenging the CI runner). That's a separate, larger change still being worked in PR #458 — this PR only fixes the broken alerting so future failures surface.

## Notes

- Touches `.github/workflows/` → CODEOWNERS-gated; needs code-owner approval.
- `github.repository` is a trusted context value, passed via `env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)