### PR TITLE
test: harden streaming-protocol coverage against silently-dropped cards

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -587,18 +587,13 @@ app.get("/api/check/stream", async (c) => {
 
     if (cached) {
       tagScanResult(cached);
-      const protocolIds: ProtocolId[] = [
-        "mx",
-        "dmarc",
-        "spf",
-        "dkim",
-        "bimi",
-        "mta_sts",
-        "security_txt",
-        "tls_rpt",
-        "dnssec",
-        "dane",
-      ];
+      // Derive the replay set from `protocolRenderers` keys, not a hand-listed
+      // literal. `protocolRenderers` is `Record<ProtocolId, …>`, so adding a
+      // protocol to the union forces a renderer key, which is iterated here —
+      // no protocol can be silently dropped from the cache-hit path (#455).
+      // Object insertion order matches the previous literal, so `done` still
+      // comes last with no duplicate or reordered events.
+      const protocolIds = Object.keys(protocolRenderers) as ProtocolId[];
       for (const id of protocolIds) {
         const protocolResult = cached.protocols[id];
         // Older cached scans (pre-#40) may lack security_txt; skip rather

--- a/test/api-check-stream.test.ts
+++ b/test/api-check-stream.test.ts
@@ -17,7 +17,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { app } from "../src/index.js";
-import { scanStreaming } from "../src/orchestrator.js";
+import { PROTOCOL_LABEL, scanStreaming } from "../src/orchestrator.js";
 import { _memoryStore } from "../src/rate-limit.js";
 import { drainSSE } from "./helpers/drain-sse.js";
 
@@ -133,22 +133,31 @@ const CACHED_SCAN = {
       tags: null,
       validations: [],
     },
+    dnssec: {
+      status: "info" as const,
+      signed: false,
+      validated: false,
+      validations: [],
+    },
+    dane: {
+      status: "info" as const,
+      hosts: [],
+      validations: [],
+    },
   },
 };
 
 // ---------------------------------------------------------------------------
-// Known protocol IDs the route must emit
+// Known protocol IDs the route must emit.
+//
+// Derived from `PROTOCOL_LABEL` (a `Record<ProtocolId, string>` — the canonical
+// exhaustive id source, also used by the #454 skeleton guard) rather than a
+// hand-listed set. Adding a protocol to the `ProtocolId` union forces a new
+// `PROTOCOL_LABEL` key, which flows into this set, which makes the
+// "emits a protocol event for every known protocol" assertions exercise it.
+// This is what the stale 8-entry literal failed to do for dnssec/dane (#451).
 // ---------------------------------------------------------------------------
-const KNOWN_PROTOCOL_IDS = new Set<string>([
-  "mx",
-  "dmarc",
-  "spf",
-  "dkim",
-  "bimi",
-  "mta_sts",
-  "security_txt",
-  "tls_rpt",
-]);
+const KNOWN_PROTOCOL_IDS = new Set<string>(Object.keys(PROTOCOL_LABEL));
 
 // ---------------------------------------------------------------------------
 // Per-test setup
@@ -325,6 +334,36 @@ describe("GET /api/check/stream — happy path (cache-hit replay)", () => {
     const doneData = JSON.parse(doneFrame?.data) as { grade: string };
     expect(doneData.grade).toBe(CACHED_SCAN.grade);
   });
+});
+
+// ---------------------------------------------------------------------------
+// 1b. Cache-hit replay parity guard (#455)
+//
+// Mirrors the #454 skeleton guard (`test/streaming-skeleton.test.ts`): the
+// cache-hit replay path must emit a `protocol` event for *every* ProtocolId the
+// orchestrator can produce. `PROTOCOL_LABEL` is the canonical exhaustive id
+// source, so adding a protocol to the `ProtocolId` union forces a new key here
+// — and unless that protocol is wired into both the replay iteration
+// (`src/index.ts`) and the `CACHED_SCAN` fixture, this test fails. That is the
+// failure that the stale 8-entry fixture/list silently swallowed for
+// dnssec/dane (#451).
+// ---------------------------------------------------------------------------
+describe("GET /api/check/stream — cache-hit replay protocol parity", () => {
+  for (const id of Object.keys(PROTOCOL_LABEL)) {
+    it(`emits a 'protocol' event for the ${id} protocol on a cache hit`, async () => {
+      const res = await requestWithCacheHit(
+        "/api/check/stream?domain=test.example.com",
+      );
+      const frames = await drainSSE(res);
+      const emittedIds = frames
+        .filter((f) => f.event === "protocol")
+        .map((f) => (JSON.parse(f.data) as { id: string }).id);
+      expect(
+        emittedIds,
+        `cache-hit replay dropped protocol "${id}" — it is in PROTOCOL_LABEL but not emitted (check the replay loop in src/index.ts and the CACHED_SCAN fixture)`,
+      ).toContain(id);
+    });
+  }
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #455

## Summary

After #451 the streaming *skeleton* gained an exhaustive guard (#454), but the SSE-level tests that should have caught the DNSSEC drop were themselves stale, and one runtime list could silently drop a protocol. This brings the remaining protocol-enumerating surfaces up to the same standard.

- **`test/api-check-stream.test.ts`** — `KNOWN_PROTOCOL_IDS` is now derived from `Object.keys(PROTOCOL_LABEL)` (the exhaustive `Record<ProtocolId, string>`, same source as the #454 skeleton guard) instead of a hand-listed 8-entry set that omitted `dnssec`/`dane`. The "emits a protocol event for every known protocol" assertions now exercise all 10 protocols.
- **`CACHED_SCAN.protocols`** — extended with minimal valid `dnssec`/`dane` objects (typecheck-clean against `DnssecResult`/`DaneResult`), so the cache-hit replay test actually emits them.
- **`src/index.ts`** — the cache-hit replay `protocolIds` literal is now `Object.keys(protocolRenderers) as ProtocolId[]`. `protocolRenderers` is a `Record<ProtocolId, …>`, so a future protocol can't be omitted from the replay path. Insertion order matches the previous literal — `done` still comes last, no duplicate/reordered events.
- **New parity guard** — a per-protocol cache-hit test (mirroring the #454 skeleton guard) fails if any `PROTOCOL_LABEL` id isn't emitted on a cache hit, tying the replay iteration and the fixture to one source of truth.

No analyzer/scoring/orchestrator behavior changes; this is test/fixture hardening plus making one runtime list exhaustiveness-enforced.

## Guard discrimination check

Temporarily removing `dane` from `CACHED_SCAN.protocols` turns the new parity test (and the two enumeration tests) **red**, confirming the guard actually discriminates rather than just passing. Restored afterward.

## Verification

- `npm test` → **1193 passing, 0 failing** (73 test files)
- `npm run lint` → clean (152 files checked, no fixes applied)
- `npm run typecheck` → clean (tsc --noEmit, no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)