### PR TITLE
fix: list all checked protocols on landing + /scoring (drop hardcoded "five")

### DIFF
--- a/src/views/components.ts
+++ b/src/views/components.ts
@@ -474,6 +474,9 @@ const PROTO_LABELS: Record<string, string> = {
   security_txt: "security.txt",
   tls_rpt: "TLS-RPT",
   dnssec: "DNSSEC",
+  // DANE is checked but not scored, so it never enters protocolSummaries today.
+  // Included here defensively so scoreSnippet never falls back to a raw key.
+  dane: "DANE/TLSA",
 };
 
 export function scoreSnippet(result: ScanResult): string {

--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -194,13 +194,19 @@ export function renderLandingPage(): string {
   </div>
   <section class="landing-explainer" id="what-we-check" aria-labelledby="explainer-heading">
     <h2 id="explainer-heading">What dmarcheck checks</h2>
-    <p>dmarcheck is a free DMARC, SPF, DKIM, BIMI, and MTA-STS checker for any domain. Enter a hostname and it pulls the live DNS records, validates them against the specs, and grades the overall posture from F to A+.</p>
+    <p>dmarcheck is a free DMARC, SPF, DKIM, BIMI, and MTA-STS checker for any domain. Enter a hostname and it pulls the live DNS records, validates them against the specs, and grades the overall posture from F to A+. It also checks MX, security.txt, TLS-RPT, DNSSEC, and DANE/TLSA and reports them alongside your grade.</p>
+    <p class="explainer-note">DMARC, SPF, DKIM, BIMI, and MTA-STS drive your grade. The rest are checked for context and reported, but don't change the letter grade.</p>
     <dl class="explainer-grid">
       <div><dt><a href="/learn/dmarc">DMARC</a></dt><dd>The policy record that tells receivers how to treat unauthenticated mail and where to send aggregate reports.</dd></div>
       <div><dt><a href="/learn/spf">SPF</a></dt><dd>The list of hosts authorized to send on your behalf, including the 10-DNS-lookup budget.</dd></div>
       <div><dt><a href="/learn/dkim">DKIM</a></dt><dd>Per-selector signing keys and their key length, checked against 38 common selectors.</dd></div>
       <div><dt><a href="/learn/bimi">BIMI</a></dt><dd>The brand logo record that can render next to authenticated messages in supporting inboxes.</dd></div>
       <div><dt><a href="/learn/mta-sts">MTA-STS</a></dt><dd>The TLS enforcement policy that prevents downgrade attacks on inbound mail.</dd></div>
+      <div><dt>MX</dt><dd>The mail exchangers that accept inbound mail for the domain, with provider detection. Informational — not part of the grade.</dd></div>
+      <div><dt><a href="/learn/security-txt">security.txt</a></dt><dd>The published contact for reporting security issues, per RFC 9116. Checked and reported, not graded.</dd></div>
+      <div><dt><a href="/learn/tls-rpt">TLS-RPT</a></dt><dd>The reporting address for TLS delivery failures on inbound mail. Checked and reported, not graded.</dd></div>
+      <div><dt>DNSSEC</dt><dd>Whether the zone is cryptographically signed against DNS tampering. Checked and reported, not graded.</dd></div>
+      <div><dt>DANE/TLSA</dt><dd>TLSA records that bind your mail server's certificate to DNS. Checked and reported, not graded.</dd></div>
     </dl>
   </section>
 </main>`,
@@ -801,8 +807,9 @@ export function renderScoringRubric(
   </div>
 
   <div class="bd-card">
-    <div class="bd-card-title">The five protocols</div>
+    <div class="bd-card-title">The protocols we check</div>
     <div class="bd-card-body">
+      <p class="rubric-subhead">These protocols determine your letter grade:</p>
       <div class="rubric-protocol">
         <h3><a href="/learn/dmarc">DMARC</a></h3>
         <p>Domain-based Message Authentication, Reporting &amp; Conformance. The policy layer that ties SPF and DKIM together and tells receivers what to do with unauthenticated mail. This is the most important factor in your grade.</p>
@@ -822,6 +829,27 @@ export function renderScoringRubric(
       <div class="rubric-protocol">
         <h3><a href="/learn/mta-sts">MTA-STS</a></h3>
         <p>Mail Transfer Agent Strict Transport Security. Forces TLS encryption for inbound mail delivery, preventing downgrade attacks. Modes: testing (report only) and enforce (reject unencrypted).</p>
+      </div>
+      <p class="rubric-subhead">We also check these and report them on every scan, but they do not currently affect the grade:</p>
+      <div class="rubric-protocol">
+        <h3>MX</h3>
+        <p>Mail Exchanger records. The servers that accept inbound mail for your domain, with provider detection. Informational only.</p>
+      </div>
+      <div class="rubric-protocol">
+        <h3><a href="/learn/security-txt">security.txt</a></h3>
+        <p>A published, machine-readable contact for reporting security issues (RFC 9116). Reported, not graded.</p>
+      </div>
+      <div class="rubric-protocol">
+        <h3><a href="/learn/tls-rpt">TLS-RPT</a></h3>
+        <p>SMTP TLS Reporting. A reporting address that receives diagnostics when inbound mail fails to negotiate TLS. Reported, not graded.</p>
+      </div>
+      <div class="rubric-protocol">
+        <h3>DNSSEC</h3>
+        <p>DNS Security Extensions. Cryptographic signatures that protect your zone's records from tampering in transit. Reported, not graded.</p>
+      </div>
+      <div class="rubric-protocol">
+        <h3>DANE/TLSA</h3>
+        <p>DNS-based Authentication of Named Entities. TLSA records that pin your mail server's certificate to DNS. Reported, not graded.</p>
       </div>
     </div>
   </div>

--- a/src/views/styles.ts
+++ b/src/views/styles.ts
@@ -216,6 +216,10 @@ h1.tagline, .tagline { color: var(--clr-text-dim); font-size: 1.1rem; font-weigh
   margin: 0 auto 1.75rem; max-width: 680px;
   text-align: center; color: var(--clr-text-dim);
 }
+.landing-explainer > p.explainer-note {
+  margin: -0.75rem auto 1.25rem; max-width: 620px;
+  font-size: 0.82rem; color: var(--clr-text-muted);
+}
 .explainer-grid {
   display: grid; gap: 0.85rem; grid-template-columns: repeat(3, 1fr);
   margin: 0;
@@ -718,6 +722,11 @@ h1.domain-name, .domain-name { font-size: 1.5rem; font-weight: 700; margin: 0; }
   display: inline-flex; align-items: center; justify-content: center;
   width: 36px; height: 28px; border-radius: 6px; font-weight: 700; font-size: 0.85rem;
 }
+.rubric-subhead {
+  margin: 4px 0 6px; font-size: 0.82rem; font-weight: 600;
+  color: var(--clr-text-dim);
+}
+.rubric-subhead:not(:first-child) { margin-top: 18px; }
 .rubric-protocol { padding: 10px 0; border-bottom: 1px solid var(--clr-border-subtle); }
 .rubric-protocol:last-child { border-bottom: none; }
 .rubric-protocol h3 { font-size: 0.9rem; font-weight: 600; color: var(--clr-accent); margin-bottom: 4px; }
@@ -970,7 +979,7 @@ h1.domain-name, .domain-name { font-size: 1.5rem; font-weight: 700; margin: 0; }
   .landing-hero { padding: 1.5rem 1rem; }
   .landing-explainer { padding: 2.5rem 1rem 2rem; }
   .explainer-grid { grid-template-columns: repeat(2, 1fr); gap: 0.75rem; }
-  .explainer-grid > div:last-child { grid-column: 1 / -1; }
+  .explainer-grid > div:nth-child(odd):last-child { grid-column: 1 / -1; }
   .search-box { flex-direction: column; border-radius: 12px; }
   .search-box button { padding: 14px; }
   .report { padding: 1rem; }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -594,6 +594,41 @@ describe("HTML head tags", () => {
     expect(html).toContain('<dt><a href="/learn/mta-sts">MTA-STS</a></dt>');
   });
 
+  it("landing explainer lists every checked protocol, not just the graded set", async () => {
+    const res = await app.request("/");
+    const html = await res.text();
+    // Copy must not hardcode a protocol count (issue #453).
+    expect(html).not.toMatch(/\b(five|5)\s+protocols\b/i);
+    // The non-graded protocols must also appear in the inventory.
+    expect(html).toContain("<dt>MX</dt>");
+    expect(html).toContain(
+      '<dt><a href="/learn/security-txt">security.txt</a></dt>',
+    );
+    expect(html).toContain('<dt><a href="/learn/tls-rpt">TLS-RPT</a></dt>');
+    expect(html).toContain("<dt>DNSSEC</dt>");
+    expect(html).toContain("<dt>DANE/TLSA</dt>");
+    // The lead prose should still surface the SEO keyword targets.
+    expect(html).toContain("DMARC");
+    expect(html).toContain("MTA-STS");
+  });
+
+  it("/scoring heading is count-agnostic and lists every checked protocol", async () => {
+    const res = await app.request("/scoring");
+    const html = await res.text();
+    // Copy must not hardcode a protocol count anywhere on the page
+    // (issue #453: keep it from going stale again).
+    expect(html).not.toMatch(/\b(five|5)\s+protocols\b/i);
+    expect(html).toContain("The protocols we check");
+    // Non-graded protocols are present and distinguished from the graded set.
+    expect(html).toContain("<h3>MX</h3>");
+    expect(html).toContain(
+      '<h3><a href="/learn/security-txt">security.txt</a></h3>',
+    );
+    expect(html).toContain('<h3><a href="/learn/tls-rpt">TLS-RPT</a></h3>');
+    expect(html).toContain("<h3>DNSSEC</h3>");
+    expect(html).toContain("<h3>DANE/TLSA</h3>");
+  });
+
   it("/scoring cross-links each protocol heading to its /learn page", async () => {
     const res = await app.request("/scoring");
     const html = await res.text();


### PR DESCRIPTION
Closes #453

## What & why

dmarcheck now checks 10 protocols (DMARC, SPF, DKIM, BIMI, MTA-STS, MX, security.txt, TLS-RPT, DNSSEC, DANE/TLSA), but two user-facing surfaces still advertised only five. This corrects the stale inventory so our own copy matches what the scanner does.

## Changes (scoped exactly to the issue)

- **Landing `#what-we-check`** (`src/views/html.ts`): expanded the prose and the `<dl>` grid to list all 10 protocols. Each protocol links to its `/learn` page only where one exists (DMARC/SPF/DKIM/BIMI/MTA-STS/security-txt/tls-rpt); MX/DNSSEC/DANE render as plain text (no dead links). Added a count-agnostic note naming the graded protocols.
- **`/scoring` rubric card** (`src/views/html.ts`): renamed "The five protocols" → "The protocols we check" and split the card into a graded group and a "checked but not graded" group. No hardcoded count anywhere.
- **`PROTO_LABELS`** (`src/views/components.ts`): added a defensive `dane: "DANE/TLSA"` entry (matches the source-of-truth `PROTOCOL_LABEL`). DANE is never scored and never enters `protocolSummaries`, and `scoreSnippet` already has a `?? key` fallback — so this is display-only and changes **no grade behavior**.
- **CSS** (`src/views/styles.ts`): minor styles for the new `.explainer-note` / `.rubric-subhead` classes, plus a `:nth-child(odd):last-child` fix so the now-even mobile grid doesn't orphan-span its last cell.
- **Tests** (`test/index.test.ts`): 2 new regression tests asserting the full inventory on both surfaces and that neither hardcodes a "five protocols" count (regex guard, so it won't quietly go stale again).

## Accuracy note (issue premise is partly stale)

The issue and `CLAUDE.md` both say "DNSSEC is scored only when enabled via `SCORING_CONFIG`." I verified against `src/shared/scoring.ts`: there is **no DNSSEC knob in `ScoringConfig`** and `resolveScoring` only ever touches DMARC/SPF/DKIM/BIMI/MTA-STS. DANE is absent from scoring entirely. So I wrote the copy conservatively — DNSSEC and DANE are presented as **checked and reported, not graded** — per the issue constraint "don't claim DANE/DNSSEC affect the grade unless they actually do." If DNSSEC grading is intended to be configurable, that's a code gap to track separately, not something the copy should pre-announce.

## Verification

- `npm test` → **1185 passing, 0 failing** (73 files; +2 new regression tests)
- `npm run lint` → clean (152 files, no fixes applied)
- `npm run typecheck` → clean
- Rendered HTML confirmed by curling a dev server built from this worktree: landing grid shows all 10 entries with correct link discipline; `/scoring` shows "The protocols we check" with the graded/non-graded split and no "five". (Browser screenshot was blocked — the preview MCP runs `npm run dev` from the main checkout, not this worktree — but the integration tests exercise the identical server-render path.)

## Out of scope (follow-ups noticed)

The same stale "5 protocols" copy lives in other files the issue explicitly excluded: `src/views/html.ts:46,152,465,536`, `pricing.ts`, `markdown.ts`, `learn.ts`, `openapi.ts`, `mcp/handler.ts`, `llms-txt.ts`. Untouched here; worth a follow-up issue to align them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)