### PR TITLE
docs: open-ended learn-hub description in llms.txt

### DIFF
--- a/src/api/llms-txt.ts
+++ b/src/api/llms-txt.ts
@@ -18,7 +18,7 @@ export function buildLlmsTxt(origin: string = CANONICAL_ORIGIN): string {
 ## Docs
 
 - [Landing page](${origin}/?format=md): What dmarcheck does, how to scan a domain, rate limits.
-- [Learn hub](${origin}/learn?format=md): Plain-English explainers for DMARC, SPF, DKIM, BIMI, and MTA-STS.
+- [Learn hub](${origin}/learn?format=md): Plain-English explainers for the email security DNS records dmarcheck covers — DMARC, SPF, DKIM, BIMI, MTA-STS, and more.
 - [Scoring rubric](${origin}/scoring?format=md): How the letter grade is computed and which factors weigh most.
 - [Pricing](${origin}/pricing?format=md): Free tier and Pro plan limits.
 


### PR DESCRIPTION
## What

Update the `/llms.txt` learn-hub bullet ([src/api/llms-txt.ts:21](src/api/llms-txt.ts)) so it no longer implies a closed 5-protocol set.

**Before:**
> Plain-English explainers for DMARC, SPF, DKIM, BIMI, and MTA-STS.

**After:**
> Plain-English explainers for the email security DNS records dmarcheck covers — DMARC, SPF, DKIM, BIMI, MTA-STS, and more.

## Why

The learn hub already covers more than five protocols. On `main` it lists **7** (`LEARN_SIBLINGS` in `src/views/learn.ts` and `renderLearnHubMarkdown()` in `src/views/markdown.ts`: DMARC, SPF, DKIM, BIMI, MTA-STS, security.txt, TLS-RPT), and DNSSEC + DANE pages add two more once [#464](https://github.com/schmug/dmarcheck/pull/464) merges.

I used an **open-ended** description rather than a hard list of 7 or 9 deliberately, because #464 is still **open** — a fixed count would be stale either now (it would say 7 but #464 lands soon) or premature (saying 9 before #464 merges). The open-ended phrasing mirrors the H1 already used in `src/views/markdown.ts` (`Learn — email security DNS records`) and stays correct regardless of how many protocols the hub covers.

Scoped to `src/api/llms-txt.ts` only. The blockquote on line 16 is intentionally untouched — it describes which protocols feed the letter **grade**, a different claim from what the learn hub covers.

## Tests

No test asserts the parenthetical text. `test/llms-txt.test.ts` checks structure and that every advertised `https://dmarc.mx` URL resolves; the change adds no bare URL, so nothing needed updating.

- `npm test` — 1183 passing, 0 failing
- `npm run lint` — clean
- `npm run typecheck` — clean

No open issue tracks this; nothing to `Closes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
