### PR TITLE
fix: correct sigstore/cosign-installer pinned SHA in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,7 @@ jobs:
             "dmarcheck-${VERSION}.zip" > SHA256SUMS
 
       - name: Install cosign (Sigstore)
-        uses: sigstore/cosign-installer@11606fdb78ecbf8504a2bf72df938fc4c43bfedd # v3.8.1
+        uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
 
       - name: Sign SHA256SUMS with Sigstore keyless signing
         run: |


### PR DESCRIPTION
## Problem

The [Release run](https://github.com/schmug/dmarcheck/actions/runs/26862977402) failed at **Set up job** with:

> Unable to resolve action \`sigstore/cosign-installer@11606fdb78ecbf8504a2bf72df938fc4c43bfedd\`, unable to find version \`11606fdb78ecbf8504a2bf72df938fc4c43bfedd\`

The SHA pinned for `cosign-installer` in [release.yml:135](.github/workflows/release.yml#L135) (introduced in #428) **does not exist** in `sigstore/cosign-installer` — `GET /commits/11606fdb…` returns `422 No commit found`. The `# v3.8.1` comment was correct; the SHA beside it was not.

## Fix

Repinned to the real commit SHA that the `v3.8.1` tag points to:

```
sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
```

Verified by dereferencing the annotated tag `refs/tags/v3.8.1` → commit `d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a` (confirmed resolvable via the API). Keeps the full-SHA pin + version comment per the repo's action-pinning invariant.

## Test plan

- [x] Confirmed the old SHA returns `422 No commit found`
- [x] Confirmed the new SHA resolves and matches the `v3.8.1` tag
- [ ] Next push to `main` runs Release cleanly through the cosign step

🤖 Generated with [Claude Code](https://claude.com/claude-code)