### PR TITLE
docs: sweep stale "5 protocols" copy across pricing, OpenAPI, MCP, and SEO surfaces

### DIFF
--- a/src/api/openapi.ts
+++ b/src/api/openapi.ts
@@ -29,7 +29,8 @@ export const OPENAPI_DOCUMENT = {
   info: {
     title: "dmarcheck API",
     version: "1.0.0",
-    summary: "DNS email-security (DMARC, SPF, DKIM, BIMI, MTA-STS) scanner.",
+    summary:
+      "DNS email-security scanner (DMARC, SPF, DKIM, BIMI, MTA-STS, MX, security.txt, TLS-RPT, DNSSEC, DANE).",
     description:
       "Public, unauthenticated API that grades a domain's email-security DNS posture. Rate-limited to 10 requests per minute per IP.",
     license: { name: "MIT", identifier: "MIT" },
@@ -41,7 +42,7 @@ export const OPENAPI_DOCUMENT = {
       get: {
         summary: "Scan a domain's email-security posture",
         description:
-          "Runs DMARC, SPF, DKIM, BIMI, MTA-STS, and MX analyzers in parallel and returns a graded result. Results are cached for a short period.",
+          "Runs all analyzers (DMARC, SPF, DKIM, BIMI, MTA-STS, MX, security.txt, TLS-RPT, DNSSEC, DANE) in parallel and returns a graded result. Results are cached for a short period.",
         operationId: "scanDomain",
         parameters: [
           {

--- a/src/mcp/handler.ts
+++ b/src/mcp/handler.ts
@@ -25,7 +25,7 @@ export const MCP_SERVER_CARD = JSON.stringify({
   name: "dmarcheck",
   version: "1.0.0",
   description:
-    "DNS email-security scanner (DMARC, SPF, DKIM, BIMI, MTA-STS, MX). Rate-limited to 10 req/IP/60s.",
+    "DNS email-security scanner (DMARC, SPF, DKIM, BIMI, MTA-STS, MX, security.txt, TLS-RPT, DNSSEC, DANE). Rate-limited to 10 req/IP/60s.",
   url: "https://dmarc.mx/mcp",
   tools: [{ name: "scan_domain" }],
 });
@@ -33,7 +33,7 @@ export const MCP_SERVER_CARD = JSON.stringify({
 const SCAN_DOMAIN_TOOL = {
   name: "scan_domain",
   description:
-    "Analyse a domain's email-security DNS posture (DMARC, SPF, DKIM, BIMI, MTA-STS, MX) and return a graded result. Equivalent to GET /api/check.",
+    "Analyse a domain's email-security DNS posture (DMARC, SPF, DKIM, BIMI, MTA-STS, MX, security.txt, TLS-RPT, DNSSEC, DANE) and return a graded result. Equivalent to GET /api/check.",
   inputSchema: {
     type: "object",
     required: ["domain"],

--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -43,7 +43,7 @@ import {
 
 export const SITE_ORIGIN = "https://dmarc.mx";
 export const DEFAULT_DESCRIPTION =
-  "Free, open-source DNS email security analyzer. Check DMARC, SPF, DKIM, BIMI, and MTA-STS records for any domain.";
+  "Free, open-source DNS email security analyzer. Check DMARC, SPF, DKIM, BIMI, MTA-STS, and more for any domain.";
 
 interface PageOptions {
   title: string;
@@ -149,7 +149,7 @@ export function renderLandingPage(): string {
     <div class="landing-nav">${navLoginButton()}</div>
     <div class="landing-main">
       <div class="logo">${generateCreature("lg")}<span class="logo-text">dmar<span>check</span></span></div>
-      <h1 class="tagline">DNS email security analyzer &mdash; DMARC, SPF, DKIM, BIMI &amp; MTA-STS</h1>
+      <h1 class="tagline">DNS email security analyzer &mdash; DMARC, SPF, DKIM, BIMI &amp; more</h1>
       <form action="/check" method="GET">
         <div class="search-box">
           <input type="text" name="domain" placeholder="Enter a domain (e.g., google.com)" aria-label="Enter a domain" autocapitalize="none" autocorrect="off" spellcheck="false" autofocus required>
@@ -468,7 +468,7 @@ export function renderReport(result: ScanResult): string {
   return page({
     title: `${result.domain} DMARC report — Free check | dmarcheck`,
     path: `/check?domain=${encodeURIComponent(result.domain)}`,
-    description: `Free, open-source DMARC, SPF, DKIM, BIMI, and MTA-STS check for ${result.domain}. See the current grade, records, and fixes. No signup, no email required.`,
+    description: `Free, open-source DMARC, SPF, DKIM, BIMI, MTA-STS, and more for ${result.domain}. See the current grade, records, and fixes. No signup, no email required.`,
     noindex: !isIndexableScanDomain(result.domain),
     body: reportBody(result),
   });
@@ -539,7 +539,7 @@ export function renderStreamingLoading(
   return page({
     title: `${domain} DMARC report — Free check | dmarcheck`,
     path: `/check?domain=${encodeURIComponent(domain)}`,
-    description: `Free, open-source DMARC, SPF, DKIM, BIMI, and MTA-STS check for ${domain}. See the current grade, records, and fixes. No signup, no email required.`,
+    description: `Free, open-source DMARC, SPF, DKIM, BIMI, MTA-STS, and more for ${domain}. See the current grade, records, and fixes. No signup, no email required.`,
     noindex: !isIndexableScanDomain(domain),
     body: `<main class="report" data-qs="${esc(qs)}">
   <div class="report-nav">

--- a/src/views/markdown.ts
+++ b/src/views/markdown.ts
@@ -386,7 +386,7 @@ Run a scan: ${MD_SITE}/check?domain=example.com
 }
 
 export function renderPricingMarkdown(): string {
-  return `# Nightly DMARC, SPF, DKIM, BIMI & MTA-STS monitoring
+  return `# Nightly email-security monitoring — DMARC, SPF, DKIM & more
 
 **$19/mo.** Free forever for one-off scans.
 
@@ -397,7 +397,7 @@ Public scanner, no account needed.
 - Unlimited on-demand scans from the web UI
 - JSON API: \`GET /api/check?domain=example.com\`
 - 10 requests per minute per IP
-- All five analyzers: DMARC, SPF, DKIM, BIMI, MTA-STS
+- All analyzers: DMARC, SPF, DKIM, BIMI, MTA-STS, MX, security.txt, TLS-RPT, DNSSEC, DANE
 - Self-hostable (MIT) — <https://github.com/schmug/dmarcheck>
 
 ## Pro — $19/mo
@@ -418,7 +418,7 @@ Continuous monitoring for the domains you actually care about.
 
 ## FAQ
 
-- **Does the free scanner stay free?** Yes. The scanner, all five analyzers, and the JSON API stay free and open source. Pro adds hosted features — history, monitoring, alerts — not the scan itself.
+- **Does the free scanner stay free?** Yes. The scanner, all its analyzers, and the JSON API stay free and open source. Pro adds hosted features — history, monitoring, alerts — not the scan itself.
 - **What counts as "nightly"?** Once every 24 hours, in the early-UTC-morning window. Every domain on your watchlist gets re-scanned; if the grade drops or a protocol regresses versus the previous scan, you get an email.
 - **How do I cancel?** One click in the Stripe Customer Portal, linked from your account page. You keep access until the end of the current billing cycle and aren't charged again.
 - **Refunds?** Yes — email support@dmarc.mx within 30 days of the charge for a full refund. After 30 days, cancel at period end.

--- a/src/views/pricing.ts
+++ b/src/views/pricing.ts
@@ -8,7 +8,7 @@ const PRICING_JSON_LD = JSON.stringify({
       "@type": "Product",
       name: "dmarcheck Pro",
       description:
-        "Nightly monitoring for your domains' DMARC, SPF, DKIM, BIMI, and MTA-STS posture. Saved history, grade-drop email alerts, bulk scan, and a higher-rate API key.",
+        "Nightly email-security monitoring for your domains — DMARC, SPF, DKIM, BIMI, MTA-STS, and more. Saved history, grade-drop email alerts, bulk scan, and a higher-rate API key.",
       brand: { "@type": "Brand", name: "dmarcheck" },
       offers: {
         "@type": "Offer",
@@ -33,7 +33,7 @@ const PRICING_JSON_LD = JSON.stringify({
           name: "Does the free scanner stay free?",
           acceptedAnswer: {
             "@type": "Answer",
-            text: "Yes. The scanner, all five analyzers, and the JSON API stay free and open source. Pro adds hosted features — history, monitoring, alerts — not the scan itself.",
+            text: "Yes. The scanner, all its analyzers, and the JSON API stay free and open source. Pro adds hosted features — history, monitoring, alerts — not the scan itself.",
           },
         },
         {
@@ -79,7 +79,7 @@ export function renderPricingPage(): string {
     <a href="/">${generateCreature("sm")} Home</a>
   </div>
 
-  <h1 class="rubric-title">Nightly DMARC, SPF, DKIM, BIMI &amp; MTA-STS monitoring</h1>
+  <h1 class="rubric-title">Nightly email-security monitoring &mdash; DMARC, SPF, DKIM &amp; more</h1>
   <p class="rubric-intro"><strong>$19/mo.</strong> Free forever for one-off scans.</p>
 
   <div class="bd-card">
@@ -90,7 +90,7 @@ export function renderPricingPage(): string {
         <li>Unlimited on-demand scans from the web UI</li>
         <li>JSON API: <code>GET /api/check?domain=example.com</code></li>
         <li>10 requests per minute per IP</li>
-        <li>All five analyzers: DMARC, SPF, DKIM, BIMI, MTA-STS</li>
+        <li>All analyzers: DMARC, SPF, DKIM, BIMI, MTA-STS, MX, security.txt, TLS-RPT, DNSSEC, DANE</li>
         <li>Self-hostable &mdash; MIT-licensed, <a href="https://github.com/schmug/dmarcheck">clone &amp; run your own</a></li>
       </ul>
     </div>
@@ -122,7 +122,7 @@ export function renderPricingPage(): string {
     <div class="bd-card-body">
       <div class="rubric-protocol">
         <h3>Does the free scanner stay free?</h3>
-        <p>Yes. The scanner, all five analyzers, and the JSON API stay free and open source. Pro adds hosted features &mdash; history, monitoring, alerts &mdash; not the scan itself.</p>
+        <p>Yes. The scanner, all its analyzers, and the JSON API stay free and open source. Pro adds hosted features &mdash; history, monitoring, alerts &mdash; not the scan itself.</p>
       </div>
       <div class="rubric-protocol">
         <h3>What counts as "nightly"?</h3>
@@ -162,7 +162,7 @@ export function renderPricingPage(): string {
     title: "Pricing — dmarcheck",
     path: "/pricing",
     description:
-      "Nightly DMARC, SPF, DKIM, BIMI & MTA-STS monitoring for $19/mo. Free forever for one-off scans. Cancel anytime via Stripe.",
+      "Nightly email-security monitoring (DMARC, SPF, DKIM, BIMI, MTA-STS and more) for $19/mo. Free forever for one-off scans. Cancel anytime via Stripe.",
     jsonLd: PRICING_JSON_LD,
     body,
   });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -782,7 +782,7 @@ describe("/check meta tags and noindex gating", () => {
     expect(res.status).toBe(200);
     const html = await res.text();
     expect(html).toContain(
-      'content="Free, open-source DMARC, SPF, DKIM, BIMI, and MTA-STS check for github.com. See the current grade, records, and fixes. No signup, no email required."',
+      'content="Free, open-source DMARC, SPF, DKIM, BIMI, MTA-STS, and more for github.com. See the current grade, records, and fixes. No signup, no email required."',
     );
   });
 

--- a/test/pricing-legal.test.ts
+++ b/test/pricing-legal.test.ts
@@ -27,7 +27,8 @@ describe("pricing page", () => {
     const res = await app.request("/pricing");
     const html = await res.text();
     expect(html).toContain("$19/mo");
-    expect(html).toContain("Nightly DMARC, SPF, DKIM, BIMI");
+    expect(html).toContain("Nightly email-security monitoring");
+    expect(html).toContain("DMARC");
     expect(html).toContain("MTA-STS");
   });
 
@@ -64,7 +65,7 @@ describe("pricing page", () => {
     );
     const body = await res.text();
     expect(body).toContain("$19/mo");
-    expect(body).toContain("Nightly DMARC");
+    expect(body).toContain("Nightly email-security monitoring");
     expect(body).not.toMatch(/\[PLACEHOLDER/);
   });
 


### PR DESCRIPTION
## Summary

- Replace every user- and machine-facing enumeration that implied the scanner covers only five graded protocols (DMARC, SPF, DKIM, BIMI, MTA-STS) with either the full 10-protocol list or non-exhaustive "…and more" phrasing for short taglines.
- Source of truth: `PROTOCOL_LABEL` in `src/orchestrator.ts:53-64` (10 protocols: dmarc, spf, dkim, bimi, mta_sts, mx, security_txt, tls_rpt, dnssec, dane).
- No analyzer, scoring, or orchestrator behavior changed; copy/labels only.

## Surfaces updated

| File | What changed |
|------|-------------|
| `src/views/pricing.ts` | h1 tagline, free-tier list item, two FAQ answers, JSON-LD product description, page meta description |
| `src/views/markdown.ts` | Pricing/FAQ markdown mirror (h1, list item, FAQ answer) |
| `src/api/openapi.ts` | `info.summary` and `/api/check` operation description |
| `src/mcp/handler.ts` | MCP server card description + `scan_domain` tool description |
| `src/views/html.ts` | `DEFAULT_DESCRIPTION`, landing h1 tagline, per-result page SEO descriptions (both streaming and static) |

## Test plan

- [x] `npm test` — 1199 passing, 0 failing (1 pre-existing network integration test excluded)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] Acceptance grep `grep -rniE "five|DMARC.{0,4}SPF.{0,4}DKIM.{0,8}BIMI.{0,12}MTA" src/` returns only intentional graded-specific uses (scoring code, `html.ts:197-198` graded/contextual split, scoring page, `llms-txt.ts` "Grades a domain's…") and the updated strings that now include "and more" or the full list

## Closes

Closes #467

## Deferred

None — all Acceptance items shipped.

https://claude.ai/code/session_01AhshrnTUHFdmr762tftCXR

---
_Generated by [Claude Code](https://claude.ai/code/session_01AhshrnTUHFdmr762tftCXR)_