### PR TITLE
🎨 Palette: Add generic `data-loading-text` support for submit buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -18,3 +18,7 @@
 ## 2026-06-01 - Add aria-sort to sortable headers
 **Learning:** Sortable headers should be marked with the aria-sort attribute so that screen readers are aware of the order.
 **Action:** When creating sortable headers, ensure that only the active sorting header is marked with the aria-sort attribute.
+
+## 2026-06-04 - Add generic data-loading-text support for form submission buttons
+**Learning:** Implementing visual feedback (like 'Scanning...' or 'Adding...') on submit buttons often requires custom JS per form. By leveraging a centralized, opt-in `data-loading-text` attribute handled by a single global event listener, we can add consistent, accessible loading states across the application without polluting individual views with duplicated scripts.
+**Action:** For form submit buttons triggering slow or async operations, prefer adding a `data-loading-text` attribute (e.g., `data-loading-text="Scanning..."`) to the `<button type="submit">`. This hooks into the global form submission listener in `src/views/scripts.ts` to automatically handle disabled states and text updates.

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -2001,7 +2001,7 @@ function renderAddDomainWizardShell(): string {
       <button type="button" class="wizard-secondary" data-wizard-back hidden>Back</button>
       <span style="flex:1"></span>
       <button type="button" class="wizard-primary" data-wizard-next>Next</button>
-      <button type="submit" class="wizard-primary" data-wizard-submit hidden>Add domain</button>
+      <button type="submit" class="wizard-primary" data-wizard-submit hidden data-loading-text="Adding...">Add domain</button>
     </div>
   </form>
 </div>`;
@@ -2332,7 +2332,7 @@ export function renderDomainDetailPage({
 </div>
 <div class="action-row" style="margin-bottom:1.5rem">
   <form method="POST" action="/dashboard/domain/${encodeURIComponent(domain)}/scan" style="display:inline">
-    <button type="submit" class="btn">Scan Now</button>
+    <button type="submit" class="btn" data-loading-text="Scanning...">Scan Now</button>
   </form>
   <a href="/check?domain=${encodeURIComponent(domain)}" class="btn btn-secondary">View Full Report</a>
   <form method="POST" action="/dashboard/domain/${encodeURIComponent(domain)}/delete" style="display:inline" onsubmit="return confirm('Stop monitoring ${esc(domain)}?');">
@@ -2561,7 +2561,7 @@ ${usageBlock}
     We'll run a full DMARC/SPF/DKIM/BIMI/MTA-STS scan and notify you if the grade drops.
   </p>
   <div class="action-row">
-    <button type="submit" class="btn"${submitDisabled}>Add Domain</button>
+    <button type="submit" class="btn"${submitDisabled} data-loading-text="Adding...">Add Domain</button>
     <a href="/dashboard" class="btn btn-secondary">Cancel</a>
   </div>
 </form>`;
@@ -2690,7 +2690,7 @@ ${errorBlock}
     aria-describedby="bulk-help"
   ></textarea>
   <div class="action-row">
-    <button type="submit" class="btn">Scan</button>
+    <button type="submit" class="btn" data-loading-text="Scanning...">Scan</button>
     <a href="/dashboard" class="btn btn-secondary">Cancel</a>
   </div>
 </form>
@@ -3023,7 +3023,7 @@ ${justCreatedBanner}
     <label for="api-key-name" style="display:block;font-size:0.875rem;color:var(--clr-text-muted);margin-bottom:0.4rem">Label (optional)</label>
     <input id="api-key-name" class="settings-input" type="text" name="name" placeholder="ci-pipeline" maxlength="60" autocapitalize="none" autocorrect="off" spellcheck="false" aria-describedby="api-keys-help">
     <div class="action-row">
-      <button type="submit" class="btn">Generate API Key</button>
+      <button type="submit" class="btn" data-loading-text="Generating...">Generate API Key</button>
       <a href="/dashboard/settings" class="btn btn-secondary">Back to Settings</a>
     </div>
   </form>

--- a/src/views/scripts.ts
+++ b/src/views/scripts.ts
@@ -61,29 +61,41 @@ if (!window.__dmarcheckBound) {
   });
 
   document.addEventListener('submit', function(e) {
-    var form = e.target.closest('form[action="/check"]');
+    var form = e.target.closest('form');
     if (!form) return;
     var btn = form.querySelector('button[type="submit"]');
     if (btn) {
-      btn.disabled = true;
-      btn.textContent = 'Scanning...';
+      var loadingText = btn.getAttribute('data-loading-text');
+      if (loadingText) {
+        /* Generic loading state for any button that opts in */
+        btn.disabled = true;
+        btn.textContent = loadingText;
+      } else if (form.getAttribute('action') === '/check') {
+        /* Legacy hardcoded state for the homepage /check form */
+        btn.disabled = true;
+        btn.textContent = 'Scanning...';
+      }
     }
-    var landing = document.querySelector('.landing-main');
-    if (landing) {
-      var domain = form.querySelector('input[name="domain"]').value;
-      var wrapper = document.createElement('div');
-      wrapper.className = 'loading';
-      wrapper.setAttribute('role', 'status');
-      wrapper.setAttribute('aria-live', 'polite');
-      var spinner = document.createElement('div');
-      spinner.className = 'spinner';
-      spinner.setAttribute('aria-hidden', 'true');
-      var msg = document.createElement('p');
-      msg.textContent = 'Scanning ' + domain + '...';
-      wrapper.appendChild(spinner);
-      wrapper.appendChild(msg);
-      Array.from(landing.children).forEach(function(child) { child.style.display = 'none'; });
-      landing.appendChild(wrapper);
+
+    /* Specific UX for the homepage /check form (hides main, shows spinner) */
+    if (form.getAttribute('action') === '/check') {
+      var landing = document.querySelector('.landing-main');
+      if (landing) {
+        var domain = form.querySelector('input[name="domain"]').value;
+        var wrapper = document.createElement('div');
+        wrapper.className = 'loading';
+        wrapper.setAttribute('role', 'status');
+        wrapper.setAttribute('aria-live', 'polite');
+        var spinner = document.createElement('div');
+        spinner.className = 'spinner';
+        spinner.setAttribute('aria-hidden', 'true');
+        var msg = document.createElement('p');
+        msg.textContent = 'Scanning ' + domain + '...';
+        wrapper.appendChild(spinner);
+        wrapper.appendChild(msg);
+        Array.from(landing.children).forEach(function(child) { child.style.display = 'none'; });
+        landing.appendChild(wrapper);
+      }
     }
   });
 }


### PR DESCRIPTION
💡 What:
Added a generic `data-loading-text` attribute mechanism to the global form submit listener in `src/views/scripts.ts`. Also applied this attribute to 5 key action buttons in `src/views/dashboard.ts` (Add domain wizard, Add domain page, Scan now, Bulk scan, Generate API Key) that previously had no loading feedback.

🎯 Why:
To provide immediate visual feedback (e.g. "Scanning...", "Adding...") and prevent duplicate submissions when users trigger slower asynchronous operations.

📸 Before/After:
Before, clicking "Generate API Key" or "Scan" would leave the button visually unchanged while the server processed the request, causing potential confusion and double-clicks. After, the button instantly disables and changes to the specified loading text (e.g. "Generating...").

♿ Accessibility:
Disabling the button upon click prevents double form submissions and provides immediate, screen-reader-friendly state change feedback.

---
*PR created automatically by Jules for task [9151277271843833312](https://jules.google.com/task/9151277271843833312) started by @schmug*