### PR TITLE
security: verify pinned action SHAs resolve in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,39 @@ jobs:
       # Security tab, they just don't block PRs here. Tighten if the threat
       # model expands to cover developer machines.
       - run: npm audit --audit-level=high --omit=dev
+      # Action-pin integrity: verify every third-party SHA-pinned action in
+      # .github/workflows/** resolves to a real commit in its upstream repo.
+      # Catches typos and hallucinated pins before they reach a release run
+      # (the class of error that broke #469). Folded into the required `check`
+      # job so it always reports and never creates a merge-deadlock context.
+      - name: Verify pinned action SHAs resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          failed=0
+          while IFS= read -r pin; do
+            [ -z "$pin" ] && continue
+            action="${pin%@*}"
+            sha="${pin##*@}"
+            owner="${action%%/*}"
+            rest="${action#*/}"
+            repo="${rest%%/*}"
+            if gh api "repos/${owner}/${repo}/commits/${sha}" --silent > /dev/null 2>&1; then
+              echo "OK   ${owner}/${repo}@${sha}"
+            else
+              echo "FAIL ${owner}/${repo}@${sha} — SHA does not resolve in upstream repo"
+              failed=$((failed + 1))
+            fi
+          done < <(
+            grep -rhoE 'uses: [^ ]+@[0-9a-f]{40}' .github/workflows/ \
+              | sed 's/^uses: //' \
+              | grep -vE '^(\.\/|docker://)' \
+              | sort -u \
+              || true
+          )
+          if [ "$failed" -gt 0 ]; then
+            echo "::error::$failed pinned action SHA(s) do not resolve — fix or re-pin before merging."
+            exit 1
+          fi
+          echo "All pinned action SHAs resolve."


### PR DESCRIPTION
## Summary

- Adds a "Verify pinned action SHAs resolve" step to the required `check` job in `ci.yml`
- For every `uses: owner/repo[/path]@<40-hex>` reference across `.github/workflows/**`, calls `gh api repos/{owner}/{repo}/commits/{sha}` and fails if any returns non-2xx
- Folded into the existing required `check` job (not a separate job) so it always reports on every PR/push and never creates a merge-deadlock required-status-check context

Closes #470

## How it works

```
grep -rhoE 'uses: [^ ]+@[0-9a-f]{40}' .github/workflows/
  | strip "uses: " prefix
  | skip ./ and docker:// refs
  | sort -u
  → for each: gh api repos/{owner}/{repo}/commits/{sha}
              fail if non-2xx
```

Currently extracts 6 unique pinned refs (actions/checkout, actions/setup-node, taiki-e/install-action, sigstore/cosign-installer, github/codeql-action/init, github/codeql-action/analyze) and all resolve.

## Test plan

- [ ] CI `check` job green with current workflow pins (all valid post-#469)
- [ ] Confirm a deliberately bad SHA (e.g. all-zeros) would fail — the step exits non-zero if `gh api` returns 404/422
- [ ] Local (`./`), `docker://`, tag/branch refs produce no output and are silently skipped (no `@<40hex>` in the pattern → grep produces no match)
- [ ] `npm run lint` and `npm run typecheck` pass (YAML-only change)

## Deferred follow-ups

- None; all Acceptance items are shipped.

## Spec follow-up needed

No.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHN8DKaxysVFXokutTheMM)_