### PR TITLE
refactor: extract release skip-decision to a tested module

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,38 +22,13 @@ jobs:
           fetch-depth: 0
 
       # Detect whether all commits since the last tag are deps-only / chores.
-      # Skip patterns mirror cliff.toml commit_parsers with skip=true:
-      #   ^chore        covers chore:, chore(deps):, chore(deps-dev):, …
-      #   ^[Bb]ump      dependabot-style "Bump X from Y to Z"
-      #   ^Merge pull request / ^Merge branch  — merge commits
-      # If every commit since the last tag matches one of those patterns (or
-      # there are no new commits at all), set skip=true so the remaining steps
-      # are skipped and the job exits success without creating a tag or Release.
+      # Logic lives in scripts/release/releasable.ts; skip patterns mirror the
+      # cliff.toml commit_parsers with skip=true (a test fails if they drift).
       # Serial-number note: skipping a run leaves a gap in vYYYY.M.serial —
       # that is acceptable; the counter always counts existing tags.
       - name: Check for releasable commits
         id: check
-        run: |
-          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          if [ -z "$LAST_TAG" ]; then
-            # No prior tag — this is the first release, never skip.
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          else
-            COMMITS=$(git log "${LAST_TAG}..HEAD" --format='%s')
-            if [ -z "$COMMITS" ]; then
-              # No new commits since last tag — nothing to release.
-              echo "skip=true" >> "$GITHUB_OUTPUT"
-            else
-              NON_SKIP=$(echo "$COMMITS" | grep -vE '^(chore|[Bb]ump |Merge pull request|Merge branch)' || true)
-              if [ -z "$NON_SKIP" ]; then
-                echo "skip=true" >> "$GITHUB_OUTPUT"
-                echo "Skipping release — all commits since ${LAST_TAG} are deps/chore only:"
-                git log "${LAST_TAG}..HEAD" --format='  %s'
-              else
-                echo "skip=false" >> "$GITHUB_OUTPUT"
-              fi
-            fi
-          fi
+        run: npx --yes tsx@4 scripts/release/check-releasable.ts
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         if: steps.check.outputs.skip != 'true'

--- a/scripts/release/__tests__/releasable.test.ts
+++ b/scripts/release/__tests__/releasable.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { isReleasable, SKIP_PATTERN_SOURCES } from "../releasable.js";
+
+describe("isReleasable", () => {
+  it("returns true when there is no prior tag (first release)", () => {
+    expect(isReleasable(null)).toBe(true);
+  });
+
+  it("returns false when there are no new commits since the last tag", () => {
+    expect(isReleasable([])).toBe(false);
+  });
+
+  it("returns false when all commits are chore: prefixed", () => {
+    expect(isReleasable(["chore: update readme", "chore: cleanup"])).toBe(false);
+  });
+
+  it("returns false for chore(deps): (still starts with 'chore')", () => {
+    expect(isReleasable(["chore(deps): bump vitest from 3.0.0 to 4.0.0"])).toBe(false);
+  });
+
+  it("returns false for chore(deps-dev): (still starts with 'chore')", () => {
+    expect(isReleasable(["chore(deps-dev): bump typescript"])).toBe(false);
+  });
+
+  it("returns false when all commits are Bump-style (capital B)", () => {
+    expect(isReleasable(["Bump lodash from 1.0 to 2.0"])).toBe(false);
+  });
+
+  it("returns false when all commits are bump-style (lowercase b)", () => {
+    expect(isReleasable(["bump lodash from 1.0 to 2.0"])).toBe(false);
+  });
+
+  it("returns false for Merge pull request commits", () => {
+    expect(isReleasable(["Merge pull request #42 from owner/feature"])).toBe(false);
+  });
+
+  it("returns false for Merge branch commits", () => {
+    expect(isReleasable(["Merge branch 'feature/x' into main"])).toBe(false);
+  });
+
+  it("returns true when at least one commit is not a skip pattern (mixed set)", () => {
+    expect(
+      isReleasable([
+        "chore(deps): bump eslint",
+        "Bump lodash from 1.0 to 2.0",
+        "feat: add DNSBL analyzer",
+      ]),
+    ).toBe(true);
+  });
+
+  it("returns true when the only commit is a real feature commit", () => {
+    expect(isReleasable(["feat: add SPF strict mode"])).toBe(true);
+  });
+
+  it("'bumpversion' (no trailing space) is not a skip pattern", () => {
+    expect(isReleasable(["bumpversion"])).toBe(true);
+  });
+});
+
+describe("cliff.toml sync", () => {
+  it("SKIP_PATTERN_SOURCES matches all cliff.toml commit_parsers with skip = true", () => {
+    const toml = readFileSync(resolve(process.cwd(), "cliff.toml"), "utf8");
+    const cliffSkip = new Set<string>();
+    for (const line of toml.split("\n")) {
+      // Match lines like: { message = "^chore", skip = true },
+      const m = line.match(/\{ message = "([^"]+)"[^}]*skip = true/);
+      if (m) cliffSkip.add(m[1]);
+    }
+    const ourPatterns = new Set<string>(SKIP_PATTERN_SOURCES);
+    expect(ourPatterns).toEqual(cliffSkip);
+  });
+});

--- a/scripts/release/check-releasable.ts
+++ b/scripts/release/check-releasable.ts
@@ -1,0 +1,42 @@
+#!/usr/bin/env -S npx tsx
+import { execSync } from "node:child_process";
+import { appendFileSync } from "node:fs";
+import { isReleasable } from "./releasable.js";
+
+const lastTag = (() => {
+  try {
+    return execSync("git describe --tags --abbrev=0", {
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  } catch {
+    return "";
+  }
+})();
+
+const commits: string[] | null =
+  lastTag === ""
+    ? null
+    : execSync(`git log "${lastTag}..HEAD" --format=%s`, { encoding: "utf8" })
+        .split("\n")
+        .filter((s) => s.trim() !== "");
+
+const shouldSkip = !isReleasable(commits);
+
+const outputFile = process.env.GITHUB_OUTPUT ?? "";
+if (outputFile) {
+  appendFileSync(outputFile, `skip=${shouldSkip}\n`);
+}
+
+if (shouldSkip && commits !== null) {
+  console.log(`Skipping release — all commits since ${lastTag} are deps/chore only:`);
+  for (const c of commits) {
+    console.log(`  ${c}`);
+  }
+} else {
+  console.log(
+    lastTag
+      ? `Releasing — found releasable commits since ${lastTag}`
+      : "First release — no prior tag",
+  );
+}

--- a/scripts/release/releasable.ts
+++ b/scripts/release/releasable.ts
@@ -1,0 +1,27 @@
+// Skip-pattern strings mirroring cliff.toml commit_parsers with skip = true.
+// A drift-check test in __tests__/releasable.test.ts enforces these stay in sync.
+//   ^chore        covers chore:, chore(deps):, chore(deps-dev):, …
+//   ^[Bb]ump      dependabot-style "Bump X from Y to Z"
+//   ^Merge pull request / ^Merge branch  — merge commits
+// Serial-number note: skipping a run leaves a gap in vYYYY.M.serial — that is
+// acceptable; the counter always counts existing tags.
+export const SKIP_PATTERN_SOURCES = [
+  "^chore",
+  "^[Bb]ump ",
+  "^Merge pull request",
+  "^Merge branch",
+] as const;
+
+const SKIP = SKIP_PATTERN_SOURCES.map((s) => new RegExp(s));
+
+/**
+ * Returns true if the commit set should produce a release.
+ *   null → no prior tag; this is the first release → always releasable
+ *   []   → no new commits since last tag → not releasable (skip)
+ *   [...] → releasable iff at least one commit doesn't match every skip pattern
+ */
+export function isReleasable(commits: string[] | null): boolean {
+  if (commits === null) return true;
+  if (commits.length === 0) return false;
+  return commits.some((msg) => !SKIP.some((p) => p.test(msg)));
+}

--- a/scripts/release/tsconfig.json
+++ b/scripts/release/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- Extracts the inline bash releasable-commits check from `release.yml` into `scripts/release/releasable.ts`, which exports `isReleasable(commits: string[] | null)` and `SKIP_PATTERN_SOURCES`.
- A thin CLI wrapper `scripts/release/check-releasable.ts` handles git I/O and writes to `$GITHUB_OUTPUT`; the `release.yml` step calls it via `npx --yes tsx@4`.
- A cliff.toml drift test fails if `SKIP_PATTERN_SOURCES` and `cliff.toml`'s `skip = true` commit parsers go out of sync.

Closes #472

## Test plan

- [ ] `npm test`: 13 new tests pass — all `isReleasable()` scenarios (no-prior-tag, no-commits, all-chore, all-Bump, all-merge, mixed, `chore(deps):` edge, `bumpversion` non-skip edge) and the cliff.toml sync assertion
- [ ] `npm run typecheck`: clean
- [ ] `npm run lint`: clean
- [ ] Reasoning check: `isReleasable(["chore(deps): bump X"])` → `false` (skip); `isReleasable(["chore(deps): bump X", "feat: add Y"])` → `true` (release); `isReleasable(null)` → `true` (first release)
- [ ] Skip semantics preserved exactly — verified by test coverage matching the prior bash logic

## Acceptance deferred

None — all acceptance items shipped.

https://claude.ai/code/session_012UZfF6Pv3mP7QVn71PwivM

---
_Generated by [Claude Code](https://claude.ai/code/session_012UZfF6Pv3mP7QVn71PwivM)_