### PR TITLE
security: pin cosign CLI to v3.0.6 in release signing (supersedes #482)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,12 @@ jobs:
             "dmarcheck-${VERSION}.zip" > SHA256SUMS
 
       - name: Install cosign (Sigstore)
-        uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # Pin the cosign CLI explicitly so the signing binary can't silently
+          # drift on a future cosign-installer bump. v3.0.6 is installer
+          # v4.1.2's default; cosign 3.x requires installer v4+.
+          cosign-release: 'v3.0.6'
 
       - name: Sign SHA256SUMS with Sigstore keyless signing
         run: |


### PR DESCRIPTION
## What

Harden the Sigstore signing step in `.github/workflows/release.yml`:

- Bump `sigstore/cosign-installer` to **v4.1.2** (SHA-pinned `6f9f17788090df1f26f669e9d70d6ae9567deba6`).
- Add an explicit `cosign-release: 'v3.0.6'` input so the cosign CLI used to sign releases is pinned, not floated.

## Why

Today the installer step passes **no** `cosign-release`, so it installs whatever the installer defaults to. That default can change on any future `cosign-installer` bump — which means the binary that signs our release artifacts could silently drift to a new cosign major/minor without any change to our workflow. The release-signing path is rarely exercised, so such a drift could go unnoticed until a signature breaks or a behavior changes mid-release.

Pinning `cosign-release` freezes the signing binary explicitly. `v3.0.6` is installer v4.1.2's current default, so **this is a no-op for today's behavior** — it just locks it in.

## Why the installer bump rides along (supersedes #482)

[#482](https://github.com/schmug/dmarcheck/pull/482) bumps `cosign-installer` v3.8.1 → v4.1.2 on its own. cosign **3.x requires installer v4+** (that's the reason v4 exists), so the `cosign-release: 'v3.0.6'` pin is only valid once the installer is at v4.1.2. Adding the pin on the v3.x installer would break the signing step. To avoid an invalid intermediate state, this PR does **both in one commit** and therefore **supersedes #482**.

## Invariants preserved

- Action-pinning intact: full commit SHA + trailing `# v4.1.2` comment (per CLAUDE.md "Action pinning").
- No tag/branch refs introduced.
- `cosign-release: 'v3.0.6'` verified against installer v4.1.2's `action.yml` default.

## Verification

- v4.1.2 SHA confirmed: `gh api repos/sigstore/cosign-installer/git/ref/tags/v4.1.2` → `6f9f17788090df1f26f669e9d70d6ae9567deba6`.
- Installer v4.1.2 `action.yml` `cosign-release` default = `v3.0.6` (confirmed at the pinned SHA).
- Workflow YAML parses cleanly.

## Out of scope

No `cosign verify-blob` step, no release-verification docs, no other workflow/signing changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
