### PR TITLE
docs: refresh README cosign install path and minimum version for 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,14 +222,18 @@ itself — no long-lived private key is involved.
 
 ### Prerequisites
 
-Install [cosign](https://docs.sigstore.dev/cosign/system_config/installation/):
+Install [cosign](https://docs.sigstore.dev/cosign/system_config/installation/)
+(minimum **v2.4**; v3.x recommended):
 
 ```bash
 # macOS / Linux with Homebrew
 brew install cosign
 
-# or via Go
-go install github.com/sigstore/cosign/v2/cmd/cosign@latest
+# or via Go (installs the latest v3)
+go install github.com/sigstore/cosign/v3/cmd/cosign@latest
+
+# cosign v2.4+ also verifies the current bundle format if you prefer v2:
+# go install github.com/sigstore/cosign/v2/cmd/cosign@latest
 ```
 
 ### Verify a release


### PR DESCRIPTION
## Summary

- Updates the Go `install` path from `/v2/` to `/v3/` so copy-pasting installs the same cosign major version used for signing
- Adds `(minimum **v2.4**; v3.x recommended)` note so users know the minimum version required to verify the current Sigstore bundle format
- Keeps the v2 path as a commented alternative for users who prefer it (v2.4+ auto-detects the new bundle format)
- `verify-blob` command unchanged — no `--new-bundle-format` flag needed (cosign auto-detects)

Closes #491

## Test plan

- [x] README renders correctly — markdown is valid
- [x] `go install github.com/sigstore/cosign/v3/cmd/cosign@latest` resolves to cosign 3.x (current signer version)
- [x] `verify-blob` command block is unchanged (no flag additions)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests: 1213 passing / 1 pre-existing network-only integration test failure unrelated to this change

## Deferred follow-ups

- None — all acceptance criteria shipped

https://claude.ai/code/session_01YcHsCRqPR15Rcodpdajdpu

---
_Generated by [Claude Code](https://claude.ai/code/session_01YcHsCRqPR15Rcodpdajdpu)_