### PR TITLE
fix: dashboard scoreboard reflects the whole watchlist, not one page

### DIFF
--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -29,6 +29,8 @@ import {
   deleteDomain,
   getDomainByUserAndName,
   getDomainsByUser,
+  getGradeDistributionForUser,
+  getWorstGradedDomainForUser,
   listDomainsForUserPaged,
 } from "../db/domains.js";
 import {
@@ -386,12 +388,19 @@ dashboardRoutes.get("/", async (c) => {
   const db = (c.env as { DB: D1Database }).DB;
   const plan = await getPlanForUser(db, session.sub);
 
-  const [alerts, unackCounts, portfolioTrend, user] = await Promise.all([
-    listUnacknowledgedForUser(db, session.sub, 20),
-    countUnacknowledgedByDomain(db, session.sub),
-    getPortfolioTrendForUser(db, session.sub, 30),
-    getUserById(db, session.sub),
-  ]);
+  // distribution + worst are portfolio-wide aggregates (not per-page), so the
+  // hero, stat strip, and on-fire banner reflect the entire watchlist even
+  // when the Pro table below shows only one paginated page. distribution.total
+  // doubles as the usage count, so no separate countDomainsByUser is needed.
+  const [alerts, unackCounts, portfolioTrend, user, distribution, worst] =
+    await Promise.all([
+      listUnacknowledgedForUser(db, session.sub, 20),
+      countUnacknowledgedByDomain(db, session.sub),
+      getPortfolioTrendForUser(db, session.sub, 30),
+      getUserById(db, session.sub),
+      getGradeDistributionForUser(db, session.sub),
+      getWorstGradedDomainForUser(db, session.sub),
+    ]);
 
   // First-run = the user signed up within the last 24 hours and has exactly
   // one domain (the one auto-provisioned from their email suffix). The hero's
@@ -435,31 +444,27 @@ dashboardRoutes.get("/", async (c) => {
         controls: null,
         usage: {
           plan,
-          current: domains.length,
+          current: distribution.total,
           cap: watchlistCapFor(plan, user?.max_domains_override),
         },
+        stats: distribution,
+        worst,
       }),
     );
   }
 
   const query = parseDomainListQuery(new URL(c.req.url));
   const offset = (query.page - 1) * query.pageSize;
-  // Unfiltered watchlist count, separate from `page.total` (which respects
-  // the search/grade/frequency filters). The toolbar usage hint reflects
-  // the user's full watchlist regardless of what's currently filtered.
-  const [page, totalForUser] = await Promise.all([
-    listDomainsForUserPaged(db, {
-      userId: session.sub,
-      search: query.search || undefined,
-      grade: query.grade ?? undefined,
-      frequency: query.frequency ?? undefined,
-      sort: query.sort,
-      direction: query.direction,
-      limit: query.pageSize,
-      offset,
-    }),
-    countDomainsByUser(db, session.sub),
-  ]);
+  const page = await listDomainsForUserPaged(db, {
+    userId: session.sub,
+    search: query.search || undefined,
+    grade: query.grade ?? undefined,
+    frequency: query.frequency ?? undefined,
+    sort: query.sort,
+    direction: query.direction,
+    limit: query.pageSize,
+    offset,
+  });
 
   // Clamp out-of-range pages so a deep-linked stale URL doesn't render an
   // empty table when results exist.
@@ -496,9 +501,11 @@ dashboardRoutes.get("/", async (c) => {
       },
       usage: {
         plan,
-        current: totalForUser,
+        current: distribution.total,
         cap: watchlistCapFor(plan, user?.max_domains_override),
       },
+      stats: distribution,
+      worst,
     }),
   );
 });

--- a/src/db/domains.ts
+++ b/src/db/domains.ts
@@ -1,3 +1,5 @@
+import { type PortfolioStats, tallyGradeCounts } from "../shared/portfolio.js";
+
 export interface Domain {
   id: number;
   user_id: string;
@@ -61,6 +63,66 @@ export async function countDomainsByUser(
     .bind(userId)
     .first<{ n: number }>();
   return row?.n ?? 0;
+}
+
+// Portfolio-wide grade distribution for the dashboard scoreboard. One indexed
+// GROUP BY over the user's domains — returns counts, not rows — so the summary
+// reflects the entire watchlist regardless of which page the table is showing.
+export async function getGradeDistributionForUser(
+  db: D1Database,
+  userId: string,
+): Promise<PortfolioStats> {
+  const result = await db
+    .prepare(
+      "SELECT last_grade AS grade, COUNT(*) AS count FROM domains WHERE user_id = ? GROUP BY last_grade",
+    )
+    .bind(userId)
+    .all<{ grade: string | null; count: number }>();
+  return tallyGradeCounts(result.results);
+}
+
+// Worst-graded domain across the whole watchlist, for the hero's "triage X
+// first" line. Ordered worst→best (F lowest, S highest), tie-broken
+// alphabetically. Deliberately NOT GRADE_RANK_SQL: that table omits 'S' and so
+// ranks a perfect grade as worst — wrong for this query. Ungraded domains are
+// excluded so a freshly-added, never-scanned entry isn't mislabeled.
+const WORST_GRADE_ORDER_SQL = `CASE last_grade
+  WHEN 'S'  THEN 12
+  WHEN 'A+' THEN 11
+  WHEN 'A'  THEN 10
+  WHEN 'A-' THEN 9
+  WHEN 'B+' THEN 8
+  WHEN 'B'  THEN 7
+  WHEN 'B-' THEN 6
+  WHEN 'C+' THEN 5
+  WHEN 'C'  THEN 4
+  WHEN 'C-' THEN 3
+  WHEN 'D+' THEN 2
+  WHEN 'D'  THEN 1
+  WHEN 'D-' THEN 1
+  WHEN 'F'  THEN 0
+  ELSE 0
+END`;
+
+export interface WorstGradedDomain {
+  domain: string;
+  grade: string;
+}
+
+export async function getWorstGradedDomainForUser(
+  db: D1Database,
+  userId: string,
+): Promise<WorstGradedDomain | null> {
+  const row = await db
+    .prepare(
+      `SELECT domain, last_grade AS grade FROM domains
+       WHERE user_id = ? AND last_grade IS NOT NULL
+       ORDER BY ${WORST_GRADE_ORDER_SQL} ASC, domain ASC
+       LIMIT 1`,
+    )
+    .bind(userId)
+    .first<WorstGradedDomain>();
+  return row ?? null;
 }
 
 // Returns the subset of `domains` that the user already owns. Used by

--- a/src/shared/portfolio.ts
+++ b/src/shared/portfolio.ts
@@ -1,0 +1,44 @@
+// Portfolio-wide grade bucketing, shared by the dashboard view (which tallies
+// an in-hand list of domains) and the DB layer (which tallies grouped COUNT(*)
+// rows). Kept dependency-free so both layers can import it without dragging in
+// view or DB modules.
+
+export type GradeBucket = "healthy" | "drifting" | "failing" | "ungraded";
+
+export interface PortfolioStats {
+  total: number;
+  healthy: number;
+  drifting: number;
+  failing: number;
+  ungraded: number;
+}
+
+// Maps a letter grade to a portfolio bucket. S/A/B (with +/- modifiers) are
+// healthy, C/D are drifting, F is failing; null, the "—" placeholder, the
+// literal "ungraded", and anything unrecognized fall through to ungraded.
+export function gradeBucket(grade: string | null | undefined): GradeBucket {
+  if (!grade) return "ungraded";
+  const letter = grade.charAt(0).toUpperCase();
+  if (letter === "S" || letter === "A" || letter === "B") return "healthy";
+  if (letter === "C" || letter === "D") return "drifting";
+  if (letter === "F") return "failing";
+  return "ungraded";
+}
+
+export function emptyPortfolioStats(): PortfolioStats {
+  return { total: 0, healthy: 0, drifting: 0, failing: 0, ungraded: 0 };
+}
+
+// Folds grouped `{ grade, count }` rows (as returned by a
+// `GROUP BY last_grade` query) into a PortfolioStats tally.
+export function tallyGradeCounts(
+  rows: Iterable<{ grade: string | null; count: number }>,
+): PortfolioStats {
+  const stats = emptyPortfolioStats();
+  for (const row of rows) {
+    const n = row.count;
+    stats.total += n;
+    stats[gradeBucket(row.grade)] += n;
+  }
+  return stats;
+}

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -1,3 +1,8 @@
+import {
+  emptyPortfolioStats,
+  gradeBucket,
+  type PortfolioStats,
+} from "../shared/portfolio.js";
 import type { WebhookFormat } from "../webhooks/formats/index.js";
 import {
   esc,
@@ -1808,27 +1813,25 @@ function worstDomain(domains: DashboardDomain[]): DashboardDomain | null {
   return worst;
 }
 
-interface PortfolioStats {
-  total: number;
-  healthy: number;
-  drifting: number;
-  failing: number;
-  ungraded: number;
+// Minimal shape the hero needs from the worst-graded domain. Both the in-list
+// `worstDomain` (returns a full DashboardDomain) and the DB-backed override
+// (domain + grade only) satisfy it.
+interface HeroWorst {
+  domain: string;
+  grade: string;
 }
 
+// Tally an in-hand list of domains. Used for the free tier and dev fixtures
+// where `domains` is the user's complete watchlist; the Pro path passes a
+// portfolio-wide tally computed from an aggregate query instead (see the
+// `stats` override on renderDashboardPage).
 function portfolioStats(domains: DashboardDomain[]): PortfolioStats {
-  let healthy = 0;
-  let drifting = 0;
-  let failing = 0;
-  let ungraded = 0;
+  const stats = emptyPortfolioStats();
   for (const d of domains) {
-    const letter = d.grade.charAt(0).toUpperCase();
-    if (letter === "S" || letter === "A" || letter === "B") healthy += 1;
-    else if (letter === "C" || letter === "D") drifting += 1;
-    else if (letter === "F") failing += 1;
-    else ungraded += 1;
+    stats.total += 1;
+    stats[gradeBucket(d.grade)] += 1;
   }
-  return { total: domains.length, healthy, drifting, failing, ungraded };
+  return stats;
 }
 
 // Composes the DMarcus voice line for the hero in the "terse" register the
@@ -1837,7 +1840,7 @@ function portfolioStats(domains: DashboardDomain[]): PortfolioStats {
 // rendered as <code> via the markdown-ish hero-line lookup in render.
 function heroVoiceLine(
   stats: PortfolioStats,
-  worst: DashboardDomain | null,
+  worst: HeroWorst | null,
 ): {
   line: string;
   sub: string;
@@ -1905,7 +1908,7 @@ function renderOnFireBanner(failing: number): string {
 
 function renderDashboardHero(
   stats: PortfolioStats,
-  worst: DashboardDomain | null,
+  worst: HeroWorst | null,
   portfolioTrend: number[],
 ): string {
   // Mood comes from the worst *graded* domain. With nothing scored yet there
@@ -2051,6 +2054,8 @@ export function renderDashboardPage({
   plan = "pro",
   portfolioTrend = [],
   isFirstRun = false,
+  stats: statsOverride,
+  worst: worstOverride,
 }: {
   email: string;
   alerts?: DashboardAlert[];
@@ -2067,9 +2072,18 @@ export function renderDashboardPage({
   // True when the user just signed up and the only domain is the auto-
   // provisioned one from their email suffix. Drives the welcome banner.
   isFirstRun?: boolean;
+  // Portfolio-wide scoreboard inputs. Omit them when `domains` is the user's
+  // complete list (free tier, dev fixtures) and they're derived from it. Pass
+  // them when `domains` is a paginated subset (Pro) so the hero, stat strip,
+  // and on-fire banner reflect the whole watchlist, not just the visible page.
+  stats?: PortfolioStats;
+  worst?: HeroWorst | null;
 }): string {
-  const stats = portfolioStats(domains);
-  const worst = worstDomain(domains);
+  const stats = statsOverride ?? portfolioStats(domains);
+  // `!== undefined` (not `??`) so an explicit `null` override — "no graded
+  // domain in the whole watchlist" — wins over deriving from the page rows.
+  const worst =
+    worstOverride !== undefined ? worstOverride : worstDomain(domains);
   const banners: string[] = [];
   if (plan === "free") banners.push(renderFreeTierBanner());
   if (isFirstRun && domains.length === 1) {
@@ -2078,7 +2092,7 @@ export function renderDashboardPage({
   if (stats.failing >= 3) banners.push(renderOnFireBanner(stats.failing));
 
   const hero = renderDashboardHero(stats, worst, portfolioTrend);
-  const statStrip = domains.length > 0 ? renderDashboardStatStrip(stats) : "";
+  const statStrip = stats.total > 0 ? renderDashboardStatStrip(stats) : "";
 
   return dashboardPage(
     "Domains — dmarc.mx",

--- a/test/dashboard-routes.test.ts
+++ b/test/dashboard-routes.test.ts
@@ -178,6 +178,41 @@ function createMockDB(data: {
         const rows = filterPagedDomains(sql, bindings, domains);
         return { n: rows.length } as T;
       }
+      // getWorstGradedDomainForUser: lowest-graded domain across the watchlist,
+      // tie-broken alphabetically, ungraded excluded, S treated as best.
+      if (
+        /last_grade IS NOT NULL/i.test(sql) &&
+        /ORDER BY/i.test(sql) &&
+        /LIMIT 1/i.test(sql)
+      ) {
+        const [userId] = bindings as [string];
+        const score: Record<string, number> = {
+          S: 12,
+          "A+": 11,
+          A: 10,
+          "A-": 9,
+          "B+": 8,
+          B: 7,
+          "B-": 6,
+          "C+": 5,
+          C: 4,
+          "C-": 3,
+          "D+": 2,
+          D: 1,
+          "D-": 1,
+          F: 0,
+        };
+        const graded = domains.filter(
+          (d) => d.user_id === userId && d.last_grade !== null,
+        );
+        if (graded.length === 0) return null;
+        graded.sort((a, b) => {
+          const ra = score[a.last_grade as string] ?? 0;
+          const rb = score[b.last_grade as string] ?? 0;
+          return ra !== rb ? ra - rb : a.domain.localeCompare(b.domain);
+        });
+        return { domain: graded[0].domain, grade: graded[0].last_grade } as T;
+      }
       return null as T | null;
     },
     all: async <T>() => {
@@ -275,6 +310,21 @@ function createMockDB(data: {
         }
         const rows = [...counts.entries()].map(([domain_id, count]) => ({
           domain_id,
+          count,
+        }));
+        return { results: rows as T[] };
+      }
+      // getGradeDistributionForUser: GROUP BY last_grade counts for the whole
+      // watchlist, scoped to the user.
+      if (/GROUP BY last_grade/i.test(sql)) {
+        const [userId] = bindings as [string];
+        const counts = new Map<string | null, number>();
+        for (const d of domains) {
+          if (d.user_id !== userId) continue;
+          counts.set(d.last_grade, (counts.get(d.last_grade) ?? 0) + 1);
+        }
+        const rows = [...counts.entries()].map(([grade, count]) => ({
+          grade,
           count,
         }));
         return { results: rows as T[] };
@@ -510,6 +560,57 @@ describe("dashboard/routes", () => {
       expect(body).toContain("domain-01.com");
       expect(body).toContain("domain-25.com");
       expect(body).not.toContain("domain-26.com");
+    });
+
+    it("computes the scoreboard from the whole watchlist, not the visible page", async () => {
+      // 30 domains: page 1 (domain-01..25, sorted asc) is all healthy A's, and
+      // every failure lives on page 2 (domain-26..30 = F). If the scoreboard
+      // read only the visible page it would show 0 failures and party-hat;
+      // portfolio-wide it must surface 5 failures and triage the worst.
+      const proDomains = Array.from({ length: 30 }, (_, i) => ({
+        id: i + 1,
+        user_id: "user_pro",
+        domain: `domain-${String(i + 1).padStart(2, "0")}.com`,
+        is_free: 0,
+        scan_frequency: "weekly" as const,
+        last_scanned_at: 1700000000 + i,
+        last_grade: i < 25 ? "A" : "F",
+        created_at: 1700000000 + i,
+      }));
+      const db = createMockDB({
+        users: [
+          {
+            id: "user_pro",
+            email: "pro@example.com",
+            email_domain: "example.com",
+            stripe_customer_id: "cus_x",
+            email_alerts_enabled: 1,
+            api_key_retirement_acknowledged_at: 1700000000,
+            created_at: 1700000000,
+          },
+        ],
+        subscriptions: [{ user_id: "user_pro", status: "active" }],
+        domains: proDomains,
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_pro", "pro@example.com");
+      const res = await app.request("/dashboard", {
+        headers: { Cookie: cookie },
+      });
+      const body = await res.text();
+      // The headline symptom: the "Domains" stat card shows the full watchlist
+      // size (30), not the visible page size (25). The stat-card-value anchor
+      // avoids colliding with the "Showing 1–25 of 30" pagination string.
+      expect(body).toMatch(/stat-card-value">30</);
+      // On-fire banner + hero reflect all 5 portfolio failures.
+      expect(body).toContain("5 domains failing");
+      expect(body).toContain("5 domains are failing");
+      // The worst domain (page 2, not in the visible table) is triaged.
+      expect(body).toContain("domain-26.com");
+      // A failing portfolio must not celebrate just because page 1 is green.
+      // Anchor on the rendered creature element so the CSS rule of the same
+      // name (always inlined) doesn't trip the assertion.
+      expect(body).not.toMatch(/<div class="creature[^"]*creature-partying/);
     });
 
     it("filters by search query for Pro users", async () => {

--- a/test/dashboard-views.test.ts
+++ b/test/dashboard-views.test.ts
@@ -342,6 +342,51 @@ describe("renderDashboardPage", () => {
       expect(hasSection(html, "stat-card-fail")).toBe(true); // 1 failing
     });
 
+    it("derives the scoreboard from the explicit stats override, not the page rows", () => {
+      // The Pro dashboard passes one paginated page of rows but portfolio-wide
+      // stats/worst. The scoreboard, on-fire banner, and hero "triage" line
+      // must reflect the whole watchlist, not just the visible page.
+      const html = renderDashboardPage({
+        email: "u@x.com",
+        plan: "pro",
+        // Page rows are all healthy A's — if the scoreboard read these, it would
+        // show 2 healthy / 0 failing and party-hat.
+        domains: [sample("A", "page-a.com"), sample("A", "page-b.com")],
+        stats: {
+          total: 344,
+          healthy: 300,
+          drifting: 32,
+          failing: 12,
+          ungraded: 0,
+        },
+        worst: { domain: "worst-in-portfolio.example", grade: "F" },
+      });
+      // "Domains" card shows the full watchlist size, not the 2 visible rows.
+      expect(html).toContain("344");
+      // Failing card + on-fire banner reflect the 12 portfolio-wide failures.
+      expect(hasSection(html, "stat-card-fail")).toBe(true);
+      expect(hasSection(html, "dashboard-banner-fire")).toBe(true);
+      expect(html).toContain("12 domains failing");
+      // Hero triages the portfolio-wide worst domain, which isn't on this page.
+      expect(html).toContain("12 domains are failing");
+      expect(html).toContain("worst-in-portfolio.example");
+      // A failing portfolio must never party-hat, even though the page is green.
+      expect(html).not.toMatch(/<div class="creature[^"]*creature-partying/);
+    });
+
+    it("falls back to deriving stats from domains when no override is given", () => {
+      // Free tier and fixtures pass the full list as `domains` and omit the
+      // override — the derived path must keep working unchanged.
+      const html = renderDashboardPage({
+        email: "u@x.com",
+        domains: [sample("A", "a.com"), sample("F", "b.com")],
+      });
+      expect(html).toContain('class="stat-strip"');
+      expect(hasSection(html, "stat-card-pass")).toBe(true); // 1 healthy
+      expect(hasSection(html, "stat-card-fail")).toBe(true); // 1 failing
+      expect(html).toContain("b.com"); // worst derived from the list
+    });
+
     it("renders the free-tier banner only when plan=free", () => {
       const free = renderDashboardPage({
         email: "u@x.com",

--- a/test/db-domains.test.ts
+++ b/test/db-domains.test.ts
@@ -5,6 +5,8 @@ import {
   deleteDomain,
   getDomainByUserAndName,
   getDomainsByUser,
+  getGradeDistributionForUser,
+  getWorstGradedDomainForUser,
   listDomainsForUserPaged,
   updateLastScan,
 } from "../src/db/domains.js";
@@ -72,6 +74,42 @@ function makeD1Mock(): D1Database {
               }
               return null;
             }
+            // getWorstGradedDomainForUser: lowest-graded domain across the whole
+            // watchlist, tie-broken alphabetically, ungraded rows excluded.
+            if (
+              /last_grade IS NOT NULL/i.test(sql) &&
+              /ORDER BY/i.test(sql) &&
+              /LIMIT 1/i.test(sql)
+            ) {
+              const [userId] = params as [string];
+              const score: Record<string, number> = {
+                S: 12,
+                "A+": 11,
+                A: 10,
+                "A-": 9,
+                "B+": 8,
+                B: 7,
+                "B-": 6,
+                "C+": 5,
+                C: 4,
+                "C-": 3,
+                "D+": 2,
+                D: 1,
+                "D-": 1,
+                F: 0,
+              };
+              const graded = [...store.values()].filter(
+                (row) => row.user_id === userId && row.last_grade !== null,
+              );
+              if (graded.length === 0) return null;
+              graded.sort((a, b) => {
+                const ra = score[a.last_grade as string] ?? 0;
+                const rb = score[b.last_grade as string] ?? 0;
+                return ra !== rb ? ra - rb : a.domain.localeCompare(b.domain);
+              });
+              const worst = graded[0];
+              return { domain: worst.domain, grade: worst.last_grade } as T;
+            }
             return null;
           },
           all: async <T>(): Promise<{ results: T[] }> => {
@@ -80,6 +118,23 @@ function makeD1Mock(): D1Database {
               const results = [...store.values()]
                 .filter((row) => row.user_id === userId)
                 .sort((a, b) => a.created_at - b.created_at) as T[];
+              return { results };
+            }
+            // getGradeDistributionForUser: GROUP BY last_grade counts.
+            if (/GROUP BY last_grade/i.test(sql)) {
+              const [userId] = params as [string];
+              const counts = new Map<string | null, number>();
+              for (const row of store.values()) {
+                if (row.user_id !== userId) continue;
+                counts.set(
+                  row.last_grade,
+                  (counts.get(row.last_grade) ?? 0) + 1,
+                );
+              }
+              const results = [...counts.entries()].map(([grade, count]) => ({
+                grade,
+                count,
+              })) as T[];
               return { results };
             }
             return { results: [] };
@@ -254,6 +309,89 @@ describe("db/domains", () => {
       const updated = await getDomainByUserAndName(db, "user-1", "rescan.com");
       expect(updated?.last_grade).toBe("A+");
       expect(updated?.last_scanned_at).toBe(1700001000);
+    });
+  });
+
+  // Helper: create a domain and optionally stamp a grade on it, mirroring how
+  // the cron/scan path populates domains.last_grade.
+  async function addGraded(
+    userId: string,
+    domain: string,
+    grade: string | null,
+  ): Promise<void> {
+    await createDomain(db, { userId, domain, isFree: false });
+    if (grade !== null) {
+      const d = await getDomainByUserAndName(db, userId, domain);
+      if (d) await updateLastScan(db, d.id, grade, 1700000000);
+    }
+  }
+
+  describe("getGradeDistributionForUser", () => {
+    it("tallies the whole watchlist into healthy/drifting/failing/ungraded", async () => {
+      await addGraded("user-1", "a1.com", "A");
+      await addGraded("user-1", "a2.com", "A");
+      await addGraded("user-1", "b1.com", "B-");
+      await addGraded("user-1", "c1.com", "C");
+      await addGraded("user-1", "f1.com", "F");
+      await addGraded("user-1", "f2.com", "F");
+      await addGraded("user-1", "f3.com", "F");
+      await addGraded("user-1", "u1.com", null);
+      // Another user's domain must not bleed into the tally.
+      await addGraded("user-2", "other.com", "F");
+
+      const stats = await getGradeDistributionForUser(db, "user-1");
+      expect(stats).toEqual({
+        total: 8,
+        healthy: 3,
+        drifting: 1,
+        failing: 3,
+        ungraded: 1,
+      });
+    });
+
+    it("returns an all-zero tally for a user with no domains", async () => {
+      const stats = await getGradeDistributionForUser(db, "nobody");
+      expect(stats).toEqual({
+        total: 0,
+        healthy: 0,
+        drifting: 0,
+        failing: 0,
+        ungraded: 0,
+      });
+    });
+  });
+
+  describe("getWorstGradedDomainForUser", () => {
+    it("returns the lowest-graded domain, tie-broken alphabetically", async () => {
+      await addGraded("user-1", "zeta.com", "F");
+      await addGraded("user-1", "alpha.com", "F");
+      await addGraded("user-1", "mid.com", "C");
+
+      const worst = await getWorstGradedDomainForUser(db, "user-1");
+      expect(worst).toEqual({ domain: "alpha.com", grade: "F" });
+    });
+
+    it("ignores ungraded domains", async () => {
+      await addGraded("user-1", "ungraded.com", null);
+      await addGraded("user-1", "graded.com", "D");
+
+      const worst = await getWorstGradedDomainForUser(db, "user-1");
+      expect(worst).toEqual({ domain: "graded.com", grade: "D" });
+    });
+
+    it("does not rank a perfect S grade as the worst", async () => {
+      await addGraded("user-1", "perfect.com", "S");
+      await addGraded("user-1", "drifting.com", "C");
+
+      const worst = await getWorstGradedDomainForUser(db, "user-1");
+      expect(worst).toEqual({ domain: "drifting.com", grade: "C" });
+    });
+
+    it("returns null when no domain has been graded", async () => {
+      await addGraded("user-1", "pending.com", null);
+
+      const worst = await getWorstGradedDomainForUser(db, "user-1");
+      expect(worst).toBeNull();
     });
   });
 });

--- a/test/portfolio.test.ts
+++ b/test/portfolio.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  emptyPortfolioStats,
+  gradeBucket,
+  tallyGradeCounts,
+} from "../src/shared/portfolio.js";
+
+describe("gradeBucket", () => {
+  it("buckets S, A, and B grades (with modifiers) as healthy", () => {
+    for (const g of ["S", "A+", "A", "A-", "B+", "B", "B-"]) {
+      expect(gradeBucket(g)).toBe("healthy");
+    }
+  });
+
+  it("buckets C and D grades (with modifiers) as drifting", () => {
+    for (const g of ["C+", "C", "C-", "D+", "D", "D-"]) {
+      expect(gradeBucket(g)).toBe("drifting");
+    }
+  });
+
+  it("buckets F as failing", () => {
+    expect(gradeBucket("F")).toBe("failing");
+  });
+
+  it("buckets null, empty, the placeholder dash, and unknown grades as ungraded", () => {
+    expect(gradeBucket(null)).toBe("ungraded");
+    expect(gradeBucket(undefined)).toBe("ungraded");
+    expect(gradeBucket("")).toBe("ungraded");
+    expect(gradeBucket("—")).toBe("ungraded");
+    expect(gradeBucket("ungraded")).toBe("ungraded");
+  });
+
+  it("is case-insensitive on the leading letter", () => {
+    expect(gradeBucket("a")).toBe("healthy");
+    expect(gradeBucket("f")).toBe("failing");
+  });
+});
+
+describe("emptyPortfolioStats", () => {
+  it("returns an all-zero stats object", () => {
+    expect(emptyPortfolioStats()).toEqual({
+      total: 0,
+      healthy: 0,
+      drifting: 0,
+      failing: 0,
+      ungraded: 0,
+    });
+  });
+});
+
+describe("tallyGradeCounts", () => {
+  it("sums grouped grade counts into the right buckets", () => {
+    const stats = tallyGradeCounts([
+      { grade: "A", count: 5 },
+      { grade: "B-", count: 2 },
+      { grade: "C", count: 3 },
+      { grade: "F", count: 12 },
+      { grade: null, count: 4 },
+    ]);
+    expect(stats).toEqual({
+      total: 26,
+      healthy: 7,
+      drifting: 3,
+      failing: 12,
+      ungraded: 4,
+    });
+  });
+
+  it("returns an empty stats object for no rows", () => {
+    expect(tallyGradeCounts([])).toEqual(emptyPortfolioStats());
+  });
+});


### PR DESCRIPTION
## Problem

On the Pro dashboard, the portfolio **hero**, the **stat strip** (Domains / Healthy / Drifting / Failing), and the **"N domains failing" banner** derived their counts from the `domains` array passed to `renderDashboardPage` — which on the Pro path is a single paginated page (≤25 rows). For an account with more domains than fit on a page (e.g. a grandfathered 344-domain watchlist), the scoreboard showed **page-local** numbers (Domains capped at 25), and the hero triaged the worst domain *on the visible page* rather than across the whole watchlist.

Reported symptom: "shows 25 instead of 344."

## Fix

Compute the scoreboard from portfolio-wide aggregates instead of the page rows:

- **`src/shared/portfolio.ts`** (new, pure, dependency-free): `gradeBucket`, `emptyPortfolioStats`, `tallyGradeCounts` + the shared `PortfolioStats` type. The view's `portfolioStats` now delegates to `gradeBucket` (same mapping as before).
- **`src/db/domains.ts`**: two aggregate queries —
  - `getGradeDistributionForUser` — `GROUP BY last_grade`, bucketed in JS. Returns counts, not rows.
  - `getWorstGradedDomainForUser` — lowest-graded domain across the watchlist for the hero's "triage X first" line. Uses its own grade-rank CASE that correctly ranks `S` as **best** (deliberately *not* the table's `GRADE_RANK_SQL`, which omits `S` and would rank a perfect grade as worst).
- **`src/views/dashboard.ts`**: `renderDashboardPage` gains optional `stats` / `worst` overrides. When omitted it still derives from `domains` (free tier + dev fixtures, where the list is already the full watchlist), so existing callers and behavior are unchanged. Stat-strip visibility now keys on `stats.total > 0`.
- **`src/dashboard/routes.ts`**: `GET /dashboard` computes `distribution` + `worst` once and passes them on both the free and Pro branches; `usage.current` reuses `distribution.total` (drops a redundant `countDomainsByUser`).

The domain **table itself stays paginated** — only the summary numbers change. The `/dashboard/domains` live-search fragment is untouched (it never rendered the strip), so the scoreboard correctly stays portfolio-wide regardless of filter/page.

No DB migration (read-only SELECTs).

## Tests

- `test/portfolio.test.ts` (new) — `gradeBucket` boundaries + `tallyGradeCounts`.
- `test/db-domains.test.ts` — both new aggregate queries, incl. the regression guard that `S` is never ranked worst.
- `test/dashboard-views.test.ts` — the `stats`/`worst` override drives the scoreboard, not the page rows; omitting it still derives from `domains`.
- `test/dashboard-routes.test.ts` — a Pro user whose failing domains live on **page 2**: the Domains card shows 30 (not 25), the on-fire banner + hero report all 5 portfolio failures, and the worst domain (off-page) is triaged.

**Gate:** 1231 tests passing · `tsc --noEmit` clean · biome clean.

## Notes

- `src/db/` is CODEOWNERS-gated — this needs a code-owner review before merge. **Auto-merge intentionally not enabled.**
- Follow-up (deferred by request): surface the *most-common* portfolio failure in the hero — filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)