### PR TITLE
🎨 Palette: [UX/a11y] Add consistent loading states to forms

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -22,3 +22,7 @@
 ## 2026-06-04 - Add generic data-loading-text support for form submission buttons
 **Learning:** Implementing visual feedback (like 'Scanning...' or 'Adding...') on submit buttons often requires custom JS per form. By leveraging a centralized, opt-in `data-loading-text` attribute handled by a single global event listener, we can add consistent, accessible loading states across the application without polluting individual views with duplicated scripts.
 **Action:** For form submit buttons triggering slow or async operations, prefer adding a `data-loading-text` attribute (e.g., `data-loading-text="Scanning..."`) to the `<button type="submit">`. This hooks into the global form submission listener in `src/views/scripts.ts` to automatically handle disabled states and text updates.
+
+## 2026-06-05 - Add data-loading-text to standard synchronous forms
+**Learning:** Using `data-loading-text` isn't just for heavy async processes; standard forms with synchronous POST operations (like settings saves, revokes, or dismissals) also benefit. It provides immediate visual feedback, confirms the click, and disables the button to prevent accidental double-submissions while the server processes the request.
+**Action:** Consistently apply `data-loading-text` to all `<button type="submit">` elements in the app (e.g., settings save buttons, destructive actions) to utilize the global form submit listener for consistent UX and protection against double-clicking.

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -1484,14 +1484,14 @@ export function renderAlertsSection(
   <span class="alert-message">${esc(describeAlert(a))}</span>
   <span class="alert-time">${esc(relativeTime(a.createdAt, now))}</span>
   <form method="post" action="${ackHref}">
-    <button type="submit" class="btn-dismiss" aria-label="Dismiss alert for ${esc(a.domain)}">Dismiss</button>
+    <button type="submit" class="btn-dismiss" aria-label="Dismiss alert for ${esc(a.domain)}" data-loading-text="Dismissing...">Dismiss</button>
   </form>
 </li>`;
   }
   const dismissAll =
     alerts.length >= 2
       ? `<form method="post" action="/dashboard/alerts/acknowledge-all" class="dismiss-all-form">
-    <button type="submit" class="btn-dismiss btn-dismiss-all">Dismiss all</button>
+    <button type="submit" class="btn-dismiss btn-dismiss-all" data-loading-text="Dismissing...">Dismiss all</button>
   </form>`
       : "";
   return `<section class="alerts-needs-attention" aria-label="Domain regressions needing attention">
@@ -2351,7 +2351,7 @@ export function renderDomainDetailPage({
   </form>
   <a href="/check?domain=${encodeURIComponent(domain)}" class="btn btn-secondary">View Full Report</a>
   <form method="POST" action="/dashboard/domain/${encodeURIComponent(domain)}/delete" style="display:inline" onsubmit="return confirm('Stop monitoring ${esc(domain)}?');">
-    <button type="submit" class="btn btn-danger" aria-label="Delete domain ${esc(domain)}">Delete</button>
+    <button type="submit" class="btn btn-danger" aria-label="Delete domain ${esc(domain)}" data-loading-text="Deleting...">Delete</button>
   </form>
 </div>
 <div class="section-card">
@@ -2827,12 +2827,12 @@ ${retirementBanner}
     <p id="webhook-format-help" style="font-size:0.8125rem;color:var(--clr-text-muted);margin:0.4rem 0 0.75rem">
       Raw posts the signed envelope for your own receiver. Slack and Google Chat send a chat message and omit the signature header (those platforms don't verify it).
     </p>
-    <button type="submit" class="btn">Save Webhook</button>
+    <button type="submit" class="btn" data-loading-text="Saving...">Save Webhook</button>
   </form>
   ${
     webhookUrl
       ? `<form method="POST" action="/dashboard/settings/webhook/test" style="margin-top:0.5rem">
-    <button type="submit" class="btn btn-secondary">Send test event</button>
+    <button type="submit" class="btn btn-secondary" data-loading-text="Sending...">Send test event</button>
   </form>`
       : ""
   }
@@ -2850,7 +2850,7 @@ ${retirementBanner}
       <input type="checkbox" name="enabled" ${emailAlertsEnabled ? "checked" : ""}>
       <span>Send me grade-drop alerts by email</span>
     </label>
-    <button type="submit" class="btn btn-secondary">Save Preference</button>
+    <button type="submit" class="btn btn-secondary" data-loading-text="Saving...">Save Preference</button>
   </form>
 </div>
 
@@ -2864,7 +2864,7 @@ ${retirementBanner}
       <input type="checkbox" name="enabled" ${notifyOnChangeOnly ? "checked" : ""}>
       <span>Only notify me when a scan result changes (grade or protocol status)</span>
     </label>
-    <button type="submit" class="btn btn-secondary">Save Preference</button>
+    <button type="submit" class="btn btn-secondary" data-loading-text="Saving...">Save Preference</button>
   </form>
 </div>
 
@@ -3001,7 +3001,7 @@ export function renderApiKeysPage({
           ? ""
           : `<form method="POST" action="/dashboard/settings/api-keys/revoke" style="display:inline" onsubmit="return confirm('Revoke this key? Requests using it will start failing.');">
               <input type="hidden" name="id" value="${esc(k.id)}">
-              <button type="submit" class="btn btn-danger" style="padding:0.25rem 0.6rem;font-size:0.8125rem" aria-label="Revoke API key ${labelName}">Revoke</button>
+              <button type="submit" class="btn btn-danger" style="padding:0.25rem 0.6rem;font-size:0.8125rem" aria-label="Revoke API key ${labelName}" data-loading-text="Revoking...">Revoke</button>
             </form>`;
         return `<tr>
   <td>${name}</td>


### PR DESCRIPTION
**💡 What:**
Added the `data-loading-text` attribute to several synchronous form submission buttons across the dashboard (e.g., Save Webhook, Delete Domain, Revoke API Key, Dismiss Alerts).

**🎯 Why:**
Standard synchronous form submissions can leave users wondering if their click registered, especially if the server response is slightly delayed. This change leverages the existing global JavaScript form event listener to instantly provide a visual loading state (e.g., changing "Save Webhook" to "Saving...") and temporarily disables the button to prevent accidental double-submissions.

**📸 Before/After:**
*   **Before:** Clicking "Save Webhook" or "Delete" gave no immediate feedback while waiting for the server redirect.
*   **After:** The button immediately text updates to indicate the action is processing, and becomes un-clickable.

**♿ Accessibility:**
The disabled state intrinsically communicates to screen readers that the element is no longer interactive while the submission occurs.

---
*PR created automatically by Jules for task [10509990340792812699](https://jules.google.com/task/10509990340792812699) started by @schmug*