### PR TITLE
feat: surface top-failing protocol in dashboard hero and on-fire banner

### DIFF
--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -36,6 +36,7 @@ import {
 import {
   getDashboardExportRows,
   getPortfolioTrendForUser,
+  getProtocolResultsForUser,
   getScanHistory,
   getScanHistoryWithProtocols,
   recordScan,
@@ -52,6 +53,7 @@ import { getRecentDeliveriesForUser } from "../db/webhook-deliveries.js";
 import { scan } from "../orchestrator.js";
 import { normalizeDomain } from "../shared/domain.js";
 import { PRO_WATCHLIST_CAP, watchlistCapFor } from "../shared/limits.js";
+import { tallyProtocolFailures } from "../shared/portfolio.js";
 import {
   computeGradeBreakdown,
   type ScoringConfig,
@@ -392,15 +394,25 @@ dashboardRoutes.get("/", async (c) => {
   // hero, stat strip, and on-fire banner reflect the entire watchlist even
   // when the Pro table below shows only one paginated page. distribution.total
   // doubles as the usage count, so no separate countDomainsByUser is needed.
-  const [alerts, unackCounts, portfolioTrend, user, distribution, worst] =
-    await Promise.all([
-      listUnacknowledgedForUser(db, session.sub, 20),
-      countUnacknowledgedByDomain(db, session.sub),
-      getPortfolioTrendForUser(db, session.sub, 30),
-      getUserById(db, session.sub),
-      getGradeDistributionForUser(db, session.sub),
-      getWorstGradedDomainForUser(db, session.sub),
-    ]);
+  const [
+    alerts,
+    unackCounts,
+    portfolioTrend,
+    user,
+    distribution,
+    worst,
+    protocolRows,
+  ] = await Promise.all([
+    listUnacknowledgedForUser(db, session.sub, 20),
+    countUnacknowledgedByDomain(db, session.sub),
+    getPortfolioTrendForUser(db, session.sub, 30),
+    getUserById(db, session.sub),
+    getGradeDistributionForUser(db, session.sub),
+    getWorstGradedDomainForUser(db, session.sub),
+    getProtocolResultsForUser(db, session.sub),
+  ]);
+
+  const topFailure = tallyProtocolFailures(protocolRows);
 
   // First-run = the user signed up within the last 24 hours and has exactly
   // one domain (the one auto-provisioned from their email suffix). The hero's
@@ -449,6 +461,7 @@ dashboardRoutes.get("/", async (c) => {
         },
         stats: distribution,
         worst,
+        topFailure,
       }),
     );
   }
@@ -506,6 +519,7 @@ dashboardRoutes.get("/", async (c) => {
       },
       stats: distribution,
       worst,
+      topFailure,
     }),
   );
 });

--- a/src/db/scans.ts
+++ b/src/db/scans.ts
@@ -172,6 +172,29 @@ export interface DashboardExportRow {
   protocol_results: string | null;
 }
 
+// Returns the latest protocol_results blob for every domain in the user's
+// watchlist. Used to compute per-protocol failure tallies without fresh DNS
+// lookups. Reuses the same correlated-subquery shape as getDashboardExportRows.
+export async function getProtocolResultsForUser(
+  db: D1Database,
+  userId: string,
+): Promise<Array<{ protocol_results: string | null }>> {
+  const result = await db
+    .prepare(
+      `SELECT
+         (SELECT sh.protocol_results
+            FROM scan_history sh
+           WHERE sh.domain_id = d.id
+           ORDER BY sh.scanned_at DESC
+           LIMIT 1) AS protocol_results
+       FROM domains d
+       WHERE d.user_id = ?`,
+    )
+    .bind(userId)
+    .all<{ protocol_results: string | null }>();
+  return result.results;
+}
+
 export async function getDashboardExportRows(
   db: D1Database,
   userId: string,

--- a/src/shared/portfolio.ts
+++ b/src/shared/portfolio.ts
@@ -42,3 +42,51 @@ export function tallyGradeCounts(
   }
   return stats;
 }
+
+export interface TopFailure {
+  protocol: string;
+  count: number;
+}
+
+// Tallies the most-common failing protocol across the latest scans in `rows`.
+// Each row's `protocol_results` is a JSON blob shaped as
+// `{ [protocol]: { status: "pass"|"warn"|"fail"|"info" } }`.
+// Returns null when no protocol is failing across any row.
+// Tie-breaking is alphabetical so output is deterministic.
+export function tallyProtocolFailures(
+  rows: Iterable<{ protocol_results: string | null }>,
+): TopFailure | null {
+  const counts = new Map<string, number>();
+  for (const row of rows) {
+    if (!row.protocol_results) continue;
+    let parsed: Record<string, { status?: unknown } | null | undefined> | null =
+      null;
+    try {
+      const raw = JSON.parse(row.protocol_results);
+      if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+        parsed = raw as Record<string, { status?: unknown } | null | undefined>;
+      }
+    } catch {
+      continue;
+    }
+    if (!parsed) continue;
+    for (const key of Object.keys(parsed)) {
+      const entry = parsed[key];
+      if (entry && typeof entry === "object" && entry.status === "fail") {
+        counts.set(key, (counts.get(key) ?? 0) + 1);
+      }
+    }
+  }
+  if (counts.size === 0) return null;
+  let top: TopFailure | null = null;
+  for (const [protocol, count] of counts) {
+    if (
+      !top ||
+      count > top.count ||
+      (count === top.count && protocol < top.protocol)
+    ) {
+      top = { protocol, count };
+    }
+  }
+  return top;
+}

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -2,6 +2,7 @@ import {
   emptyPortfolioStats,
   gradeBucket,
   type PortfolioStats,
+  type TopFailure,
 } from "../shared/portfolio.js";
 import type { WebhookFormat } from "../webhooks/formats/index.js";
 import {
@@ -1841,6 +1842,7 @@ function portfolioStats(domains: DashboardDomain[]): PortfolioStats {
 function heroVoiceLine(
   stats: PortfolioStats,
   worst: HeroWorst | null,
+  topFailure?: TopFailure | null,
 ): {
   line: string;
   sub: string;
@@ -1852,15 +1854,23 @@ function heroVoiceLine(
     };
   }
   if (stats.failing >= 3) {
+    const sub =
+      topFailure && topFailure.count > 0
+        ? `Top failure: ${esc(protocolDisplayName(topFailure.protocol))} — ${topFailure.count} of ${stats.failing} failing domains.`
+        : "DMARC, SPF, or DKIM regressions usually trace to a recent DNS edit.";
     return {
       line: `${stats.failing} domains are failing. Triage <code>${esc(worst?.domain ?? "")}</code> first.`,
-      sub: "DMARC, SPF, or DKIM regressions usually trace to a recent DNS edit.",
+      sub,
     };
   }
   if (stats.failing > 0 && worst) {
+    const sub =
+      topFailure && topFailure.count > 0
+        ? `Top failure: ${esc(protocolDisplayName(topFailure.protocol))} — ${topFailure.count} of ${stats.failing} failing ${stats.failing === 1 ? "domain" : "domains"}.`
+        : "Open it to see the diff and grab the fix.";
     return {
       line: `<code>${esc(worst.domain)}</code> is failing. The rest of the watchlist is steady.`,
-      sub: "Open it to see the diff and grab the fix.",
+      sub,
     };
   }
   if (stats.drifting > 0) {
@@ -1900,9 +1910,22 @@ function renderFirstRunBanner(domain: string): string {
 </div>`;
 }
 
-function renderOnFireBanner(failing: number): string {
+function protocolDisplayName(key: string): string {
+  if (key === "mta_sts") return "MTA-STS";
+  if (key === "security_txt") return "security.txt";
+  return key.toUpperCase();
+}
+
+function renderOnFireBanner(
+  failing: number,
+  topFailure: TopFailure | null | undefined,
+): string {
+  const insight =
+    topFailure && topFailure.count > 0
+      ? `<strong>${esc(protocolDisplayName(topFailure.protocol))}</strong> is the top issue — ${topFailure.count} of ${failing} failing ${failing === 1 ? "domain" : "domains"}.`
+      : "Walk down the list — most regressions share a single root cause.";
   return `<div class="dashboard-banner dashboard-banner-fire" role="region" aria-label="Multiple failures">
-  <span class="dashboard-banner-text"><strong>${failing} domains failing.</strong> Walk down the list — most regressions share a single root cause.</span>
+  <span class="dashboard-banner-text"><strong>${failing} domains failing.</strong> ${insight}</span>
 </div>`;
 }
 
@@ -1910,6 +1933,7 @@ function renderDashboardHero(
   stats: PortfolioStats,
   worst: HeroWorst | null,
   portfolioTrend: number[],
+  topFailure?: TopFailure | null,
 ): string {
   // Mood comes from the worst *graded* domain. With nothing scored yet there
   // is no signal to react to, so DMarcus defaults to neutral rather than
@@ -1920,7 +1944,7 @@ function renderDashboardHero(
   // "we won".
   const partyHat =
     stats.healthy > 0 && stats.failing === 0 && stats.drifting === 0;
-  const { line, sub } = heroVoiceLine(stats, worst);
+  const { line, sub } = heroVoiceLine(stats, worst, topFailure);
 
   // Score on a 0–100 scale derived from the latest portfolio average (0–12),
   // for legibility in the hero's right column. Falls back to a sensible
@@ -2056,6 +2080,7 @@ export function renderDashboardPage({
   isFirstRun = false,
   stats: statsOverride,
   worst: worstOverride,
+  topFailure,
 }: {
   email: string;
   alerts?: DashboardAlert[];
@@ -2078,20 +2103,30 @@ export function renderDashboardPage({
   // and on-fire banner reflect the whole watchlist, not just the visible page.
   stats?: PortfolioStats;
   worst?: HeroWorst | null;
+  // Most-common failing protocol across the whole watchlist. Null when no
+  // domains are failing or no protocol_results blobs exist yet.
+  topFailure?: TopFailure | null;
 }): string {
   const stats = statsOverride ?? portfolioStats(domains);
   // `!== undefined` (not `??`) so an explicit `null` override — "no graded
   // domain in the whole watchlist" — wins over deriving from the page rows.
   const worst =
     worstOverride !== undefined ? worstOverride : worstDomain(domains);
+  const activeTopFailure = stats.failing > 0 ? topFailure : null;
   const banners: string[] = [];
   if (plan === "free") banners.push(renderFreeTierBanner());
   if (isFirstRun && domains.length === 1) {
     banners.push(renderFirstRunBanner(domains[0].domain));
   }
-  if (stats.failing >= 3) banners.push(renderOnFireBanner(stats.failing));
+  if (stats.failing >= 3)
+    banners.push(renderOnFireBanner(stats.failing, activeTopFailure));
 
-  const hero = renderDashboardHero(stats, worst, portfolioTrend);
+  const hero = renderDashboardHero(
+    stats,
+    worst,
+    portfolioTrend,
+    activeTopFailure,
+  );
   const statStrip = stats.total > 0 ? renderDashboardStatStrip(stats) : "";
 
   return dashboardPage(

--- a/test/dashboard-views.test.ts
+++ b/test/dashboard-views.test.ts
@@ -537,6 +537,87 @@ describe("renderDashboardPage", () => {
       expect(html).toContain("data-drawer-link");
     });
 
+    describe("topFailure insight", () => {
+      it("shows top-failure protocol in the hero sub when 1 domain is failing", () => {
+        const html = renderDashboardPage({
+          email: "u@x.com",
+          domains: [sample("F", "broken.com")],
+          topFailure: { protocol: "dkim", count: 1 },
+        });
+        expect(html).toContain("Top failure: DKIM");
+        expect(html).toContain("1 of 1 failing domain");
+      });
+
+      it("shows top-failure in the hero sub and on-fire banner when 3+ domains are failing", () => {
+        const html = renderDashboardPage({
+          email: "u@x.com",
+          domains: [
+            sample("F", "x.com"),
+            sample("F", "y.com"),
+            sample("F", "z.com"),
+          ],
+          topFailure: { protocol: "dkim", count: 3 },
+        });
+        // Banner names the protocol
+        expect(html).toContain("<strong>DKIM</strong> is the top issue");
+        expect(html).toContain("3 of 3 failing");
+        // Hero sub also names it
+        expect(html).toContain("Top failure: DKIM");
+      });
+
+      it("shows correct count when topFailure affects a subset of failing domains", () => {
+        const html = renderDashboardPage({
+          email: "u@x.com",
+          stats: {
+            total: 12,
+            healthy: 0,
+            drifting: 0,
+            failing: 12,
+            ungraded: 0,
+          },
+          worst: { domain: "w.example", grade: "F" },
+          topFailure: { protocol: "dkim", count: 9 },
+          domains: [],
+        });
+        expect(html).toContain("9 of 12 failing");
+      });
+
+      it("renders MTA-STS display name correctly", () => {
+        const html = renderDashboardPage({
+          email: "u@x.com",
+          domains: [sample("F", "broken.com")],
+          topFailure: { protocol: "mta_sts", count: 1 },
+        });
+        expect(html).toContain("MTA-STS");
+        expect(html).not.toContain("MTA_STS");
+      });
+
+      it("falls back to generic copy when topFailure is null", () => {
+        const html = renderDashboardPage({
+          email: "u@x.com",
+          domains: [
+            sample("F", "x.com"),
+            sample("F", "y.com"),
+            sample("F", "z.com"),
+          ],
+          topFailure: null,
+        });
+        expect(html).toContain("single root cause");
+        expect(html).not.toContain("Top failure:");
+      });
+
+      it("suppresses top-failure copy when the portfolio has no failing domains", () => {
+        const html = renderDashboardPage({
+          email: "u@x.com",
+          domains: [sample("A", "good.com")],
+          // topFailure passed but should not appear — gated on stats.failing > 0
+          topFailure: { protocol: "dkim", count: 1 },
+        });
+        expect(html).not.toContain("Top failure:");
+        expect(html).not.toContain("top issue");
+      });
+    });
+
     it("preserves the existing alerts section markup above the table", () => {
       const html = renderDashboardPage({
         email: "u@x.com",

--- a/test/portfolio.test.ts
+++ b/test/portfolio.test.ts
@@ -3,6 +3,7 @@ import {
   emptyPortfolioStats,
   gradeBucket,
   tallyGradeCounts,
+  tallyProtocolFailures,
 } from "../src/shared/portfolio.js";
 
 describe("gradeBucket", () => {
@@ -45,6 +46,88 @@ describe("emptyPortfolioStats", () => {
       failing: 0,
       ungraded: 0,
     });
+  });
+});
+
+describe("tallyProtocolFailures", () => {
+  function row(protocols: Record<string, { status: string }> | null) {
+    return {
+      protocol_results: protocols ? JSON.stringify(protocols) : null,
+    };
+  }
+
+  it("returns null when there are no rows", () => {
+    expect(tallyProtocolFailures([])).toBeNull();
+  });
+
+  it("returns null when all rows have null protocol_results", () => {
+    expect(tallyProtocolFailures([{ protocol_results: null }])).toBeNull();
+  });
+
+  it("returns null when no protocol has status=fail", () => {
+    expect(
+      tallyProtocolFailures([
+        row({ dmarc: { status: "pass" }, spf: { status: "warn" } }),
+        row({ dmarc: { status: "pass" } }),
+      ]),
+    ).toBeNull();
+  });
+
+  it("identifies the single failing protocol", () => {
+    const result = tallyProtocolFailures([
+      row({ dmarc: { status: "fail" }, spf: { status: "pass" } }),
+      row({ dmarc: { status: "fail" } }),
+      row({ dmarc: { status: "pass" } }),
+    ]);
+    expect(result).toEqual({ protocol: "dmarc", count: 2 });
+  });
+
+  it("picks the most-common failing protocol across mixed rows", () => {
+    const result = tallyProtocolFailures([
+      row({ dmarc: { status: "fail" }, dkim: { status: "fail" } }),
+      row({ dkim: { status: "fail" }, spf: { status: "pass" } }),
+      row({ dkim: { status: "fail" } }),
+      row({ dmarc: { status: "pass" } }),
+    ]);
+    // dkim fails 3 times, dmarc fails 1 time
+    expect(result).toEqual({ protocol: "dkim", count: 3 });
+  });
+
+  it("breaks ties alphabetically (lower protocol name wins)", () => {
+    const result = tallyProtocolFailures([
+      row({ bimi: { status: "fail" }, spf: { status: "fail" } }),
+      row({ bimi: { status: "fail" }, spf: { status: "fail" } }),
+    ]);
+    // bimi and spf both fail 2 times; bimi < spf alphabetically
+    expect(result).toEqual({ protocol: "bimi", count: 2 });
+  });
+
+  it("skips rows with invalid JSON gracefully", () => {
+    const rows = [
+      { protocol_results: "not-json" },
+      row({ dmarc: { status: "fail" } }),
+    ];
+    expect(tallyProtocolFailures(rows)).toEqual({
+      protocol: "dmarc",
+      count: 1,
+    });
+  });
+
+  it("skips rows with null protocol_results", () => {
+    const rows = [{ protocol_results: null }, row({ spf: { status: "fail" } })];
+    expect(tallyProtocolFailures(rows)).toEqual({ protocol: "spf", count: 1 });
+  });
+
+  it("returns null for an all-healthy portfolio", () => {
+    const rows = [
+      row({
+        dmarc: { status: "pass" },
+        spf: { status: "pass" },
+        dkim: { status: "pass" },
+      }),
+      row({ dmarc: { status: "warn" }, mta_sts: { status: "warn" } }),
+    ];
+    expect(tallyProtocolFailures(rows)).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `tallyProtocolFailures()` pure helper in `src/shared/portfolio.ts` that walks `protocol_results` JSON blobs and returns the most-common `fail`-status protocol with its domain count (tie-breaking is alphabetical for determinism).
- Adds `getProtocolResultsForUser()` in `src/db/scans.ts` using the same correlated-subquery shape as `getDashboardExportRows` — latest scan blob per domain, no fresh DNS.
- Wires both into the dashboard `GET /` route (both free and pro paths) alongside existing parallel fetches, passed as `topFailure` to `renderDashboardPage`.
- Updates `renderOnFireBanner` and `heroVoiceLine` to name the top protocol when `stats.failing > 0`; falls back to the existing generic copy when `topFailure` is null.

Closes #498

## Test plan

- [x] `npm test` — 1245 passing, 0 failing (1 pre-existing network integration test excluded from this count)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `test/portfolio.test.ts` — 8 new tests cover: empty input, all-null rows, no failures, single protocol, most-common wins, tie-breaking alphabetical, invalid JSON skipped, healthy portfolio returns null
- [x] `test/dashboard-views.test.ts` — 5 new tests cover: 1 failing domain shows top failure, 3+ failing shows in banner + hero, subset count, MTA-STS display name, null topFailure falls back to generic copy, healthy portfolio suppresses top-failure copy

## Acceptance shipped

- [x] When ≥1 domain is failing, hero/banner names the protocol and affected-domain count
- [x] Computed across the whole watchlist (not just paginated page)
- [x] No top-failure line when portfolio has zero failing domains
- [x] Pure aggregation has unit tests; route renders end-to-end in view tests
- [x] All CI gates pass; no new migration

## Acceptance deferred

none

https://claude.ai/code/session_01MuuJx8CRTM3NFrMBrt6k87

---
_Generated by [Claude Code](https://claude.ai/code/session_01MuuJx8CRTM3NFrMBrt6k87)_