### PR TITLE
🎨 Palette: Extend `data-loading-text` to synchronous forms

### DIFF
--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -1633,7 +1633,7 @@ function renderDomainToolbar(controls: DashboardControls): string {
   ${controls.direction !== "asc" ? `<input type="hidden" name="dir" value="${esc(controls.direction)}">` : ""}
   ${controls.pageSize !== 25 ? `<input type="hidden" name="pageSize" value="${controls.pageSize}">` : ""}
   <div class="toolbar-actions">
-    <button type="submit" class="btn">Apply</button>
+    <button type="submit" class="btn" data-loading-text="Applying...">Apply</button>
     <a href="/dashboard" class="btn btn-secondary">Reset</a>
   </div>
 </form>`;

--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -153,7 +153,7 @@ export function renderLandingPage(): string {
       <form action="/check" method="GET">
         <div class="search-box">
           <input type="text" name="domain" placeholder="Enter a domain (e.g., google.com)" aria-label="Enter a domain" autocapitalize="none" autocorrect="off" spellcheck="false" autofocus required>
-          <button type="submit">Scan</button>
+          <button type="submit" data-loading-text="Scanning...">Scan</button>
         </div>
         <details class="advanced-options">
           <summary>Advanced options</summary>

--- a/src/views/learn.ts
+++ b/src/views/learn.ts
@@ -144,7 +144,7 @@ function learnCta(placeholder: string): string {
       <form action="/check" method="GET" class="learn-cta-form">
         <div class="search-box">
           <input type="text" name="domain" placeholder="${esc(placeholder)}" aria-label="Enter a domain" autocapitalize="none" autocorrect="off" spellcheck="false" required>
-          <button type="submit">Scan</button>
+          <button type="submit" data-loading-text="Scanning...">Scan</button>
         </div>
       </form>
     </div>

--- a/src/views/scripts.ts
+++ b/src/views/scripts.ts
@@ -70,10 +70,6 @@ if (!window.__dmarcheckBound) {
         /* Generic loading state for any button that opts in */
         btn.disabled = true;
         btn.textContent = loadingText;
-      } else if (form.getAttribute('action') === '/check') {
-        /* Legacy hardcoded state for the homepage /check form */
-        btn.disabled = true;
-        btn.textContent = 'Scanning...';
       }
     }
 


### PR DESCRIPTION
💡 **What:** Adds `data-loading-text` attributes to standard synchronous form submission buttons, specifically the main `Scan` buttons (on `/` and `/learn`) and the dashboard `Apply` filter button. Also removes the legacy `/check` hardcoded text override in `scripts.ts`.

🎯 **Why:** Previously, standard synchronous POST forms (like scanning from the homepage) relied on hardcoded Javascript rules or had no visual feedback at all. Providing immediate feedback confirms the user's action and disables the button to prevent accidental double-submissions while the server processes the synchronous request.

📸 **Before/After:**
- The check form buttons now handle their own disabled state text ("Scanning...") universally through the global event listener, rather than needing JS hardcodes.
- Applying filters in the dashboard now visually updates the apply button to "Applying..." and disables it while navigating.

♿ **Accessibility:** Visually disabled states prevent user confusion and double clicks during brief page loads.

---
*PR created automatically by Jules for task [4406387488919973210](https://jules.google.com/task/4406387488919973210) started by @schmug*