### PR TITLE
fix: add Sigstore sign→verify smoke test to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,3 +124,23 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           gh release upload "$VERSION" SHA256SUMS SHA256SUMS.bundle
+
+      - name: Verify Sigstore signature (post-upload smoke test)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          SLUG="schmug/dmarcheck"
+          mkdir -p .sig-verify
+          # Re-download the just-uploaded assets; retry once for asset-propagation lag
+          gh release download "$VERSION" --repo "$SLUG" \
+            --pattern 'SHA256SUMS' --pattern 'SHA256SUMS.bundle' \
+            --dir .sig-verify --clobber || \
+          gh release download "$VERSION" --repo "$SLUG" \
+            --pattern 'SHA256SUMS' --pattern 'SHA256SUMS.bundle' \
+            --dir .sig-verify --clobber
+          cosign verify-blob \
+            --bundle .sig-verify/SHA256SUMS.bundle \
+            --certificate-identity-regexp "https://github.com/schmug/dmarcheck/.github/workflows/release.yml" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            .sig-verify/SHA256SUMS


### PR DESCRIPTION
## Summary

- Adds a `Verify Sigstore signature (post-upload smoke test)` step at the end of `release.yml`, immediately after `Upload SHA256SUMS and signature bundle`
- The step re-downloads the just-published `SHA256SUMS` and `SHA256SUMS.bundle` from the GitHub release, then runs `cosign verify-blob` to confirm the sign→verify round-trip is intact
- Retries the download once (no sleep, matching the existing `gh release download` retry pattern) to tolerate brief asset-propagation lag
- Fails the release job if cosign does not print `Verified OK`, so a cosign upgrade that breaks bundle format or the signing pipeline is caught before it reaches users

Closes #492

## Test plan

- [ ] On the next push to `main` that triggers a release, confirm the new `Verify Sigstore signature` step runs and prints `Verified OK`
- [ ] To test failure mode: temporarily corrupt the bundle or swap the OIDC issuer and confirm the step fails the job
- [ ] `npm test` — 1245 passing, 0 failing
- [ ] `npm run typecheck` — clean
- [ ] `npm run lint` — clean

## Deferred follow-ups

None — all Acceptance items from #492 are shipped in this PR.

## Spec follow-up needed

No — this change does not touch or narrow any spec document.

https://claude.ai/code/session_01KjhxDi32w7taHZzVgsc2so

---
_Generated by [Claude Code](https://claude.ai/code/session_01KjhxDi32w7taHZzVgsc2so)_