### PR TITLE
fix: add post-release cosign sign→verify smoke check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,3 +124,24 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           gh release upload "$VERSION" SHA256SUMS SHA256SUMS.bundle
+
+      - name: Verify SHA256SUMS signature (post-release smoke)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          SLUG="schmug/dmarcheck"
+          # Download the just-uploaded files; retry once for asset-propagation lag.
+          gh release download "$VERSION" --repo "$SLUG" \
+            --pattern "SHA256SUMS" --output verify-SHA256SUMS || \
+          gh release download "$VERSION" --repo "$SLUG" \
+            --pattern "SHA256SUMS" --output verify-SHA256SUMS
+          gh release download "$VERSION" --repo "$SLUG" \
+            --pattern "SHA256SUMS.bundle" --output verify-SHA256SUMS.bundle || \
+          gh release download "$VERSION" --repo "$SLUG" \
+            --pattern "SHA256SUMS.bundle" --output verify-SHA256SUMS.bundle
+          cosign verify-blob \
+            --bundle verify-SHA256SUMS.bundle \
+            --certificate-identity-regexp "https://github.com/schmug/dmarcheck/.github/workflows/release.yml" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            verify-SHA256SUMS


### PR DESCRIPTION
## Summary

- Adds a "Verify SHA256SUMS signature (post-release smoke)" step at the end of `release.yml`, immediately after the existing upload step
- Downloads the just-published `SHA256SUMS` and `SHA256SUMS.bundle` from the release (with single-retry for asset-propagation lag, mirroring the existing `gh release download` retry pattern at lines 97–104)
- Runs the canonical `cosign verify-blob` command — same identity regexp and OIDC issuer as documented in `README.md:249-253` — and fails the job if verification does not produce `Verified OK`

Closes #492

## Test plan

- [x] `npm test` — 1245 passing, 1 pre-existing network integration failure (confirmed identical on `main`)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] New step follows repo invariants: `ubuntu-latest` runner, no new action pins needed (cosign-installer already installed by the preceding step), `GH_TOKEN` from `secrets.GITHUB_TOKEN` (already available in the job's `permissions: contents: write`)
- [x] Retry pattern mirrors the existing `Generate SHA256SUMS` step's `|| retry` idiom
- [x] Certificate identity regexp matches `release.yml`'s own path (same workflow, same job)

## Deferred follow-ups

- Approach 2 (key-based round-trip in `pull_request` CI) — would catch cosign regressions on Dependabot bump PRs before merge; deferred per issue guidance to prefer the lightest option that works
- README verification-doc updates (tracked in issue as out of scope)

https://claude.ai/code/session_013cRbmouHc5xQc3ZDsAS2CP

---
_Generated by [Claude Code](https://claude.ai/code/session_013cRbmouHc5xQc3ZDsAS2CP)_