### PR TITLE
fix: scope dashboard top-failure tally to failing-grade domains

### DIFF
--- a/src/db/scans.ts
+++ b/src/db/scans.ts
@@ -172,16 +172,21 @@ export interface DashboardExportRow {
   protocol_results: string | null;
 }
 
-// Returns the latest protocol_results blob for every domain in the user's
-// watchlist. Used to compute per-protocol failure tallies without fresh DNS
-// lookups. Reuses the same correlated-subquery shape as getDashboardExportRows.
+// Returns the latest protocol_results blob plus the current grade for every
+// domain in the user's watchlist. Used to compute per-protocol failure tallies
+// without fresh DNS lookups; the grade lets tallyProtocolFailures scope the
+// count to the failing bucket. Reuses the same correlated-subquery shape as
+// getDashboardExportRows.
 export async function getProtocolResultsForUser(
   db: D1Database,
   userId: string,
-): Promise<Array<{ protocol_results: string | null }>> {
+): Promise<
+  Array<{ last_grade: string | null; protocol_results: string | null }>
+> {
   const result = await db
     .prepare(
       `SELECT
+         d.last_grade AS last_grade,
          (SELECT sh.protocol_results
             FROM scan_history sh
            WHERE sh.domain_id = d.id
@@ -191,7 +196,7 @@ export async function getProtocolResultsForUser(
        WHERE d.user_id = ?`,
     )
     .bind(userId)
-    .all<{ protocol_results: string | null }>();
+    .all<{ last_grade: string | null; protocol_results: string | null }>();
   return result.results;
 }
 

--- a/src/shared/portfolio.ts
+++ b/src/shared/portfolio.ts
@@ -48,16 +48,25 @@ export interface TopFailure {
   count: number;
 }
 
-// Tallies the most-common failing protocol across the latest scans in `rows`.
+// Tallies the most-common failing protocol across the latest scans of the
+// domains in the *failing* grade bucket. Rows outside that bucket are ignored:
+// the dashboard renders the count against the "N failing domains" stat, and
+// protocols like MTA-STS report status "fail" on most healthy domains too
+// (no _mta-sts record), so a watchlist-wide tally would both exceed the
+// denominator and surface the wrong protocol.
 // Each row's `protocol_results` is a JSON blob shaped as
 // `{ [protocol]: { status: "pass"|"warn"|"fail"|"info" } }`.
-// Returns null when no protocol is failing across any row.
+// Returns null when no protocol is failing across any failing-bucket row.
 // Tie-breaking is alphabetical so output is deterministic.
 export function tallyProtocolFailures(
-  rows: Iterable<{ protocol_results: string | null }>,
+  rows: Iterable<{
+    last_grade: string | null;
+    protocol_results: string | null;
+  }>,
 ): TopFailure | null {
   const counts = new Map<string, number>();
   for (const row of rows) {
+    if (gradeBucket(row.last_grade) !== "failing") continue;
     if (!row.protocol_results) continue;
     let parsed: Record<string, { status?: unknown } | null | undefined> | null =
       null;

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -2103,8 +2103,10 @@ export function renderDashboardPage({
   // and on-fire banner reflect the whole watchlist, not just the visible page.
   stats?: PortfolioStats;
   worst?: HeroWorst | null;
-  // Most-common failing protocol across the whole watchlist. Null when no
-  // domains are failing or no protocol_results blobs exist yet.
+  // Most-common failing protocol among the watchlist's failing-grade domains
+  // (same bucket as stats.failing, so the rendered "N of M failing domains"
+  // shares one denominator). Null when no domains are failing or no
+  // protocol_results blobs exist yet.
   topFailure?: TopFailure | null;
 }): string {
   const stats = statsOverride ?? portfolioStats(domains);

--- a/test/dashboard-routes.test.ts
+++ b/test/dashboard-routes.test.ts
@@ -613,6 +613,68 @@ describe("dashboard/routes", () => {
       expect(body).not.toMatch(/<div class="creature[^"]*creature-partying/);
     });
 
+    it("names the top failure among failing domains, not the watchlist-wide protocol tally", async () => {
+      // Regression: MTA-STS reports status "fail" on most healthy domains too
+      // (no _mta-sts record), so a watchlist-wide tally produced banners like
+      // "MTA-STS is the top issue — 342 of 199 failing domains". The numerator
+      // must come from the same failing-grade bucket as the denominator.
+      const proDomains = Array.from({ length: 30 }, (_, i) => ({
+        id: i + 1,
+        user_id: "user_pro",
+        domain: `domain-${String(i + 1).padStart(2, "0")}.com`,
+        is_free: 0,
+        scan_frequency: "weekly" as const,
+        last_scanned_at: 1700000000 + i,
+        last_grade: i < 25 ? "A" : "F",
+        created_at: 1700000000 + i,
+      }));
+      // Healthy domains fail MTA-STS only; F domains fail DMARC (and most
+      // also fail MTA-STS, like real portfolios).
+      const scanHistory = proDomains.map((d, i) => ({
+        id: i + 1,
+        domain_id: d.id,
+        grade: d.last_grade,
+        scanned_at: 1700000000 + i,
+        score_factors: null,
+        protocol_results: JSON.stringify(
+          i < 25
+            ? { dmarc: { status: "pass" }, mta_sts: { status: "fail" } }
+            : {
+                dmarc: { status: "fail" },
+                mta_sts: { status: i < 29 ? "fail" : "pass" },
+              },
+        ),
+      }));
+      const db = createMockDB({
+        users: [
+          {
+            id: "user_pro",
+            email: "pro@example.com",
+            email_domain: "example.com",
+            stripe_customer_id: "cus_x",
+            email_alerts_enabled: 1,
+            api_key_retirement_acknowledged_at: 1700000000,
+            created_at: 1700000000,
+          },
+        ],
+        subscriptions: [{ user_id: "user_pro", status: "active" }],
+        domains: proDomains,
+        scanHistory,
+      });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_pro", "pro@example.com");
+      const res = await app.request("/dashboard", {
+        headers: { Cookie: cookie },
+      });
+      const body = await res.text();
+      // DMARC fails on all 5 failing domains; MTA-STS only on 4 of them. The
+      // 25 healthy MTA-STS failures must not be counted.
+      expect(body).toContain("<strong>DMARC</strong> is the top issue");
+      expect(body).toContain("5 of 5 failing domains");
+      expect(body).not.toContain("MTA-STS</strong> is the top issue");
+      expect(body).not.toContain("29 of 5");
+    });
+
     it("filters by search query for Pro users", async () => {
       const db = createMockDB({
         users: [

--- a/test/portfolio.test.ts
+++ b/test/portfolio.test.ts
@@ -50,8 +50,12 @@ describe("emptyPortfolioStats", () => {
 });
 
 describe("tallyProtocolFailures", () => {
-  function row(protocols: Record<string, { status: string }> | null) {
+  function row(
+    protocols: Record<string, { status: string }> | null,
+    grade: string | null = "F",
+  ) {
     return {
+      last_grade: grade,
       protocol_results: protocols ? JSON.stringify(protocols) : null,
     };
   }
@@ -61,7 +65,9 @@ describe("tallyProtocolFailures", () => {
   });
 
   it("returns null when all rows have null protocol_results", () => {
-    expect(tallyProtocolFailures([{ protocol_results: null }])).toBeNull();
+    expect(
+      tallyProtocolFailures([{ last_grade: "F", protocol_results: null }]),
+    ).toBeNull();
   });
 
   it("returns null when no protocol has status=fail", () => {
@@ -104,7 +110,7 @@ describe("tallyProtocolFailures", () => {
 
   it("skips rows with invalid JSON gracefully", () => {
     const rows = [
-      { protocol_results: "not-json" },
+      { last_grade: "F", protocol_results: "not-json" },
       row({ dmarc: { status: "fail" } }),
     ];
     expect(tallyProtocolFailures(rows)).toEqual({
@@ -114,7 +120,10 @@ describe("tallyProtocolFailures", () => {
   });
 
   it("skips rows with null protocol_results", () => {
-    const rows = [{ protocol_results: null }, row({ spf: { status: "fail" } })];
+    const rows = [
+      { last_grade: "F", protocol_results: null },
+      row({ spf: { status: "fail" } }),
+    ];
     expect(tallyProtocolFailures(rows)).toEqual({ protocol: "spf", count: 1 });
   });
 
@@ -126,6 +135,44 @@ describe("tallyProtocolFailures", () => {
         dkim: { status: "pass" },
       }),
       row({ dmarc: { status: "warn" }, mta_sts: { status: "warn" } }),
+    ];
+    expect(tallyProtocolFailures(rows)).toBeNull();
+  });
+
+  it("ignores protocol failures on domains outside the failing bucket", () => {
+    // The 2026-06 dashboard bug: MTA-STS fails on most *healthy* domains too
+    // (no _mta-sts record → status "fail"), so a watchlist-wide tally reported
+    // "MTA-STS — 342 of 199 failing domains". Only failing-bucket rows count.
+    const result = tallyProtocolFailures([
+      row({ mta_sts: { status: "fail" } }, "A"),
+      row({ mta_sts: { status: "fail" } }, "A"),
+      row({ mta_sts: { status: "fail" } }, "B+"),
+      row({ spf: { status: "fail" } }, "C"),
+      row({ dmarc: { status: "fail" }, mta_sts: { status: "fail" } }, "F"),
+      row({ dmarc: { status: "fail" } }, "F"),
+    ]);
+    // dmarc fails on both F domains; mta_sts on only one of them. The three
+    // healthy MTA-STS failures and the drifting SPF failure are ignored.
+    expect(result).toEqual({ protocol: "dmarc", count: 2 });
+  });
+
+  it("never counts more domains than are in the failing bucket", () => {
+    const rows = [
+      ...Array.from({ length: 5 }, () =>
+        row({ mta_sts: { status: "fail" } }, "A"),
+      ),
+      row({ dmarc: { status: "fail" } }, "F"),
+    ];
+    const result = tallyProtocolFailures(rows);
+    expect(result).toEqual({ protocol: "dmarc", count: 1 });
+  });
+
+  it("returns null when failures exist only on healthy, drifting, or ungraded domains", () => {
+    const rows = [
+      row({ mta_sts: { status: "fail" } }, "A"),
+      row({ spf: { status: "fail" } }, "D"),
+      row({ dkim: { status: "fail" } }, null),
+      row({ dmarc: { status: "fail" } }, "—"),
     ];
     expect(tallyProtocolFailures(rows)).toBeNull();
   });


### PR DESCRIPTION
## Problem

The hero / on-fire banner shipped in #500 rendered impossible copy:

> **199 domains failing. MTA-STS is the top issue — 342 of 199 failing domains.**

Two bugs, one root cause:

1. **Numerator > denominator.** `tallyProtocolFailures()` counted protocol `status: "fail"` across the **entire watchlist** (every domain's latest scan, any grade), while the copy renders that count against `stats.failing`, which only counts grade-F domains. Different populations, so 342 "of" 199.
2. **Wrong protocol.** The MTA-STS analyzer reports `status: "fail"` whenever the `_mta-sts` TXT record is absent — true for most domains, including healthy A-grade ones. Tallied watchlist-wide, MTA-STS always dominates. Among the domains that are actually failing (grade F = no DMARC or p=none), DMARC is the real top issue.

The spec's own example in #498 ("9 of your 12 **failing** domains have no valid DKIM") implies the tally is scoped to failing domains.

## Fix

- `tallyProtocolFailures()` (src/shared/portfolio.ts) now skips rows outside the failing grade bucket (`gradeBucket(last_grade) !== "failing"`), so the numerator and the `stats.failing` denominator share one population and the count can never exceed it.
- `getProtocolResultsForUser()` (src/db/scans.ts) selects `d.last_grade` alongside the `protocol_results` blob to feed the filter. No migration; no view-layer changes.

## Tests

- Unit (test/portfolio.test.ts): healthy/drifting/ungraded rows with protocol failures are ignored; count never exceeds failing-bucket size; all-non-failing portfolios return null.
- End-to-end (test/dashboard-routes.test.ts): a 30-domain watchlist where 25 healthy domains fail MTA-STS and 5 grade-F domains fail DMARC renders "**DMARC** is the top issue — 5 of 5 failing domains", not "MTA-STS … 29 of 5".
- Gates: 1250 tests passing / 0 failing, `tsc --noEmit` clean, biome clean.

Fixes the regression introduced in #500 (issue #498).

🤖 Generated with [Claude Code](https://claude.com/claude-code)