### PR TITLE
fix: detect unknown SPF mechanisms/modifiers per RFC 7208 §4.6.1

### DIFF
--- a/src/analyzers/spf.ts
+++ b/src/analyzers/spf.ts
@@ -130,6 +130,15 @@ export async function analyzeSpf(domain: string): Promise<SpfResult> {
     });
   }
 
+  // Unknown/malformed mechanism or modifier check (RFC 7208 §4.6.1)
+  const unknownTerms = tree.mechanisms.filter((t) => !isKnownSpfTerm(t));
+  if (unknownTerms.length > 0) {
+    validations.push({
+      status: "fail",
+      message: `Unknown SPF ${unknownTerms.length === 1 ? "term" : "terms"} — receivers will permerror (RFC 7208 §4.6.1): ${unknownTerms.join(", ")}`,
+    });
+  }
+
   const hasFailure = validations.some((v) => v.status === "fail");
   const hasWarn = validations.some((v) => v.status === "warn");
   const status = hasFailure ? "fail" : hasWarn ? "warn" : "pass";
@@ -258,4 +267,27 @@ function parseSpfMechanisms(record: string): string[] {
     .replace(/^v=spf1\s*/, "")
     .split(/\s+/)
     .filter((t) => t.length > 0);
+}
+
+// RFC 7208 §5 mechanisms and §6 modifiers. Strip optional qualifier prefix
+// before matching so "+all", "-all", "~all", "?all" are all recognized.
+function isKnownSpfTerm(term: string): boolean {
+  const bare = term.replace(/^[+\-~?]/, "");
+  return (
+    bare === "all" ||
+    bare.startsWith("include:") ||
+    bare === "a" ||
+    bare.startsWith("a:") ||
+    bare.startsWith("a/") ||
+    bare === "mx" ||
+    bare.startsWith("mx:") ||
+    bare.startsWith("mx/") ||
+    bare === "ptr" ||
+    bare.startsWith("ptr:") ||
+    bare.startsWith("ip4:") ||
+    bare.startsWith("ip6:") ||
+    bare.startsWith("exists:") ||
+    bare.startsWith("redirect=") ||
+    bare.startsWith("exp=")
+  );
 }

--- a/test/analyzers.test.ts
+++ b/test/analyzers.test.ts
@@ -452,4 +452,55 @@ describe("analyzeSpf", () => {
       false,
     );
   });
+
+  it("fails when a typo'd mechanism is present (RFC 7208 §4.6.1 unknown term)", async () => {
+    mockQueryTxt.mockResolvedValue({
+      entries: ["v=spf1 inculde:spf.google.com -all"],
+      raw: "v=spf1 inculde:spf.google.com -all",
+    });
+
+    const result = await analyzeSpf("example.com");
+    expect(result.status).toBe("fail");
+    expect(
+      result.validations.some(
+        (v) =>
+          v.status === "fail" &&
+          v.message.includes("Unknown") &&
+          v.message.includes("inculde:spf.google.com"),
+      ),
+    ).toBe(true);
+  });
+
+  it("flags multiple unknown terms in a single validation (RFC 7208 §4.6.1)", async () => {
+    mockQueryTxt.mockResolvedValue({
+      entries: ["v=spf1 inculde:a.example.com somejunk -all"],
+      raw: "v=spf1 inculde:a.example.com somejunk -all",
+    });
+
+    const result = await analyzeSpf("example.com");
+    expect(result.status).toBe("fail");
+    const unknownValidation = result.validations.find(
+      (v) => v.status === "fail" && v.message.includes("Unknown"),
+    );
+    expect(unknownValidation?.message).toContain("inculde:a.example.com");
+    expect(unknownValidation?.message).toContain("somejunk");
+  });
+
+  it("does not flag unknown terms for a clean record with all known mechanisms", async () => {
+    mockQueryTxt.mockResolvedValueOnce({
+      entries: [
+        "v=spf1 ip4:192.0.2.0/24 ip6:2001:db8::/32 a mx include:_spf.example.com ~all",
+      ],
+      raw: "v=spf1 ip4:192.0.2.0/24 ip6:2001:db8::/32 a mx include:_spf.example.com ~all",
+    });
+    mockQueryTxt.mockResolvedValueOnce({
+      entries: ["v=spf1 ip4:203.0.113.0/24 -all"],
+      raw: "v=spf1 ip4:203.0.113.0/24 -all",
+    });
+
+    const result = await analyzeSpf("example.com");
+    expect(result.validations.some((v) => v.message.includes("Unknown"))).toBe(
+      false,
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `isKnownSpfTerm()` helper that validates each root-record SPF term against the RFC 7208 §5 mechanism list (`all`, `include:`, `a`, `mx`, `ptr`, `ip4:`, `ip6:`, `exists:`) and §6 modifier list (`redirect=`, `exp=`).
- Unknown terms (e.g. typos like `inculde:spf.google.com`) now push a `fail` validation citing RFC 7208 §4.6.1, since compliant receivers will permerror on unrecognized terms.
- Qualifier prefixes (`+`, `-`, `~`, `?`) are stripped before matching so `~all`, `-all`, etc. are all recognized correctly.

Closes #435 (partial — one backlog item; the issue stays open as the canonical checklist)

## Test plan

- [ ] `npm test` — 1252 passing, 0 new failures (1 pre-existing integration test fails due to live network in CI container)
- [ ] `npm run typecheck` — clean
- [ ] `npm run lint` — clean
- [ ] New tests: typo'd mechanism → `fail` + message includes term; multiple unknown terms → all listed; clean record with all known mechanisms → no unknown-term validation

## Deferred (from #435 checklist)

None from this item. Remaining items stay in #435 for follow-up focused PRs.

https://claude.ai/code/session_01KRQc4HQGqSBMirCMohyhoG

---
_Generated by [Claude Code](https://claude.ai/code/session_01KRQc4HQGqSBMirCMohyhoG)_