### PR TITLE
🛡️ Sentinel: [HIGH] Fix PII/secret leakage in Sentry logs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1513,6 +1513,26 @@ export default Sentry.withSentry<Env>(
         return samplingContext.parentSampled;
       return 0.3;
     },
+    beforeSend(event) {
+      if (event.request?.headers) {
+        const scrubbedHeaders = { ...event.request.headers };
+        for (const key of Object.keys(scrubbedHeaders)) {
+          const lowerKey = key.toLowerCase();
+          if (
+            lowerKey === "cookie" ||
+            lowerKey === "authorization" ||
+            lowerKey === "stripe-signature"
+          ) {
+            scrubbedHeaders[key] = "[Filtered]";
+          }
+        }
+        event.request.headers = scrubbedHeaders;
+      }
+      if (event.request?.cookies) {
+        event.request.cookies = { filtered: "[Filtered]" };
+      }
+      return event;
+    },
   }),
   handler,
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,7 @@ import {
   type RateLimitResult,
   rateLimitHeaders,
 } from "./rate-limit.js";
+import { scrubSentryEvent } from "./sentry-scrub.js";
 import { normalizeDomain } from "./shared/domain.js";
 import { listIndexableScanDomains } from "./shared/indexable-domains.js";
 import { watchlistCapFor } from "./shared/limits.js";
@@ -1513,26 +1514,10 @@ export default Sentry.withSentry<Env>(
         return samplingContext.parentSampled;
       return 0.3;
     },
-    beforeSend(event) {
-      if (event.request?.headers) {
-        const scrubbedHeaders = { ...event.request.headers };
-        for (const key of Object.keys(scrubbedHeaders)) {
-          const lowerKey = key.toLowerCase();
-          if (
-            lowerKey === "cookie" ||
-            lowerKey === "authorization" ||
-            lowerKey === "stripe-signature"
-          ) {
-            scrubbedHeaders[key] = "[Filtered]";
-          }
-        }
-        event.request.headers = scrubbedHeaders;
-      }
-      if (event.request?.cookies) {
-        event.request.cookies = { filtered: "[Filtered]" };
-      }
-      return event;
-    },
+    // Registered on both hooks: beforeSend only covers error events, and the
+    // SDK attaches request headers to transaction events too.
+    beforeSend: scrubSentryEvent,
+    beforeSendTransaction: scrubSentryEvent,
   }),
   handler,
 );

--- a/src/sentry-scrub.ts
+++ b/src/sentry-scrub.ts
@@ -1,0 +1,49 @@
+import type { Event } from "@sentry/cloudflare";
+
+// Header-name snippets treated as sensitive, mirroring @sentry/core's
+// SENSITIVE_HEADER_SNIPPETS (which the SDK only applies to span attributes,
+// not to event.request.headers) plus "signature" for stripe-signature.
+// Snippet matching (not exact names) is deliberate: it covers authorization,
+// cookie, stripe-signature, cf-access-jwt-assertion (the Access credential on
+// preview deploys), and any future *-token / *-key header without a code change.
+const SENSITIVE_HEADER_SNIPPETS = [
+  "auth",
+  "token",
+  "secret",
+  "session",
+  "password",
+  "passwd",
+  "pwd",
+  "key",
+  "jwt",
+  "bearer",
+  "sso",
+  "saml",
+  "csrf",
+  "xsrf",
+  "credentials",
+  "signature",
+  "cookie",
+];
+
+// Scrubs credentials from an outgoing Sentry event. Must be registered as BOTH
+// `beforeSend` and `beforeSendTransaction`: beforeSend only runs for error
+// events, while the SDK's requestDataIntegration attaches request headers to
+// transaction events too (~30% of requests via tracesSampler).
+export function scrubSentryEvent<E extends Event>(event: E): E {
+  if (event.request?.headers) {
+    // Copy before writing — the headers object is shared scope metadata.
+    const scrubbed: Record<string, string> = { ...event.request.headers };
+    for (const key of Object.keys(scrubbed)) {
+      const lowerKey = key.toLowerCase();
+      if (SENSITIVE_HEADER_SNIPPETS.some((s) => lowerKey.includes(s))) {
+        scrubbed[key] = "[Filtered]";
+      }
+    }
+    event.request.headers = scrubbed;
+  }
+  if (event.request?.cookies) {
+    event.request.cookies = { filtered: "[Filtered]" };
+  }
+  return event;
+}

--- a/test/sentry-scrub.test.ts
+++ b/test/sentry-scrub.test.ts
@@ -1,0 +1,85 @@
+import type { Event } from "@sentry/cloudflare";
+import { describe, expect, it } from "vitest";
+import { scrubSentryEvent } from "../src/sentry-scrub.js";
+
+function makeEvent(headers: Record<string, string>): Event {
+  return { request: { headers } };
+}
+
+describe("scrubSentryEvent", () => {
+  it("filters the credential headers dmarcheck receives", () => {
+    const event = scrubSentryEvent(
+      makeEvent({
+        authorization: "Bearer dmk_abc123",
+        cookie: "session=secret",
+        "stripe-signature": "t=1,v1=abc",
+        "cf-access-jwt-assertion": "eyJhbGciOi...",
+      }),
+    );
+    expect(event.request?.headers).toEqual({
+      authorization: "[Filtered]",
+      cookie: "[Filtered]",
+      "stripe-signature": "[Filtered]",
+      "cf-access-jwt-assertion": "[Filtered]",
+    });
+  });
+
+  it("matches header names case-insensitively", () => {
+    const event = scrubSentryEvent(
+      makeEvent({
+        Authorization: "Bearer dmk_abc123",
+        "CF-Access-Jwt-Assertion": "eyJhbGciOi...",
+      }),
+    );
+    expect(event.request?.headers).toEqual({
+      Authorization: "[Filtered]",
+      "CF-Access-Jwt-Assertion": "[Filtered]",
+    });
+  });
+
+  it("filters by sensitive snippet, not just exact names", () => {
+    const event = scrubSentryEvent(
+      makeEvent({
+        "x-api-key": "dmk_abc123",
+        "x-auth-token": "tok",
+        "x-csrf-token": "tok",
+      }),
+    );
+    expect(event.request?.headers).toEqual({
+      "x-api-key": "[Filtered]",
+      "x-auth-token": "[Filtered]",
+      "x-csrf-token": "[Filtered]",
+    });
+  });
+
+  it("leaves non-sensitive headers untouched", () => {
+    const headers = {
+      host: "dmarc.mx",
+      "content-type": "application/json",
+      "user-agent": "curl/8.0",
+      accept: "text/html",
+    };
+    const event = scrubSentryEvent(makeEvent({ ...headers }));
+    expect(event.request?.headers).toEqual(headers);
+  });
+
+  it("does not mutate the original headers object (shared scope data)", () => {
+    const headers = { authorization: "Bearer dmk_abc123" };
+    scrubSentryEvent(makeEvent(headers));
+    expect(headers.authorization).toBe("Bearer dmk_abc123");
+  });
+
+  it("blanks parsed cookies when present", () => {
+    const event: Event = {
+      request: { cookies: { session: "secret", theme: "dark" } },
+    };
+    expect(scrubSentryEvent(event).request?.cookies).toEqual({
+      filtered: "[Filtered]",
+    });
+  });
+
+  it("returns events without request data unchanged", () => {
+    const event: Event = { message: "boom" };
+    expect(scrubSentryEvent(event)).toBe(event);
+  });
+});


### PR DESCRIPTION
## 🚨 Severity
HIGH

## 💡 Vulnerability
The application previously did not scrub incoming request data before capturing exceptions via Sentry (identified as T6 in the Threat Model). This meant that if an error occurred on an authenticated route or a Stripe webhook, sensitive headers like `Authorization` (API keys), `Cookie` (session tokens), or `Stripe-Signature` could be included in the error report sent to Sentry, exposing them to anyone with access to the logs.

## 🎯 Impact
Exposure of sensitive credentials or PII to third-party logging services, potentially allowing unauthorized access to user accounts, API access, or billing manipulation if the logs were ever compromised.

## 🔧 Fix
Added a `beforeSend` hook in the `Sentry.withSentry` configuration inside `src/index.ts`. This hook intercepts the event before it is sent to Sentry, creates a copy of the request headers, and replaces the values of `cookie`, `authorization`, and `stripe-signature` with `[Filtered]`. It also filters the `cookies` object if present.

## ✅ Verification
1. `pnpm run lint:fix` passes.
2. `pnpm test` passes (1,249 tests passing, confirming no unintended side effects on request handling).
3. The Sentry `beforeSend` hook safely clones the headers before modifying them, avoiding any mutation of the live request object.

---
*PR created automatically by Jules for task [8890733642709389670](https://jules.google.com/task/8890733642709389670) started by @schmug*