### PR TITLE
🎨 Palette: fix multi-step wizard keyboard progression

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -26,3 +26,7 @@
 ## 2026-06-05 - Add data-loading-text to standard synchronous forms
 **Learning:** Using `data-loading-text` isn't just for heavy async processes; standard forms with synchronous POST operations (like settings saves, revokes, or dismissals) also benefit. It provides immediate visual feedback, confirms the click, and disables the button to prevent accidental double-submissions while the server processes the request.
 **Action:** Consistently apply `data-loading-text` to all `<button type="submit">` elements in the app (e.g., settings save buttons, destructive actions) to utilize the global form submit listener for consistent UX and protection against double-clicking.
+
+## 2026-06-06 - Multi-step Wizard Keyboard Progression
+**Learning:** Standard HTML forms will prematurely submit if a user hits "Enter" on an early step of a multi-step wizard, disrupting the user flow and potentially submitting incomplete data.
+**Action:** Intercept the `submit` event on the form and call `e.preventDefault()`. If the user is not on the final step, programmatically advance to the next step (e.g., by simulating a click on the "Next" button). This ensures smooth keyboard navigation through the wizard.

--- a/src/views/scripts.ts
+++ b/src/views/scripts.ts
@@ -1360,6 +1360,15 @@ if (typeof navigator !== 'undefined' && navigator.modelContext && typeof navigat
       if (e.key === 'Escape') closeWizard();
       else trapFocus(wizard, e);
     });
+
+    if (form) {
+      form.addEventListener('submit', function(e) {
+        if (step < 3) {
+          e.preventDefault();
+          if (nextBtn) nextBtn.click();
+        }
+      });
+    }
   }
 })();
 `;


### PR DESCRIPTION
## 💡 What

Intercepts the `submit` event on the Add Domain wizard form. If the user is on an early step (step 1 or 2) and presses Enter, it prevents the default form submission and programmatically triggers the "Next" button.

## 🎯 Why

Standard HTML forms naturally attempt to submit when a user presses "Enter" from within an input field. In a multi-step wizard, this disrupts the user flow by bypassing the remaining steps and submitting incomplete data. This change ensures users can smoothly navigate through the Add Domain wizard using only their keyboard.

## 📸 Before/After
_N/A - This is an interaction/behavioral change, no visual changes._

## ♿ Accessibility

Improves keyboard navigation. Users relying on keyboards can now safely press Enter to proceed to the next step without accidentally submitting the form early.

---
*PR created automatically by Jules for task [4245190694175708841](https://jules.google.com/task/4245190694175708841) started by @schmug*