### PR TITLE
seo: block CSV export URL crawling via robots.txt and nofollow

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -915,11 +915,16 @@ app.get("/llms.txt", (c) => {
 
 // Crawl guidance for search engines. Block the API namespace (Google was
 // logging `/api/check?domain=dmarc.mx` as "Crawled - currently not indexed"
-// noise) and point to the sitemap.
+// noise) and CSV export URLs (each crawl triggers a full live DNS scan; the
+// X-Robots-Tag: noindex on text/csv stops indexing but not crawling, #521),
+// and point to the sitemap. `/*format=csv` uses only Google-supported
+// wildcards and cannot match plain /check?domain=X pages because `=` is
+// rejected by normalizeDomain.
 app.get("/robots.txt", (c) => {
   const body = `User-agent: *
 Allow: /
 Disallow: /api/
+Disallow: /*format=csv
 Sitemap: https://dmarc.mx/sitemap.xml
 `;
   return c.body(body, 200, {

--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -440,7 +440,7 @@ function reportBody(result: ScanResult): string {
   <div class="report-meta">
     <time datetime="${esc(result.timestamp)}">Scanned ${esc(new Date(result.timestamp).toUTCString())}</time> &middot;
     <a href="/api/check?domain=${encodeURIComponent(result.domain)}">View JSON &nearr;</a> &middot;
-    <a href="/check?domain=${encodeURIComponent(result.domain)}&format=csv" class="csv-download">Download CSV &darr;</a>
+    <a href="/check?domain=${encodeURIComponent(result.domain)}&format=csv" class="csv-download" rel="nofollow">Download CSV &darr;</a>
   </div>
   ${renderMxCard(mx)}
   ${renderDmarcCard(dmarc)}
@@ -486,7 +486,7 @@ export function renderReportHeader(result: ScanResult): string {
   <div class="report-meta">
     <time datetime="${esc(result.timestamp)}">Scanned ${esc(new Date(result.timestamp).toUTCString())}</time> &middot;
     <a href="/api/check?domain=${encodeURIComponent(result.domain)}">View JSON &nearr;</a> &middot;
-    <a href="/check?domain=${encodeURIComponent(result.domain)}&format=csv" class="csv-download">Download CSV &darr;</a>
+    <a href="/check?domain=${encodeURIComponent(result.domain)}&format=csv" class="csv-download" rel="nofollow">Download CSV &darr;</a>
   </div>`;
 }
 

--- a/test/components.test.ts
+++ b/test/components.test.ts
@@ -13,7 +13,12 @@ import {
   statusDot,
   themeToggle,
 } from "../src/views/components";
-import { renderError, renderLandingPage } from "../src/views/html";
+import {
+  renderError,
+  renderLandingPage,
+  renderReport,
+  renderReportHeader,
+} from "../src/views/html";
 import { CSS } from "../src/views/styles";
 
 function makeScanResult(overrides: Partial<ScanResult> = {}): ScanResult {
@@ -452,5 +457,23 @@ describe("page HTML theme integration", () => {
     const html = renderLandingPage();
     expect(html).toContain('fill="currentColor"');
     expect(html).not.toContain('fill="#71717a"');
+  });
+});
+
+describe("CSV download links", () => {
+  // Googlebot was re-crawling /check?domain=X&format=csv URLs discovered via
+  // these anchors, burning crawl budget and triggering live DNS scans (#521).
+  it("renderReport marks the CSV export anchor rel=nofollow", () => {
+    const html = renderReport(makeScanResult());
+    expect(html).toContain(
+      '<a href="/check?domain=example.com&format=csv" class="csv-download" rel="nofollow">Download CSV',
+    );
+  });
+
+  it("renderReportHeader marks the CSV export anchor rel=nofollow", () => {
+    const html = renderReportHeader(makeScanResult());
+    expect(html).toContain(
+      '<a href="/check?domain=example.com&format=csv" class="csv-download" rel="nofollow">Download CSV',
+    );
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -707,6 +707,15 @@ describe("SEO routes", () => {
     expect(body).toContain("Sitemap: https://dmarc.mx/sitemap.xml");
   });
 
+  it("disallows CSV export URLs without blocking plain /check pages", async () => {
+    const res = await app.request("/robots.txt");
+    const body = await res.text();
+    expect(body).toContain("Disallow: /*format=csv");
+    // Plain /check?domain=X pages are indexed and earning impressions —
+    // no rule may match them.
+    expect(body).not.toContain("Disallow: /check");
+  });
+
   it("serves /sitemap.xml listing the core URLs", async () => {
     const res = await app.request("/sitemap.xml");
     expect(res.status).toBe(200);


### PR DESCRIPTION
## Summary

Implements #521 — stops Googlebot from re-crawling `/check?domain=X&format=csv` export URLs, which burn crawl budget and trigger a full live DNS scan per fetch.

- **robots.txt** ([src/index.ts](src/index.ts)): added `Disallow: /*format=csv`. Uses only Google-supported wildcards (`*`); cannot match plain `/check?domain=X` pages (which are indexed and earning impressions) because `=` is rejected by `normalizeDomain`'s `[a-z0-9.-]` allowlist.
- **`rel="nofollow"`** on both "Download CSV" anchors in [src/views/html.ts](src/views/html.ts) (`reportBody` and `renderReportHeader`). Link text and styling unchanged.
- The `X-Robots-Tag: noindex` middleware on `text/csv` is untouched (defense in depth — it prevents indexing but not crawling).

## Tests (TDD — failing tests written first)

- Extended the robots.txt test in `test/index.test.ts`: asserts `Disallow: /*format=csv` is present and that no `Disallow: /check` rule exists.
- New `CSV download links` describe in `test/components.test.ts`: asserts both `renderReport` and `renderReportHeader` emit the anchor with `rel="nofollow"`.

## Results

- `npm test`: **1263 passing, 0 failing** (76 files)
- `npm run lint`: clean
- `npm run typecheck`: clean
- Verified live against `wrangler dev`: `/robots.txt` serves the new rule; `/check?domain=dmarc.mx&_direct=1` renders the CSV anchor with `rel="nofollow"`.

## Out of scope (per issue)

`/check/score` endpoint, sitemap changes, `src/csv.ts` — none touched. No spec gaps identified.

Closes #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)