### PR TITLE
security: mask sensitive query params in scrubSentryEvent

### DIFF
--- a/src/sentry-scrub.ts
+++ b/src/sentry-scrub.ts
@@ -38,34 +38,37 @@ function isSensitiveParam(name: string): boolean {
   );
 }
 
+// Masks sensitive param values in a raw query string (no leading "?") via
+// string surgery rather than URLSearchParams: the masked value stays a literal
+// "[Filtered]" (not %5BFiltered%5D) and untouched params keep their original
+// byte-for-byte encoding instead of being re-serialized.
 function scrubQueryString(qs: string): string {
   if (!qs) return qs;
-  const params = new URLSearchParams(qs);
-  let changed = false;
-  for (const key of [...params.keys()]) {
-    if (isSensitiveParam(key)) {
-      params.set(key, "[Filtered]");
-      changed = true;
-    }
-  }
-  return changed ? params.toString() : qs;
+  return qs
+    .split("&")
+    .map((pair) => {
+      const eq = pair.indexOf("=");
+      if (eq === -1) return pair;
+      const name = pair.slice(0, eq);
+      return isSensitiveParam(name) ? `${name}=[Filtered]` : pair;
+    })
+    .join("&");
 }
 
 function scrubUrlString(raw: string): string {
-  let parsed: URL;
   try {
-    parsed = new URL(raw);
+    // Parseability check only — a relative or malformed URL is returned
+    // as-is rather than risking a throw inside a beforeSend* hook (which
+    // would drop the event). String surgery below avoids URL re-encoding.
+    new URL(raw);
   } catch {
     return raw;
   }
-  let changed = false;
-  for (const key of [...parsed.searchParams.keys()]) {
-    if (isSensitiveParam(key)) {
-      parsed.searchParams.set(key, "[Filtered]");
-      changed = true;
-    }
-  }
-  return changed ? parsed.toString() : raw;
+  const queryStart = raw.indexOf("?");
+  if (queryStart === -1) return raw;
+  return (
+    raw.slice(0, queryStart + 1) + scrubQueryString(raw.slice(queryStart + 1))
+  );
 }
 
 // Scrubs credentials from an outgoing Sentry event. Must be registered as BOTH

--- a/src/sentry-scrub.ts
+++ b/src/sentry-scrub.ts
@@ -26,6 +26,48 @@ const SENSITIVE_HEADER_SNIPPETS = [
   "cookie",
 ];
 
+// OAuth callback params not matched by SENSITIVE_HEADER_SNIPPETS but sensitive
+// when they appear in request URLs (code is single-use; state carries CSRF token).
+const SENSITIVE_PARAM_EXACT = new Set(["code", "state"]);
+
+function isSensitiveParam(name: string): boolean {
+  const lower = name.toLowerCase();
+  return (
+    SENSITIVE_PARAM_EXACT.has(lower) ||
+    SENSITIVE_HEADER_SNIPPETS.some((s) => lower.includes(s))
+  );
+}
+
+function scrubQueryString(qs: string): string {
+  if (!qs) return qs;
+  const params = new URLSearchParams(qs);
+  let changed = false;
+  for (const key of [...params.keys()]) {
+    if (isSensitiveParam(key)) {
+      params.set(key, "[Filtered]");
+      changed = true;
+    }
+  }
+  return changed ? params.toString() : qs;
+}
+
+function scrubUrlString(raw: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return raw;
+  }
+  let changed = false;
+  for (const key of [...parsed.searchParams.keys()]) {
+    if (isSensitiveParam(key)) {
+      parsed.searchParams.set(key, "[Filtered]");
+      changed = true;
+    }
+  }
+  return changed ? parsed.toString() : raw;
+}
+
 // Scrubs credentials from an outgoing Sentry event. Must be registered as BOTH
 // `beforeSend` and `beforeSendTransaction`: beforeSend only runs for error
 // events, while the SDK's requestDataIntegration attaches request headers to
@@ -44,6 +86,28 @@ export function scrubSentryEvent<E extends Event>(event: E): E {
   }
   if (event.request?.cookies) {
     event.request.cookies = { filtered: "[Filtered]" };
+  }
+  if (event.request?.url) {
+    event.request.url = scrubUrlString(event.request.url);
+  }
+  if (event.request?.query_string !== undefined) {
+    const qs = event.request.query_string;
+    if (typeof qs === "string") {
+      event.request.query_string = scrubQueryString(qs);
+    } else if (Array.isArray(qs)) {
+      event.request.query_string = (qs as [string, string][]).map(
+        ([k, v]): [string, string] => [
+          k,
+          isSensitiveParam(k) ? "[Filtered]" : v,
+        ],
+      );
+    } else if (qs !== null && typeof qs === "object") {
+      const result: Record<string, string> = {};
+      for (const [k, v] of Object.entries(qs)) {
+        result[k] = isSensitiveParam(k) ? "[Filtered]" : v;
+      }
+      event.request.query_string = result;
+    }
   }
   return event;
 }

--- a/test/sentry-scrub.test.ts
+++ b/test/sentry-scrub.test.ts
@@ -83,3 +83,79 @@ describe("scrubSentryEvent", () => {
     expect(scrubSentryEvent(event)).toBe(event);
   });
 });
+
+describe("scrubSentryEvent — URL and query_string scrubbing", () => {
+  it("masks token param in request.url", () => {
+    const event = scrubSentryEvent({
+      request: {
+        url: "https://dmarc.mx/alerts/unsubscribe?token=abc123&domain=example.com",
+      },
+    } as Event);
+    expect(event.request?.url).toBe(
+      "https://dmarc.mx/alerts/unsubscribe?token=%5BFiltered%5D&domain=example.com",
+    );
+  });
+
+  it("masks code and state params in auth callback URL", () => {
+    const event = scrubSentryEvent({
+      request: {
+        url: "https://dmarc.mx/auth/callback?code=AUTHCODE&state=STATETOKEN&foo=bar",
+      },
+    } as Event);
+    expect(event.request?.url).toBe(
+      "https://dmarc.mx/auth/callback?code=%5BFiltered%5D&state=%5BFiltered%5D&foo=bar",
+    );
+  });
+
+  it("leaves non-sensitive URL params unchanged", () => {
+    const url = "https://dmarc.mx/check?domain=example.com&format=json";
+    const event = scrubSentryEvent({ request: { url } } as Event);
+    expect(event.request?.url).toBe(url);
+  });
+
+  it("does not throw on a malformed or relative URL, returns it unchanged", () => {
+    const badUrl = "/relative/path?token=abc";
+    const event = scrubSentryEvent({ request: { url: badUrl } } as Event);
+    expect(event.request?.url).toBe(badUrl);
+  });
+
+  it("masks sensitive params in string query_string", () => {
+    const event = scrubSentryEvent({
+      request: {
+        url: "https://dmarc.mx/alerts/unsubscribe?token=abc123&domain=example.com",
+        query_string: "token=abc123&domain=example.com",
+      },
+    } as Event);
+    expect(event.request?.query_string).toBe(
+      "token=%5BFiltered%5D&domain=example.com",
+    );
+  });
+
+  it("leaves non-sensitive query_string params unchanged", () => {
+    const qs = "domain=example.com&format=json";
+    const event = scrubSentryEvent({ request: { query_string: qs } } as Event);
+    expect(event.request?.query_string).toBe(qs);
+  });
+
+  it("handles empty string query_string without throwing", () => {
+    const event = scrubSentryEvent({
+      request: { query_string: "" },
+    } as Event);
+    expect(event.request?.query_string).toBe("");
+  });
+
+  it("masks params case-insensitively (Token, CODE, STATE)", () => {
+    const event = scrubSentryEvent({
+      request: {
+        url: "https://dmarc.mx/auth/callback?CODE=xyz&State=abc&domain=ex.com",
+        query_string: "CODE=xyz&State=abc&domain=ex.com",
+      },
+    } as Event);
+    expect(event.request?.url).toContain("CODE=%5BFiltered%5D");
+    expect(event.request?.url).toContain("State=%5BFiltered%5D");
+    expect(event.request?.url).toContain("domain=ex.com");
+    expect(event.request?.query_string).toContain("CODE=%5BFiltered%5D");
+    expect(event.request?.query_string).toContain("State=%5BFiltered%5D");
+    expect(event.request?.query_string).toContain("domain=ex.com");
+  });
+});

--- a/test/sentry-scrub.test.ts
+++ b/test/sentry-scrub.test.ts
@@ -85,14 +85,14 @@ describe("scrubSentryEvent", () => {
 });
 
 describe("scrubSentryEvent — URL and query_string scrubbing", () => {
-  it("masks token param in request.url", () => {
+  it("masks token param in request.url with a literal [Filtered]", () => {
     const event = scrubSentryEvent({
       request: {
         url: "https://dmarc.mx/alerts/unsubscribe?token=abc123&domain=example.com",
       },
     } as Event);
     expect(event.request?.url).toBe(
-      "https://dmarc.mx/alerts/unsubscribe?token=%5BFiltered%5D&domain=example.com",
+      "https://dmarc.mx/alerts/unsubscribe?token=[Filtered]&domain=example.com",
     );
   });
 
@@ -103,7 +103,33 @@ describe("scrubSentryEvent — URL and query_string scrubbing", () => {
       },
     } as Event);
     expect(event.request?.url).toBe(
-      "https://dmarc.mx/auth/callback?code=%5BFiltered%5D&state=%5BFiltered%5D&foo=bar",
+      "https://dmarc.mx/auth/callback?code=[Filtered]&state=[Filtered]&foo=bar",
+    );
+  });
+
+  it("masks params whose names contain a sensitive header snippet", () => {
+    const event = scrubSentryEvent({
+      request: {
+        query_string: "api_key=dmk_abc&session_id=s1&signature=sig",
+      },
+    } as Event);
+    expect(event.request?.query_string).toBe(
+      "api_key=[Filtered]&session_id=[Filtered]&signature=[Filtered]",
+    );
+  });
+
+  it("preserves the original encoding of untouched params", () => {
+    const event = scrubSentryEvent({
+      request: {
+        url: "https://dmarc.mx/check?domain=ex%2Eample.com&q=a%20b+c&token=tok",
+        query_string: "domain=ex%2Eample.com&q=a%20b+c&token=tok",
+      },
+    } as Event);
+    expect(event.request?.url).toBe(
+      "https://dmarc.mx/check?domain=ex%2Eample.com&q=a%20b+c&token=[Filtered]",
+    );
+    expect(event.request?.query_string).toBe(
+      "domain=ex%2Eample.com&q=a%20b+c&token=[Filtered]",
     );
   });
 
@@ -117,6 +143,10 @@ describe("scrubSentryEvent — URL and query_string scrubbing", () => {
     const badUrl = "/relative/path?token=abc";
     const event = scrubSentryEvent({ request: { url: badUrl } } as Event);
     expect(event.request?.url).toBe(badUrl);
+    const malformed = scrubSentryEvent({
+      request: { url: "http://[bad" },
+    } as Event);
+    expect(malformed.request?.url).toBe("http://[bad");
   });
 
   it("masks sensitive params in string query_string", () => {
@@ -127,7 +157,7 @@ describe("scrubSentryEvent — URL and query_string scrubbing", () => {
       },
     } as Event);
     expect(event.request?.query_string).toBe(
-      "token=%5BFiltered%5D&domain=example.com",
+      "token=[Filtered]&domain=example.com",
     );
   });
 
@@ -151,11 +181,11 @@ describe("scrubSentryEvent — URL and query_string scrubbing", () => {
         query_string: "CODE=xyz&State=abc&domain=ex.com",
       },
     } as Event);
-    expect(event.request?.url).toContain("CODE=%5BFiltered%5D");
-    expect(event.request?.url).toContain("State=%5BFiltered%5D");
+    expect(event.request?.url).toContain("CODE=[Filtered]");
+    expect(event.request?.url).toContain("State=[Filtered]");
     expect(event.request?.url).toContain("domain=ex.com");
-    expect(event.request?.query_string).toContain("CODE=%5BFiltered%5D");
-    expect(event.request?.query_string).toContain("State=%5BFiltered%5D");
+    expect(event.request?.query_string).toContain("CODE=[Filtered]");
+    expect(event.request?.query_string).toContain("State=[Filtered]");
     expect(event.request?.query_string).toContain("domain=ex.com");
   });
 });


### PR DESCRIPTION
## Summary

- Extends `scrubSentryEvent` to redact values of sensitive query parameters from `event.request.url` and `event.request.query_string` before events leave the worker
- Covers `token`, `code`, `state` (case-insensitive exact match) plus any param name containing a `SENSITIVE_HEADER_SNIPPETS` snippet
- Malformed or relative URLs are returned unchanged to prevent exceptions in the `beforeSend`/`beforeSendTransaction` hooks

Closes #519

## Test plan

- [x] 8 new tests in `test/sentry-scrub.test.ts` covering: `token=` masking, `code=`/`state=` OAuth masking, non-sensitive params unchanged, malformed URL no-throw, string `query_string` masking, empty `query_string`, case-insensitive param names
- [x] All 7 existing header/cookie scrub tests still pass (1267 passing, 1 pre-existing network failure unrelated to this change)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean

## What this does NOT change

- `beforeSend` / `beforeSendTransaction` hook registration (`src/index.ts:1519-1520`) — unchanged
- Header and cookie scrubbing behavior — unchanged
- `tracesSampler` or any sampling behavior — out of scope per issue

---
_Generated by [Claude Code](https://claude.ai/code/session_011DV8oiUPghi4d2xQDzZcyz)_