### PR TITLE
security: mask sensitive query params in Sentry events

### DIFF
--- a/src/sentry-scrub.ts
+++ b/src/sentry-scrub.ts
@@ -26,10 +26,54 @@ const SENSITIVE_HEADER_SNIPPETS = [
   "cookie",
 ];
 
+// Query params whose exact (lowercased) name is sensitive even though it
+// contains no header snippet: the unsubscribe HMAC (?token= is snippet-covered,
+// but listed for clarity) and the WorkOS callback's ?code= / ?state=.
+const SENSITIVE_PARAM_NAMES = ["token", "code", "state"];
+
+function isSensitiveParamName(name: string): boolean {
+  const lowerName = name.toLowerCase();
+  return (
+    SENSITIVE_PARAM_NAMES.includes(lowerName) ||
+    SENSITIVE_HEADER_SNIPPETS.some((s) => lowerName.includes(s))
+  );
+}
+
+// Masks sensitive param values in a raw query string (no leading "?"),
+// preserving param names and the original encoding of everything else.
+function maskQueryString(query: string): string {
+  if (!query) return query;
+  return query
+    .split("&")
+    .map((pair) => {
+      const eq = pair.indexOf("=");
+      if (eq === -1) return pair;
+      const name = pair.slice(0, eq);
+      return isSensitiveParamName(name) ? `${name}=[Filtered]` : pair;
+    })
+    .join("&");
+}
+
+function maskUrl(url: string): string {
+  try {
+    // Parseability check only — a relative or malformed URL is returned
+    // as-is rather than risking a throw inside a beforeSend* hook (which
+    // would drop the event). String surgery below avoids URL re-encoding.
+    new URL(url);
+  } catch {
+    return url;
+  }
+  const queryStart = url.indexOf("?");
+  if (queryStart === -1) return url;
+  const prefix = url.slice(0, queryStart + 1);
+  return prefix + maskQueryString(url.slice(queryStart + 1));
+}
+
 // Scrubs credentials from an outgoing Sentry event. Must be registered as BOTH
 // `beforeSend` and `beforeSendTransaction`: beforeSend only runs for error
-// events, while the SDK's requestDataIntegration attaches request headers to
-// transaction events too (~30% of requests via tracesSampler).
+// events, while the SDK's requestDataIntegration attaches request headers,
+// the full request URL, and the query string to transaction events too
+// (~30% of requests via tracesSampler).
 export function scrubSentryEvent<E extends Event>(event: E): E {
   if (event.request?.headers) {
     // Copy before writing — the headers object is shared scope metadata.
@@ -44,6 +88,12 @@ export function scrubSentryEvent<E extends Event>(event: E): E {
   }
   if (event.request?.cookies) {
     event.request.cookies = { filtered: "[Filtered]" };
+  }
+  if (typeof event.request?.url === "string") {
+    event.request.url = maskUrl(event.request.url);
+  }
+  if (typeof event.request?.query_string === "string") {
+    event.request.query_string = maskQueryString(event.request.query_string);
   }
   return event;
 }

--- a/test/sentry-scrub.test.ts
+++ b/test/sentry-scrub.test.ts
@@ -82,4 +82,88 @@ describe("scrubSentryEvent", () => {
     const event: Event = { message: "boom" };
     expect(scrubSentryEvent(event)).toBe(event);
   });
+
+  describe("sensitive query params", () => {
+    it("masks the unsubscribe token value in request.url", () => {
+      const event: Event = {
+        request: { url: "https://dmarc.mx/email/unsubscribe?token=abc123" },
+      };
+      expect(scrubSentryEvent(event).request?.url).toBe(
+        "https://dmarc.mx/email/unsubscribe?token=[Filtered]",
+      );
+    });
+
+    it("masks code and state in both url and query_string", () => {
+      const event: Event = {
+        request: {
+          url: "https://dmarc.mx/auth/callback?code=authcode123&state=st456",
+          query_string: "code=authcode123&state=st456",
+        },
+      };
+      const scrubbed = scrubSentryEvent(event);
+      expect(scrubbed.request?.url).toBe(
+        "https://dmarc.mx/auth/callback?code=[Filtered]&state=[Filtered]",
+      );
+      expect(scrubbed.request?.query_string).toBe(
+        "code=[Filtered]&state=[Filtered]",
+      );
+    });
+
+    it("matches param names case-insensitively", () => {
+      const event: Event = {
+        request: { query_string: "TOKEN=abc&Code=def&State=ghi" },
+      };
+      expect(scrubSentryEvent(event).request?.query_string).toBe(
+        "TOKEN=[Filtered]&Code=[Filtered]&State=[Filtered]",
+      );
+    });
+
+    it("masks params whose names contain a sensitive header snippet", () => {
+      const event: Event = {
+        request: {
+          query_string: "api_key=dmk_abc&session_id=s1&signature=sig",
+        },
+      };
+      expect(scrubSentryEvent(event).request?.query_string).toBe(
+        "api_key=[Filtered]&session_id=[Filtered]&signature=[Filtered]",
+      );
+    });
+
+    it("leaves non-sensitive params unchanged alongside masked ones", () => {
+      const event: Event = {
+        request: {
+          url: "https://dmarc.mx/check?domain=example.com&format=json&selectors=s1.s2&token=tok",
+          query_string:
+            "domain=example.com&format=json&selectors=s1.s2&token=tok",
+        },
+      };
+      const scrubbed = scrubSentryEvent(event);
+      expect(scrubbed.request?.url).toBe(
+        "https://dmarc.mx/check?domain=example.com&format=json&selectors=s1.s2&token=[Filtered]",
+      );
+      expect(scrubbed.request?.query_string).toBe(
+        "domain=example.com&format=json&selectors=s1.s2&token=[Filtered]",
+      );
+    });
+
+    it("returns a relative or malformed url unchanged without throwing", () => {
+      const relative: Event = {
+        request: { url: "/email/unsubscribe?token=abc" },
+      };
+      expect(scrubSentryEvent(relative).request?.url).toBe(
+        "/email/unsubscribe?token=abc",
+      );
+      const malformed: Event = { request: { url: "http://[bad" } };
+      expect(scrubSentryEvent(malformed).request?.url).toBe("http://[bad");
+    });
+
+    it("returns an empty query_string and a query-less url unchanged", () => {
+      const event: Event = {
+        request: { url: "https://dmarc.mx/check", query_string: "" },
+      };
+      const scrubbed = scrubSentryEvent(event);
+      expect(scrubbed.request?.url).toBe("https://dmarc.mx/check");
+      expect(scrubbed.request?.query_string).toBe("");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

`@sentry/cloudflare`'s `requestDataIntegration` attaches the full request URL and raw query string to every outgoing event (errors **and** transactions), so first-party tokens were reaching Sentry: the `/email/unsubscribe?token=<HMAC>` link and the WorkOS callback's `?code=…&state=…`. This extends `scrubSentryEvent` (already registered as both `beforeSend` and `beforeSendTransaction`) to mask those values in `event.request.url` and `event.request.query_string`.

Residual low finding from the security review of #516.

Closes #519

## Approach

- Params named `token`, `code`, or `state` (case-insensitive), plus any param whose lowercased name contains a snippet from the existing `SENSITIVE_HEADER_SNIPPETS` list (`api_key`, `session_id`, `signature`, …), get their value replaced with `[Filtered]`. Param names are preserved for debuggability.
- Both fields are masked with the same query-string surgery (split on `&`, replace value after the first `=`), so `url` and `query_string` stay consistent and non-sensitive params keep their original encoding byte-for-byte.
- `maskUrl` uses `new URL()` purely as a parseability gate: a relative or malformed URL is returned unchanged instead of throwing — an exception in a `beforeSend*` hook would drop the event entirely. The function stays pure and dependency-free.
- No change to hook registration in `src/index.ts`; header/cookie scrubbing is untouched.

## Testing (TDD)

Wrote the 7 new tests first and watched them fail (5 failed on unmasked values; 2 are no-throw/unchanged guards), then implemented:

- `test/sentry-scrub.test.ts`: 14 passed (7 existing + 7 new)
- `npm run typecheck`: clean
- `npm run lint`: clean (156 files, no fixes)
- `npm test`: 1266 passed; 1 pre-existing local-environment failure in `test/integration/mta-sts-runtime.test.ts` (live-network fetch inside workerd fails on this machine — it fails identically on a clean tree with this change stashed, and the production endpoint itself is healthy via curl/dig). CI on `ubuntu-latest` is the authoritative gate for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)