### PR TITLE
seo: add "How to find your DKIM selector" section to /learn/dkim

### DIFF
--- a/src/analyzers/dkim.ts
+++ b/src/analyzers/dkim.ts
@@ -2,7 +2,7 @@ import { queryTxt } from "../dns/client.js";
 import { parseTags } from "../shared/parse-tags.js";
 import type { DkimResult, DkimSelectorResult, Validation } from "./types.js";
 
-const COMMON_SELECTORS = [
+export const COMMON_SELECTORS = [
   "google",
   "selector1",
   "selector2",

--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -1,3 +1,4 @@
+import { COMMON_SELECTORS } from "../analyzers/dkim.js";
 import type {
   BimiResult,
   DaneResult,
@@ -166,7 +167,7 @@ export function renderLandingPage(): string {
                    autocorrect="off"
                    spellcheck="false"
                    aria-describedby="selectors-help" />
-            <small id="selectors-help">Comma-separated. These are checked in addition to the 38 common selectors.</small>
+            <small id="selectors-help">Comma-separated. These are checked in addition to the ${COMMON_SELECTORS.length} common selectors.</small>
           </div>
         </details>
       </form>
@@ -199,7 +200,7 @@ export function renderLandingPage(): string {
     <dl class="explainer-grid">
       <div><dt><a href="/learn/dmarc">DMARC</a></dt><dd>The policy record that tells receivers how to treat unauthenticated mail and where to send aggregate reports.</dd></div>
       <div><dt><a href="/learn/spf">SPF</a></dt><dd>The list of hosts authorized to send on your behalf, including the 10-DNS-lookup budget.</dd></div>
-      <div><dt><a href="/learn/dkim">DKIM</a></dt><dd>Per-selector signing keys and their key length, checked against 38 common selectors.</dd></div>
+      <div><dt><a href="/learn/dkim">DKIM</a></dt><dd>Per-selector signing keys and their key length, checked against ${COMMON_SELECTORS.length} common selectors.</dd></div>
       <div><dt><a href="/learn/bimi">BIMI</a></dt><dd>The brand logo record that can render next to authenticated messages in supporting inboxes.</dd></div>
       <div><dt><a href="/learn/mta-sts">MTA-STS</a></dt><dd>The TLS enforcement policy that prevents downgrade attacks on inbound mail.</dd></div>
       <div><dt>MX</dt><dd>The mail exchangers that accept inbound mail for the domain, with provider detection. Informational — not part of the grade.</dd></div>

--- a/src/views/learn.ts
+++ b/src/views/learn.ts
@@ -1,3 +1,4 @@
+import { COMMON_SELECTORS } from "../analyzers/dkim.js";
 import { esc, generateCreature } from "./components.js";
 import { page, SITE_ORIGIN } from "./html.js";
 
@@ -8,7 +9,7 @@ import { page, SITE_ORIGIN } from "./html.js";
 
 // Bump when materially editing any learn page prose. It lives here rather than
 // per-function so all five stay in sync by default.
-const LEARN_PUBLISHED = "2026-04-11";
+const LEARN_PUBLISHED = "2026-06-12";
 
 interface LearnPageOptions {
   protocol: string; // "DMARC"
@@ -425,7 +426,21 @@ export function renderLearnDkim(): string {
         <div><dt><code>t</code></dt><dd>Flags. <code>t=y</code> marks the selector as testing-only — receivers are expected to treat failures leniently.</dd></div>
         <div><dt>Selector</dt><dd>An arbitrary label you pick (e.g. <code>google</code>, <code>selector1</code>, <code>s1</code>) that lets you publish multiple keys simultaneously for rotation.</dd></div>
       </dl>
-      <p class="tier-text" style="margin-top:12px">dmarcheck automatically probes 38 common selectors used by major providers (Google Workspace, Microsoft 365, Proton Mail, Fastmail, Zoho, Postmark, Amazon SES, and others), and you can pass a custom selector in the Advanced options on the home page if you use something unusual.</p>
+      <p class="tier-text" style="margin-top:12px">dmarcheck automatically probes ${COMMON_SELECTORS.length} common selectors used by major providers (Google Workspace, Microsoft 365, Proton Mail, Fastmail, Zoho, Postmark, Amazon SES, and others), and you can pass a custom selector in the Advanced options on the home page if you use something unusual.</p>
+    </div>
+  </div>
+
+  <div class="bd-card">
+    <h2 class="bd-card-title" id="find-your-selector">How to find your DKIM selector</h2>
+    <div class="bd-card-body">
+      <p class="tier-text">The selector is not a secret — every signed message announces it. If a vendor doc told you to &ldquo;check your DKIM selector&rdquo; or a scan came back with no selectors found, here is where to look.</p>
+      <ol class="learn-steps">
+        <li><strong>Read it out of a message you sent.</strong> Open a message from your domain in the receiving mailbox and view the full headers (Gmail: three-dot menu &rarr; &ldquo;Show original&rdquo;; Outlook: &ldquo;View message source&rdquo;). Find the <code>DKIM-Signature</code> header — the <code>s=</code> tag is the selector and <code>d=</code> is the domain it signs for:
+        <pre class="learn-example"><code>DKIM-Signature: v=1; a=rsa-sha256; d=yourdomain.com; s=selector1; ...</code></pre>
+        Here the selector is <code>selector1</code>, so the public key lives at <code>selector1._domainkey.yourdomain.com</code> — exactly the record dmarcheck looks up.</li>
+        <li><strong>Try your provider's documented default.</strong> Google Workspace signs with <code>google</code>, Microsoft 365 rotates between <code>selector1</code> and <code>selector2</code>, Proton Mail uses <code>protonmail</code> (plus <code>protonmail2</code> and <code>protonmail3</code>), Fastmail uses <code>fm1</code> through <code>fm3</code>, and Zoho Mail uses <code>default</code>.</li>
+        <li><strong>Or skip the detective work and scan.</strong> dmarcheck probes ${COMMON_SELECTORS.length} common selectors on every scan — the provider defaults above plus the usual names from transactional senders like Postmark, Mandrill, and Amazon SES. If yours is custom, add it under Advanced options on the home page and scan again.</li>
+      </ol>
     </div>
   </div>
 
@@ -465,7 +480,7 @@ export function renderLearnDkim(): string {
       "What is DKIM? Selectors, key rotation, and 2048-bit keys — dmarcheck",
     headline: "What is DKIM? Selectors, key strength, and rotation",
     description:
-      "A plain-English guide to DKIM: how signing selectors live in DNS, why 2048-bit keys matter, how to rotate without downtime, and why dmarcheck probes 38 common selectors.",
+      "A plain-English guide to DKIM: how to find your DKIM selector from a message header or your provider's default, why 2048-bit keys matter, and how to rotate without downtime.",
     body,
   });
 }

--- a/src/views/styles.ts
+++ b/src/views/styles.ts
@@ -643,6 +643,7 @@ h1.domain-name, .domain-name { font-size: 1.5rem; font-weight: 700; margin: 0; }
 .bd-card-title {
   font-size: 0.75rem; font-weight: 600; text-transform: uppercase;
   letter-spacing: 1px; color: var(--clr-text-muted); padding: 14px 18px 0;
+  margin: 0;
 }
 .bd-card-body { padding: 12px 18px 16px; }
 .tier-text { font-size: 0.9rem; line-height: 1.6; color: var(--clr-text); }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -595,6 +595,15 @@ describe("HTML head tags", () => {
     expect(html).toContain('<dt><a href="/learn/mta-sts">MTA-STS</a></dt>');
   });
 
+  it("landing page cites the analyzer's real selector probe count", async () => {
+    const res = await app.request("/");
+    const html = await res.text();
+    // Copy must not hardcode the probe count — it drifted to a stale "38"
+    // while COMMON_SELECTORS held 36 entries (#523).
+    expect(html).toContain(`${COMMON_SELECTORS.length} common selectors`);
+    expect(html).not.toContain("38 common selectors");
+  });
+
   it("landing explainer lists every checked protocol, not just the graded set", async () => {
     const res = await app.request("/");
     const html = await res.text();

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { COMMON_SELECTORS } from "../src/analyzers/dkim.js";
 import { app, normalizeDomain, parseSelectors } from "../src/index.js";
 import { _memoryStore } from "../src/rate-limit.js";
 
@@ -901,6 +902,33 @@ describe("Learn pages", () => {
     const html = await res.text();
     expect(html).toContain("2048");
     expect(html).toMatch(/selector/i);
+  });
+
+  it("DKIM learn page explains how to find your selector under a stable anchor", async () => {
+    const res = await app.request("/learn/dkim");
+    const html = await res.text();
+    // The anchor id is a contract: scan-report validations will deep-link to
+    // it (#524). Do not rename without checking callers.
+    expect(html).toMatch(/<h2[^>]*\bid="find-your-selector"[^>]*>/);
+    // Path 1: read the s= tag from a real DKIM-Signature header
+    expect(html).toContain("DKIM-Signature");
+    expect(html).toContain("<code>s=</code>");
+    // Path 2: provider defaults, sourced from the analyzer's probe list
+    for (const sel of ["google", "selector1", "selector2"]) {
+      expect(COMMON_SELECTORS).toContain(sel);
+      expect(html).toContain(`<code>${sel}</code>`);
+    }
+    // Path 3: the scan CTA cites the analyzer's real probe count
+    expect(html).toContain(`${COMMON_SELECTORS.length} common selectors`);
+    expect(html).not.toContain("38 common selectors");
+  });
+
+  it("DKIM learn page meta description includes selector-finding phrasing", async () => {
+    const res = await app.request("/learn/dkim");
+    const html = await res.text();
+    expect(html).toMatch(
+      /<meta name="description" content="[^"]*find your DKIM selector[^"]*"/i,
+    );
   });
 
   it("BIMI learn page mentions VMC and the DMARC requirement", async () => {


### PR DESCRIPTION
Closes #523

## What

- New `<h2 id="find-your-selector">How to find your DKIM selector</h2>` section on `/learn/dkim`, covering the three discovery paths from the issue:
  1. **Header inspection** — read the `s=` tag from a real `DKIM-Signature` header (with an example header and the resulting `_domainkey` lookup name)
  2. **Provider defaults** — Google Workspace `google`, Microsoft 365 `selector1`/`selector2`, Proton Mail `protonmail`(2/3), Fastmail `fm1`–`fm3`, Zoho `default`; every claim matches the analyzer's own `PROVIDER_SELECTORS`/`COMMON_SELECTORS`
  3. **Scan CTA** — dmarcheck probes the common selectors automatically; custom selectors via Advanced options
- Meta description updated with "find your DKIM selector" phrasing
- The anchor id is a stable contract for #524 (scan-report deep links) — do not rename without checking callers

## Count fix (drift found while implementing)

The issue body says "38 common selectors", but `COMMON_SELECTORS` has **36** entries — the page copy, the meta description, and (second commit) two landing-page strings had hardcoded the stale 38. Per the issue's own instruction ("cite the real count from here, don't hardcode blindly"), all four spots now interpolate `COMMON_SELECTORS.length`, and the tests import the array so the assertions can't drift either.

## Notes for review

- `src/analyzers/dkim.ts` is touched only to `export` the existing `COMMON_SELECTORS` const — no behavior change, but it's a CODEOWNERS-gated path
- `.bd-card-title` gains `margin: 0` so the `h2` variant renders identically to the existing `div` titles (no-op for divs)
- `LEARN_PUBLISHED` bumped per the in-file convention for material prose edits

## Verification

- TDD: all three new tests written first and watched fail, then implementation
- `npm test`: 1263 passing, 0 failing
- `npm run lint`, `npm run typecheck`: clean
- Verified live in `wrangler dev`: `/learn/dkim#find-your-selector` scrolls to the H2, section renders with all three paths, all probe-count mentions read "36" (learn page and landing page), no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)