### PR TITLE
seo: add per-provider SPF/DKIM/DMARC record sections to /mx pages

### DIFF
--- a/src/data/mx-providers.ts
+++ b/src/data/mx-providers.ts
@@ -115,6 +115,20 @@ export const MX_PROVIDERS: readonly MxProvider[] = [
           "The MX hostname alone is enough — only Microsoft can serve that domain. If you want a second signal, look at the SPF record: a Microsoft 365 tenant will `include:spf.protection.outlook.com`. The DKIM keys live at `selector1._domainkey` and `selector2._domainkey` and point at `selector*-<tenant>._domainkey.<tenant>.onmicrosoft.com`.",
         ],
       },
+      {
+        title: "SPF, DKIM, and DMARC records for Microsoft 365",
+        paragraphs: [
+          "Microsoft's documented SPF record for a domain that sends only through Microsoft 365 is `v=spf1 include:spf.protection.outlook.com -all`. The hard-fail `-all` is Microsoft's own recommendation — they expect DKIM and DMARC to carry the authentication load. If anything else sends as your domain (a CRM, a newsletter tool), add its mechanism to this one record; publishing a second SPF record alongside it is a permanent error, not a backup.",
+          "DKIM is two CNAME records with fixed names and tenant-specific targets. The hostnames are always `selector1._domainkey` and `selector2._domainkey`; the targets embed your domain (dots replaced by dashes) and your `<tenant>.onmicrosoft.com` initial domain. Domains added since May 2025 get a newer target format ending in `dkim.mail.microsoft` with an unpredictable partition character — either way, copy the exact values from the Defender portal rather than constructing them by hand.",
+          "Microsoft's DMARC guidance is the standard ramp: start at `v=DMARC1; p=none;` with a `rua` reporting address, then move to `quarantine` and finally `reject` once the reports are clean. After all three records are live, run your domain through dmarcheck to confirm they parse and align.",
+        ],
+        list: [
+          "SPF: `v=spf1 include:spf.protection.outlook.com -all`",
+          "DKIM: `selector1._domainkey` → `selector1-<domain-with-dashes>._domainkey.<tenant>.onmicrosoft.com` (CNAME; tenant-specific target)",
+          "DKIM: `selector2._domainkey` → same pattern with `selector2-`",
+          "DMARC: `v=DMARC1; p=none; rua=mailto:<reports>@<yourdomain>` to start — Microsoft's stated goal is `p=reject`",
+        ],
+      },
     ],
   },
   {
@@ -167,6 +181,19 @@ export const MX_PROVIDERS: readonly MxProvider[] = [
           "Unlike Microsoft 365's per-tenant hostname, every Workspace customer shares the same MX hosts — so the MX alone doesn't reveal the tenant. The tenant identifier shows up elsewhere: the SPF record includes `_spf.google.com`, and DKIM uses `google._domainkey` by default. If the domain publishes DMARC with a `rua` mailto pointing at `*.google.com`, that's another tell.",
         ],
       },
+      {
+        title: "SPF, DKIM, and DMARC records for Google Workspace",
+        paragraphs: [
+          "For a domain that sends mail only through Workspace, the record Google documents is `v=spf1 include:_spf.google.com ~all` — note the softfail `~all`; Google's setup page doesn't ask for `-all`. Domains that also send through other services fold every sender into that single TXT record (Google's own examples show `include:_spf.google.com include:amazonses.com` side by side), because SPF permits exactly one record per name — two records fail outright.",
+          "DKIM is a TXT record at `google._domainkey` — `google` is the default selector — whose value is a public key you generate per-domain in the Admin console (Apps → Google Workspace → Gmail → Authenticate email). Pick a 2048-bit key unless your DNS host can't store one, in which case fall back to 1024.",
+          "Google's DMARC examples start at `v=DMARC1; p=none;` with `rua` reporting and tighten to `quarantine` or `reject` as the reports come back clean. Once the three records are published, a dmarcheck scan will show whether they parse the way Gmail's own checks expect.",
+        ],
+        list: [
+          "SPF: `v=spf1 include:_spf.google.com ~all`",
+          "DKIM: TXT at `google._domainkey` — key generated per-domain in the Admin console (2048-bit preferred)",
+          "DMARC: `v=DMARC1; p=none; rua=mailto:<reports>@<yourdomain>` to start",
+        ],
+      },
     ],
   },
   {
@@ -209,6 +236,20 @@ export const MX_PROVIDERS: readonly MxProvider[] = [
         title: "Who runs it",
         paragraphs: [
           "Mimecast Limited, headquartered in the UK, runs the service. It's a publicly-known enterprise email security vendor used by tens of thousands of organisations, often in regulated industries where a separate filtering perimeter is a compliance requirement.",
+        ],
+      },
+      {
+        title: "SPF, DKIM, and DMARC records for Mimecast",
+        paragraphs: [
+          "Mimecast's SPF include is regional — you authorise the data centre your tenant lives in, not one global hostname. A US tenant publishes `v=spf1 include:us._netblocks.mimecast.com ~all`; the prefix changes per region. A catch-all `include:_netblocks.mimecast.com` exists too, but it burns six DNS lookups against SPF's limit of ten where a regional include costs one — and any other senders your domain uses must share that budget inside the same single TXT record (a duplicate SPF record is an instant permerror).",
+          'There is no universal Mimecast DKIM selector. Signing keys are generated per customer, per domain, in the Mimecast Administration Console (a DNS Authentication – Outbound Signing definition); you publish the generated public key as a TXT record at `<selector>._domainkey.<yourdomain>`, with generated selectors shaped like `mimecast20260612`. Anyone quoting you a fixed "Mimecast DKIM record" is guessing.',
+          "DMARC sits on top as usual — `v=DMARC1; p=none;` with reporting, walked up to `reject`; Mimecast sells DMARC Analyzer for exactly that ramp. Scan your domain with dmarcheck after cutover to check the gateway's records and your policy in one pass.",
+        ],
+        list: [
+          "`v=spf1 include:us._netblocks.mimecast.com ~all` — United States",
+          "`v=spf1 include:eu._netblocks.mimecast.com ~all` — Europe (excluding Germany)",
+          "`v=spf1 include:de._netblocks.mimecast.com ~all` — Germany",
+          "`za` (South Africa), `au` (Australia), and `ca` (Canada) follow the same pattern",
         ],
       },
     ],
@@ -254,6 +295,14 @@ export const MX_PROVIDERS: readonly MxProvider[] = [
           "Proofpoint, Inc. is a US-based security vendor (now owned by Thoma Bravo since 2021). It's one of the largest commercial email security providers, particularly common in financial services, healthcare and government supply chains.",
         ],
       },
+      {
+        title: "SPF, DKIM, and DMARC records for Proofpoint",
+        paragraphs: [
+          "Which SPF record you publish depends on the tier. Proofpoint Essentials documents stack-specific records — `v=spf1 a:dispatch-us.ppe-hosted.com ~all` for US stacks, `v=spf1 a:dispatch-eu.ppe-hosted.com ~all` for EU — matching the `ppe-hosted.com` infrastructure your account was provisioned on. Enterprise (`pphosted.com`) customers get no universal include at all: authorized sending hosts are per-customer, supplied in the admin console or by your Proofpoint account team, so treat any blog quoting a generic `pphosted.com` SPF include with suspicion.",
+          "DKIM is per-customer too. You create a signing key per domain in the Proofpoint console, the selector is yours to choose (the console pre-fills one), and what lands in DNS is a TXT record at `<selector>._domainkey.<yourdomain>` holding your generated public key. No fixed selector exists across Proofpoint customers.",
+          "Proofpoint's published DMARC starter is `v=DMARC1; p=none; rua=mailto:<reports>@<yourdomain>; pct=100`, walked up to `quarantine` and then `reject` over a few months. Whatever the tier, keep every SPF mechanism in one TXT record — adding a second record makes evaluation fail outright — then run the domain through dmarcheck to confirm the result.",
+        ],
+      },
     ],
   },
   {
@@ -297,6 +346,20 @@ export const MX_PROVIDERS: readonly MxProvider[] = [
         title: "Who runs it",
         paragraphs: [
           "Fastmail Pty Ltd is an Australian, privately-held mailbox provider. It's a popular choice for technical users and small businesses that want a paid alternative to Gmail or Outlook with strong CalDAV/CardDAV support and no advertising.",
+        ],
+      },
+      {
+        title: "SPF, DKIM, and DMARC records for Fastmail",
+        paragraphs: [
+          "Fastmail's documented SPF record is `v=spf1 include:spf.messagingengine.com ?all` — and yes, that's a neutral `?all`, not the softfail most providers suggest: Fastmail leans on DKIM for authentication and treats SPF as advisory. Other services that send for the domain get their includes merged into this same record, never published as a second one (SPF tolerates exactly one TXT record per hostname).",
+          "DKIM is three CNAME records, and your domain appears inside the target as well as the host: `fm1._domainkey.<yourdomain>` points at `fm1.<yourdomain>.dkim.fmhosted.com`, with `fm2` and `fm3` following suit. The CNAME indirection is what lets Fastmail rotate the underlying keys without you ever touching DNS again. Older domains may still carry a deprecated `mesmtp._domainkey` record; new setups need only fm1–fm3.",
+          "Fastmail's manual-DNS table ships DMARC as a bare `v=DMARC1; p=none;` — monitoring-grade, with no reporting address. Tightening to `quarantine` or `reject` is on you once you've added `rua` and watched the reports. Scan the domain on dmarcheck to see how that default actually scores.",
+        ],
+        list: [
+          "SPF: `v=spf1 include:spf.messagingengine.com ?all`",
+          "DKIM: `fm1._domainkey` → `fm1.<yourdomain>.dkim.fmhosted.com` (CNAME)",
+          "DKIM: `fm2._domainkey` and `fm3._domainkey` → same pattern",
+          "DMARC: `v=DMARC1; p=none;` (Fastmail's documented baseline)",
         ],
       },
     ],
@@ -348,7 +411,15 @@ export const MX_PROVIDERS: readonly MxProvider[] = [
       {
         title: "Identifying a Zoho tenant",
         paragraphs: [
-          "The MX hostname is unambiguous — only Zoho can serve those. The SPF record will `include:zoho.com` (or the regional equivalent). DKIM selectors are named `zoho._domainkey` by default but can be renamed.",
+          "The MX hostname is unambiguous — only Zoho can serve those. The SPF record will `include:zohomail.com` (or `one.zoho.com` for multi-service accounts). DKIM selectors are named `zoho._domainkey` by default but can be renamed.",
+        ],
+      },
+      {
+        title: "SPF, DKIM, and DMARC records for Zoho Mail",
+        paragraphs: [
+          "Zoho's SPF include is `include:zohomail.com` regardless of which data centre hosts the tenant — only the MX hostnames are regional. Zoho's own help pages waver on the qualifier (the headline prescription says `-all`, the step-by-step walkthroughs say `~all`), so `v=spf1 include:zohomail.com ~all` is the safe form while you're still validating; tighten to `-all` once DKIM is live. Accounts using several Zoho services can swap in `include:one.zoho.com` to save lookups — always within the one permitted SPF record, since publishing two is a permerror.",
+          "DKIM keys are generated per domain in the Zoho Mail Admin Console (Email Configuration → DKIM). The selector is your choice — Zoho's setup docs use `zoho` as the example — and the result is a TXT record at `<selector>._domainkey.<yourdomain>` holding the generated public key, verified and enabled back in the console.",
+          "Zoho documents the full DMARC ramp explicitly: `v=DMARC1; p=none; rua=mailto:admin@<yourdomain>`, then `p=quarantine` (optionally throttled with `pct=`), then `p=reject`. Publish all three record types, then check the domain on dmarcheck to confirm they resolve and parse.",
         ],
       },
     ],
@@ -395,6 +466,14 @@ export const MX_PROVIDERS: readonly MxProvider[] = [
           "Amazon Web Services. SES inbound is a developer-facing service — its presence usually indicates an application is processing received mail programmatically, not a human reading an inbox.",
         ],
       },
+      {
+        title: "SPF, DKIM, and DMARC records for Amazon SES",
+        paragraphs: [
+          "SES inverts the usual order: DKIM comes first and SPF needs an extra step. Easy DKIM gives you three CNAME records — `<token>._domainkey.<yourdomain>` pointing at `<token>.dkim.amazonses.com` — where each `<token>` is a random per-identity string from the SES console. In some newer regions the target is `dkim.<region>.amazonses.com` (or a cell-based hosted zone), so copy the exact values SES generates rather than assuming the suffix.",
+          "Out of the box SES sends from an `amazonses.com` MAIL FROM, which passes SPF but never aligns for DMARC. The fix is a custom MAIL FROM subdomain carrying two records: an MX of `10 feedback-smtp.<region>.amazonses.com` and the TXT `v=spf1 include:amazonses.com ~all`, with `<region>` matching where the identity lives. Those live on the MAIL FROM subdomain — the apex domain keeps its own single SPF record (merge mechanisms into it; a second `v=spf1` TXT breaks both).",
+          "AWS's documented DMARC example is `v=DMARC1;p=quarantine;rua=mailto:<reports>@<yourdomain>`, and their recommendation is to let Easy DKIM carry alignment — it signs with your exact domain and survives forwarding, while SPF alignment through the MAIL FROM subdomain only works relaxed (no `aspf=s`). A dmarcheck scan of the domain shows whether the selectors and policy resolve.",
+        ],
+      },
     ],
   },
   {
@@ -429,13 +508,21 @@ export const MX_PROVIDERS: readonly MxProvider[] = [
       {
         title: "Forwarder, not a mailbox",
         paragraphs: [
-          "Email Routing is one-way — it accepts mail and forwards it; the destination mailbox is the real authoritative MTA. That means a domain using Email Routing won't have meaningful DKIM keys at its own selectors and may have SPF set up only for forwarding. It also means Cloudflare can't reply to bounces; non-deliverable mail gets dropped at the destination.",
+          "Email Routing is one-way — it accepts mail and forwards it; the destination mailbox is the real authoritative MTA. The SPF and DKIM records Cloudflare adds to the zone authenticate the forwarding hop, not outbound sending — the service can't originate or reply as your domain. It also means Cloudflare can't reply to bounces; non-deliverable mail gets dropped at the destination.",
         ],
       },
       {
         title: "Who runs it",
         paragraphs: [
           "Cloudflare, Inc. The service launched in 2021 and is free for domains using Cloudflare DNS. It's a popular choice for personal domains, side projects, and aliases that don't justify a full mailbox plan.",
+        ],
+      },
+      {
+        title: "SPF, DKIM, and DMARC records for Cloudflare Email Routing",
+        paragraphs: [
+          "Email Routing writes its own DNS when you enable it: the three `route1-3.mx.cloudflare.net` MX records, the SPF TXT `v=spf1 include:_spf.mx.cloudflare.net ~all`, and a DKIM TXT at `cf2024-1._domainkey` with a Cloudflare-provided key that signs forwarded mail. There's nothing to construct by hand — but if the domain also sends from somewhere (routing is receive-only), that sender's SPF mechanism has to be merged into the same TXT record, because a second `v=spf1` record invalidates both.",
+          "Forwarding is the hard case for authentication, and Cloudflare papers over it with SRS (rewriting the envelope sender so SPF passes downstream), DKIM signatures on forwarded messages, and ARC seals so the destination can trust the original verdicts. Strict DMARC policies on the sender's side can still make forwarded mail bounce — that's inherent to forwarding, not a misconfiguration.",
+          "Because Email Routing can't send as your domain, your DMARC policy mostly governs what everyone else may do with it. `v=DMARC1; p=none;` plus a `rua` address is the observing start, and many routing-only domains can go straight to `p=reject` once they've confirmed nothing legitimate sends. A dmarcheck scan of the domain shows all of these records in one report.",
         ],
       },
     ],

--- a/test/mx-providers.test.ts
+++ b/test/mx-providers.test.ts
@@ -4,6 +4,8 @@ import {
   lookupMxProvider,
   MX_PROVIDERS,
 } from "../src/data/mx-providers.js";
+import { renderMxProviderMarkdown } from "../src/views/markdown.js";
+import { renderMxProviderPage } from "../src/views/mx.js";
 
 describe("lookupMxProvider", () => {
   it("matches Microsoft 365 MX hostnames", () => {
@@ -133,6 +135,78 @@ describe("MX_PROVIDERS catalog", () => {
     for (const p of MX_PROVIDERS) {
       expect(p.hostnames.length).toBeGreaterThan(0);
       expect(p.hostnameExamples.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("record guidance sections (#525)", () => {
+  // One verified official record string per provider — sourced from vendor
+  // docs (learn.microsoft.com, knowledge.workspace.google.com, Mimecast KB,
+  // Proofpoint Essentials getting-started guides, fastmail.help, zoho.com,
+  // docs.aws.amazon.com, developers.cloudflare.com). If one of these fails,
+  // the page no longer quotes the canonical string admins search for.
+  const EXPECTED_RECORD_STRINGS: Record<string, string[]> = {
+    outlook: [
+      "v=spf1 include:spf.protection.outlook.com -all",
+      "selector1._domainkey",
+    ],
+    google: ["v=spf1 include:_spf.google.com ~all", "google._domainkey"],
+    mimecast: ["include:us._netblocks.mimecast.com"],
+    proofpoint: ["v=spf1 a:dispatch-us.ppe-hosted.com ~all"],
+    fastmail: ["v=spf1 include:spf.messagingengine.com ?all", "fm1._domainkey"],
+    zoho: ["include:zohomail.com"],
+    "amazon-ses": ["v=spf1 include:amazonses.com ~all", "dkim.amazonses.com"],
+    cloudflare: ["v=spf1 include:_spf.mx.cloudflare.net ~all"],
+  };
+
+  it("every provider has a record-guidance section", () => {
+    for (const p of MX_PROVIDERS) {
+      const guidance = p.sections.find((s) =>
+        /SPF, DKIM, and DMARC records/i.test(s.title),
+      );
+      expect(
+        guidance,
+        `${p.slug} is missing a record-guidance section`,
+      ).toBeDefined();
+    }
+  });
+
+  it("each provider's HTML page contains its official record strings", () => {
+    for (const [slug, strings] of Object.entries(EXPECTED_RECORD_STRINGS)) {
+      const html = renderMxProviderPage(slug);
+      expect(html, `no HTML page for ${slug}`).not.toBeNull();
+      for (const s of strings) {
+        expect(html, `${slug} HTML page is missing "${s}"`).toContain(s);
+      }
+    }
+  });
+
+  it("each provider's markdown rendering contains its official record strings", () => {
+    for (const [slug, strings] of Object.entries(EXPECTED_RECORD_STRINGS)) {
+      const md = renderMxProviderMarkdown(slug);
+      expect(md, `no markdown rendering for ${slug}`).not.toBeNull();
+      for (const s of strings) {
+        expect(md, `${slug} markdown is missing "${s}"`).toContain(s);
+      }
+    }
+  });
+
+  it("no two providers share identical section prose", () => {
+    // Google demotes duplicate-shaped content (#364) — every paragraph on
+    // every provider page must be written for that provider, not stamped
+    // from a template.
+    const seen = new Map<string, string>();
+    for (const p of MX_PROVIDERS) {
+      for (const section of p.sections) {
+        for (const paragraph of section.paragraphs) {
+          const firstOwner = seen.get(paragraph);
+          expect(
+            firstOwner,
+            `paragraph shared by ${firstOwner} and ${p.slug}: "${paragraph.slice(0, 60)}..."`,
+          ).toBeUndefined();
+          seen.set(paragraph, p.slug);
+        }
+      }
     }
   });
 });


### PR DESCRIPTION
Closes #525

## What

Adds an **"SPF, DKIM, and DMARC records for \<provider\>"** section to each of the 8 `/mx/<provider>` pages (outlook, google, mimecast, proofpoint, fastmail, zoho, amazon-ses, cloudflare) via the existing data-driven `sections` mechanism in `src/data/mx-providers.ts`. Data-only — no view forking; both the HTML renderer (`renderSectionsHtml`) and the markdown renderer pick the sections up generically.

## Verification of record strings

Every record string was verified against current **official vendor documentation** on 2026-06-12 (not written from memory), via parallel research agents fetching the raw pages:

- **Microsoft 365**: `v=spf1 include:spf.protection.outlook.com -all` (Microsoft recommends hard-fail), `selector1/selector2._domainkey` CNAMEs with tenant-variable targets, incl. the newer post-May-2025 `dkim.mail.microsoft` target format — learn.microsoft.com
- **Google Workspace**: `v=spf1 include:_spf.google.com ~all`, `google._domainkey` TXT (2048-bit preferred) — knowledge.workspace.google.com
- **Mimecast**: regional `<region>._netblocks.mimecast.com` includes; DKIM honestly documented as per-customer console-generated keys (no universal selector) — Mimecast KB
- **Proofpoint**: Essentials stack records `v=spf1 a:dispatch-us|eu.ppe-hosted.com ~all` (official getting-started PDFs); Enterprise documented as per-customer with **no universal include**; DKIM per-customer — proofpoint.com
- **Fastmail**: `v=spf1 include:spf.messagingengine.com ?all` (neutral qualifier is Fastmail's documented choice), `fm1-3._domainkey` CNAMEs → `fm*.<domain>.dkim.fmhosted.com`, baseline `v=DMARC1; p=none;` — fastmail.help
- **Zoho**: `include:zohomail.com` (qualifier ambiguity in Zoho's own docs noted), per-domain console-generated DKIM, documented none→quarantine→reject ramp — zoho.com
- **Amazon SES**: Easy DKIM `<token>._domainkey` CNAMEs (region/cell-variable targets flagged), custom MAIL FROM MX + `v=spf1 include:amazonses.com ~all`, AWS DMARC example — docs.aws.amazon.com
- **Cloudflare Email Routing**: `v=spf1 include:_spf.mx.cloudflare.net ~all`, auto-added `cf2024-1._domainkey` DKIM, SRS/ARC forwarding notes — developers.cloudflare.com

Tenant/region-variable parts are marked with `<placeholders>` throughout. Each section notes that multi-sender domains must merge SPF includes into one record (multi-record SPF is a permerror, #423) — phrased distinctly per provider, and ends with a scan CTA (plain prose; the section renderer intentionally has no link support).

## Bonus fixes surfaced by the doc verification

- Existing Zoho prose claimed `include:zoho.com` — the official include is `zohomail.com` (that string appears nowhere in Zoho's SPF docs). Corrected.
- Existing Cloudflare prose claimed Email Routing domains "won't have meaningful DKIM keys" — stale; Cloudflare now adds a `cf2024-1._domainkey` TXT for the forwarding hop. Corrected.

## Tests

New `record guidance sections (#525)` describe block in `test/mx-providers.test.ts` (written first, watched fail):
- every provider has a record-guidance section
- each provider's **HTML page** contains its official record strings
- each provider's **markdown rendering** contains the same strings
- no two providers share an identical section paragraph (anti-template-stamping invariant, #364)

## Gates

- `npm test`: **1264 passing, 0 failing** (76 files)
- `npm run lint`: clean
- `npm run typecheck`: clean
- Verified in a live `wrangler dev` preview: all 8 pages render the section in HTML and via `Accept: text/markdown`

🤖 Generated with [Claude Code](https://claude.com/claude-code)