### PR TITLE
seo: interpolate guide count in /learn hub intro

### DIFF
--- a/src/views/learn.ts
+++ b/src/views/learn.ts
@@ -85,54 +85,57 @@ function learnJsonLd(opts: {
   });
 }
 
-const LEARN_SIBLINGS: Array<{ slug: string; protocol: string; blurb: string }> =
-  [
-    {
-      slug: "dmarc",
-      protocol: "DMARC",
-      blurb: "Policy records, alignment, and reporting.",
-    },
-    {
-      slug: "spf",
-      protocol: "SPF",
-      blurb: "Authorized senders and the 10-lookup budget.",
-    },
-    {
-      slug: "dkim",
-      protocol: "DKIM",
-      blurb: "Signing keys, selectors, and rotation.",
-    },
-    {
-      slug: "bimi",
-      protocol: "BIMI",
-      blurb: "Inbox logos and VMC/CMC certification.",
-    },
-    {
-      slug: "mta-sts",
-      protocol: "MTA-STS",
-      blurb: "TLS enforcement for inbound mail.",
-    },
-    {
-      slug: "security-txt",
-      protocol: "security.txt",
-      blurb: "Machine-readable security disclosure policies.",
-    },
-    {
-      slug: "tls-rpt",
-      protocol: "TLS-RPT",
-      blurb: "SMTP TLS failure reporting via DNS.",
-    },
-    {
-      slug: "dnssec",
-      protocol: "DNSSEC",
-      blurb: "Signed DNS zones and the chain of trust.",
-    },
-    {
-      slug: "dane",
-      protocol: "DANE/TLSA",
-      blurb: "TLSA records pinning MX certificates over DNSSEC.",
-    },
-  ];
+export const LEARN_SIBLINGS: Array<{
+  slug: string;
+  protocol: string;
+  blurb: string;
+}> = [
+  {
+    slug: "dmarc",
+    protocol: "DMARC",
+    blurb: "Policy records, alignment, and reporting.",
+  },
+  {
+    slug: "spf",
+    protocol: "SPF",
+    blurb: "Authorized senders and the 10-lookup budget.",
+  },
+  {
+    slug: "dkim",
+    protocol: "DKIM",
+    blurb: "Signing keys, selectors, and rotation.",
+  },
+  {
+    slug: "bimi",
+    protocol: "BIMI",
+    blurb: "Inbox logos and VMC/CMC certification.",
+  },
+  {
+    slug: "mta-sts",
+    protocol: "MTA-STS",
+    blurb: "TLS enforcement for inbound mail.",
+  },
+  {
+    slug: "security-txt",
+    protocol: "security.txt",
+    blurb: "Machine-readable security disclosure policies.",
+  },
+  {
+    slug: "tls-rpt",
+    protocol: "TLS-RPT",
+    blurb: "SMTP TLS failure reporting via DNS.",
+  },
+  {
+    slug: "dnssec",
+    protocol: "DNSSEC",
+    blurb: "Signed DNS zones and the chain of trust.",
+  },
+  {
+    slug: "dane",
+    protocol: "DANE/TLSA",
+    blurb: "TLSA records pinning MX certificates over DNSSEC.",
+  },
+];
 
 function siblingLinks(currentSlug: string): string {
   const items = LEARN_SIBLINGS.filter((s) => s.slug !== currentSlug)
@@ -261,7 +264,7 @@ export function renderLearnHub(): string {
     <span class="breadcrumb-current">Learn</span>
   </nav>
   <h1 class="rubric-title">Learn email authentication</h1>
-  <p class="rubric-intro">Nine short guides to the DNS records dmarcheck scans. Each page walks through how the record works, how to read a real example, and how to fix the misconfigurations that lower your grade.</p>
+  <p class="rubric-intro">${LEARN_SIBLINGS.length} short guides to the DNS records dmarcheck scans. Each page walks through how the record works, how to read a real example, and how to fix the misconfigurations that lower your grade.</p>
   <ul class="learn-hub-grid">${cards}</ul>
   ${learnCta("Enter a domain to scan")}
   ${LEARN_FOOTER}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { COMMON_SELECTORS } from "../src/analyzers/dkim.js";
 import { app, normalizeDomain, parseSelectors } from "../src/index.js";
 import { _memoryStore } from "../src/rate-limit.js";
+import { LEARN_SIBLINGS } from "../src/views/learn.js";
 
 vi.mock("../src/cache.js", () => ({
   getCachedScan: vi.fn().mockResolvedValue(null),
@@ -857,6 +858,16 @@ describe("Learn pages", () => {
     for (const p of protocols) {
       expect(html).toContain(`href="/learn/${p.slug}"`);
     }
+  });
+
+  it("hub intro cites the real guide count from LEARN_SIBLINGS", async () => {
+    const res = await app.request("/learn");
+    const html = await res.text();
+    // Copy must not hardcode the guide count — the same drift the landing
+    // page's "five protocols" had (#453). Interpolating the array length
+    // keeps the prose honest when a tenth guide lands.
+    expect(html).toContain(`${LEARN_SIBLINGS.length} short guides`);
+    expect(html).not.toMatch(/\b(nine|ten|eleven|twelve)\s+short guides\b/i);
   });
 
   for (const p of protocols) {


### PR DESCRIPTION
## Summary

The `/learn` hub intro hardcoded **"Nine short guides"** while the list it describes is the `LEARN_SIBLINGS` array in the same file (currently 9 entries). When a tenth guide lands, the prose would silently drift — the same failure mode #453 fixed on the landing page ("five protocols") and the stale DKIM selector-probe count had.

- `src/views/learn.ts`: interpolate `${LEARN_SIBLINGS.length} short guides` in the hub intro (server-rendered, so SEO-safe) and export `LEARN_SIBLINGS` so the test can pin against it
- `test/index.test.ts`: new test in the "Learn pages" block asserting the hub cites `LEARN_SIBLINGS.length` and contains no spelled-out stale count — follows the #453 precedent test

Written TDD: the test failed against the hardcoded copy first, then the interpolation made it pass. Verified in the browser preview: the hub renders "9 short guides to the DNS records dmarcheck scans." with 9 distinct guide links.

## Test results

- `npm test`: **1261 passing, 0 failing** (76 files)
- `npm run lint`: clean
- `npm run typecheck`: clean

No spec gaps — the markdown rendering of `/learn` has no hardcoded count, and this was the only count reference in `src/views/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)