### PR TITLE
seo: keep mx datePublished stable, split out MX_MODIFIED

### DIFF
--- a/src/views/mx.ts
+++ b/src/views/mx.ts
@@ -11,7 +11,14 @@ import { page, SITE_ORIGIN } from "./html.js";
 // .breakdown.learn CSS shell, same bd-card body cards) but the JSON-LD,
 // breadcrumbs, and sibling lists are scoped to the /mx hub, not /learn.
 
+// Original publication date of the /mx lane. Stable — never bump this on
+// edits; search engines treat a moving datePublished as freshness gaming.
 const MX_PUBLISHED = "2026-05-24";
+
+// Bump when materially editing any /mx page prose. It lives here rather than
+// per-provider so all pages stay in sync by default. Only this constant moves
+// on edits; MX_PUBLISHED stays fixed.
+const MX_MODIFIED = "2026-05-24";
 
 const MX_FOOTER = `<div class="foss-callout">
     <a href="https://github.com/schmug/dmarcheck" class="foss-link">
@@ -91,7 +98,7 @@ function providerJsonLd(provider: MxProvider): string {
         headline: provider.headline,
         description: provider.description,
         datePublished: MX_PUBLISHED,
-        dateModified: MX_PUBLISHED,
+        dateModified: MX_MODIFIED,
         author: {
           "@type": "Organization",
           name: "dmarcheck",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -986,6 +986,28 @@ describe("Learn pages", () => {
   });
 });
 
+describe("MX provider pages", () => {
+  it("mx JSON-LD keeps datePublished stable at the 2026-05-24 launch date", async () => {
+    // Search engines expect datePublished to be the original publication date
+    // and only dateModified to move on edits — bumping datePublished reads as
+    // freshness gaming. The /mx lane has not been materially edited since the
+    // 2026-05-24 launch, so the two fields are currently equal; dateModified
+    // may move forward on edits but datePublished must never change.
+    const res = await app.request("/mx/google");
+    const html = await res.text();
+    const match = html.match(
+      /<script type="application\/ld\+json">(.+?)<\/script>/s,
+    );
+    expect(match).not.toBeNull();
+    const graph = JSON.parse(match?.[1] ?? "{}")["@graph"];
+    const article = graph.find(
+      (node: { "@type": string }) => node["@type"] === "TechArticle",
+    );
+    expect(article.datePublished).toBe("2026-05-24");
+    expect(article.dateModified >= article.datePublished).toBe(true);
+  });
+});
+
 describe("bare /check request", () => {
   it("redirects browsers to / when no domain query parameter is supplied", async () => {
     const res = await app.request("/check");


### PR DESCRIPTION
## Summary

Preventive fix mirroring the `/learn` date split (#529) onto the `/mx/<provider>` pages.

`src/views/mx.ts` wired both `datePublished` and `dateModified` in the TechArticle JSON-LD to the single `MX_PUBLISHED` constant. If anyone bumped that constant on a prose edit, the *publication* date would move too — a pattern search engines can read as freshness gaming. Both dates are currently honest (the /mx lane hasn't been materially edited since its 2026-05-24 publication), so this lands before any drift can happen:

- `MX_PUBLISHED` stays fixed at `"2026-05-24"` with a "never bump" comment
- New `MX_MODIFIED` (initially also `"2026-05-24"`) carries `dateModified`, with a "bump on material prose edits" comment — same comment language as `learn.ts` in #529

## Test

New route-level test in `test/index.test.ts` ("MX provider pages") asserting the `/mx/google` JSON-LD keeps `datePublished` at `2026-05-24` and `dateModified >= datePublished`. Since the two dates are currently equal, it only pins the published date (unlike the learn test, which asserts strict inequality). Mutation-checked: temporarily bumping the published date in `mx.ts` makes the test fail with the expected message.

## Gates

- `npm test` — **1261 passing, 0 failing** (76 files)
- `npm run lint` — clean
- `npm run typecheck` — clean

No spec gaps; no follow-up issues needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)