### PR TITLE
🛡️ Sentinel: [HIGH] Fix sensitive data leak in Sentry payload data

### DIFF
--- a/src/sentry-scrub.ts
+++ b/src/sentry-scrub.ts
@@ -90,6 +90,9 @@ export function scrubSentryEvent<E extends Event>(event: E): E {
   if (event.request?.cookies) {
     event.request.cookies = { filtered: "[Filtered]" };
   }
+  if (event.request?.data !== undefined) {
+    event.request.data = "[Filtered]";
+  }
   if (event.request?.url) {
     event.request.url = scrubUrlString(event.request.url);
   }

--- a/test/sentry-scrub.test.ts
+++ b/test/sentry-scrub.test.ts
@@ -78,6 +78,13 @@ describe("scrubSentryEvent", () => {
     });
   });
 
+  it("scrubs request data when present", () => {
+    const event: Event = {
+      request: { data: { secret: "do-not-log" } },
+    };
+    expect(scrubSentryEvent(event).request?.data).toBe("[Filtered]");
+  });
+
   it("returns events without request data unchanged", () => {
     const event: Event = { message: "boom" };
     expect(scrubSentryEvent(event)).toBe(event);


### PR DESCRIPTION
Addresses Threat Model T6 by explicitly scrubbing `event.request.data` before Sentry logs errors, preventing accidental leakage of sensitive request bodies.

---
*PR created automatically by Jules for task [607490128255725420](https://jules.google.com/task/607490128255725420) started by @schmug*