### PR TITLE
security: cap external DMARC report-authorization DNS lookups (GHSA-vcw3-wvwx-6fg5)

### DIFF
--- a/src/analyzers/dmarc.ts
+++ b/src/analyzers/dmarc.ts
@@ -4,6 +4,27 @@ import { parseTags } from "../shared/parse-tags.js";
 import type { DmarcResult, Validation } from "./types.js";
 
 /**
+ * DoS guard (GHSA-vcw3-wvwx-6fg5): the scanned domain's _dmarc record is
+ * attacker-controlled, and every external rua/ruf reporting domain becomes one
+ * serial, timeout-bounded outbound DNS lookup in checkReportingAuthorization.
+ * An unbounded list lets a single scan request fan out into tens of lookups
+ * charged against one rate-limit token. Bound the external authorization
+ * lookups per scan, shared across rua+ruf combined. 10 is generous — legitimate
+ * records carry 1-2 reporting URIs — and mirrors SPF's MAX_LOOKUPS.
+ */
+export const MAX_REPORT_AUTH_LOOKUPS = 10;
+
+/**
+ * Shared, mutable lookup budget threaded across the rua and ruf authorization
+ * passes so the cap bounds their combined external DNS fan-out, and the
+ * cap-exceeded warning is emitted at most once per scan.
+ */
+interface ReportAuthBudget {
+  remaining: number;
+  capReported: boolean;
+}
+
+/**
  * Extract the domain portion from a mailto: URI.
  * Returns null if the URI is not a mailto: or has no @ sign.
  * Does NOT use new URL() — that throws on mailto: in some runtimes.
@@ -37,6 +58,7 @@ async function checkReportingAuthorization(
   tagValue: string,
   tagName: "rua" | "ruf",
   validations: Validation[],
+  budget: ReportAuthBudget,
 ): Promise<void> {
   const uris = parseReportUris(tagValue);
   for (const uri of uris) {
@@ -44,6 +66,18 @@ async function checkReportingAuthorization(
     if (!reportingDomain) continue;
     // Same domain — no external authorization needed
     if (reportingDomain === localDomain.toLowerCase()) continue;
+    // External lookup required — enforce the shared cap before querying.
+    if (budget.remaining <= 0) {
+      if (!budget.capReported) {
+        validations.push({
+          status: "warn",
+          message: `More than ${MAX_REPORT_AUTH_LOOKUPS} external report destinations configured (rua/ruf) — additional destinations were not verified for report authorization`,
+        });
+        budget.capReported = true;
+      }
+      break;
+    }
+    budget.remaining--;
     const authName = `${localDomain}._report._dmarc.${reportingDomain}`;
     let authRecord: Awaited<ReturnType<typeof queryTxt>>;
     try {
@@ -120,6 +154,12 @@ export async function analyzeDmarc(domain: string): Promise<DmarcResult> {
 
   const tags = parseTags(dmarcRecord);
   const validations: Validation[] = [];
+  // Shared across the rua + ruf authorization passes so the cap bounds their
+  // combined external DNS fan-out (GHSA-vcw3-wvwx-6fg5).
+  const reportAuthBudget: ReportAuthBudget = {
+    remaining: MAX_REPORT_AUTH_LOOKUPS,
+    capReported: false,
+  };
 
   // v= check
   if (tags.v === "DMARC1") {
@@ -185,7 +225,13 @@ export async function analyzeDmarc(domain: string): Promise<DmarcResult> {
       status: "pass",
       message: "Aggregate reporting (rua) configured",
     });
-    await checkReportingAuthorization(domain, tags.rua, "rua", validations);
+    await checkReportingAuthorization(
+      domain,
+      tags.rua,
+      "rua",
+      validations,
+      reportAuthBudget,
+    );
   } else {
     validations.push({
       status: "warn",
@@ -199,7 +245,13 @@ export async function analyzeDmarc(domain: string): Promise<DmarcResult> {
       status: "pass",
       message: "Forensic reporting (ruf) configured",
     });
-    await checkReportingAuthorization(domain, tags.ruf, "ruf", validations);
+    await checkReportingAuthorization(
+      domain,
+      tags.ruf,
+      "ruf",
+      validations,
+      reportAuthBudget,
+    );
   }
 
   // pct check

--- a/test/dmarc.test.ts
+++ b/test/dmarc.test.ts
@@ -13,7 +13,10 @@ vi.mock("../src/dns/client.js", () => ({
   },
 }));
 
-import { analyzeDmarc } from "../src/analyzers/dmarc.js";
+import {
+  analyzeDmarc,
+  MAX_REPORT_AUTH_LOOKUPS,
+} from "../src/analyzers/dmarc.js";
 import { DnsLookupError, queryTxt } from "../src/dns/client.js";
 
 const mockQueryTxt = vi.mocked(queryTxt);
@@ -130,6 +133,83 @@ describe("analyzeDmarc — external rua/ruf authorization", () => {
           v.message.includes("thirdparty.com"),
       ),
     ).toBe(true);
+  });
+});
+
+describe("analyzeDmarc — external report-authorization lookup cap", () => {
+  it("caps external report-authorization lookups at MAX_REPORT_AUTH_LOOKUPS and warns", async () => {
+    expect(MAX_REPORT_AUTH_LOOKUPS).toBe(10);
+
+    // Attacker-controlled _dmarc record stuffed with 100 distinct external
+    // reporting domains. Without a cap each becomes a serial outbound DNS
+    // lookup, charged against one rate-limit token (GHSA-vcw3-wvwx-6fg5).
+    const ruaUris = Array.from(
+      { length: 100 },
+      (_, i) => `mailto:reports@ext${i}.example`,
+    ).join(",");
+    const record = `v=DMARC1; p=reject; rua=${ruaUris}`;
+    mockQueryTxt.mockResolvedValueOnce({ entries: [record], raw: record });
+    // Every external authorization lookup resolves to "absent".
+    mockQueryTxt.mockResolvedValue(null);
+
+    const result = await analyzeDmarc("mydomain.com");
+
+    // 1 call for the _dmarc record itself + at most MAX external auth lookups.
+    expect(mockQueryTxt.mock.calls.length).toBeLessThanOrEqual(
+      MAX_REPORT_AUTH_LOOKUPS + 1,
+    );
+    expect(
+      result.validations.some(
+        (v) => v.status === "warn" && v.message.includes("not verified"),
+      ),
+    ).toBe(true);
+  });
+
+  it("shares the cap across rua and ruf combined", async () => {
+    // 6 external rua + 6 external ruf = 12 external destinations; the shared
+    // cap of 10 bounds the total at 10 external lookups, one warn.
+    const ruaUris = Array.from(
+      { length: 6 },
+      (_, i) => `mailto:agg@rua${i}.example`,
+    ).join(",");
+    const rufUris = Array.from(
+      { length: 6 },
+      (_, i) => `mailto:fbl@ruf${i}.example`,
+    ).join(",");
+    const record = `v=DMARC1; p=reject; rua=${ruaUris}; ruf=${rufUris}`;
+    mockQueryTxt.mockResolvedValueOnce({ entries: [record], raw: record });
+    mockQueryTxt.mockResolvedValue(null);
+
+    const result = await analyzeDmarc("mydomain.com");
+
+    expect(mockQueryTxt.mock.calls.length).toBeLessThanOrEqual(
+      MAX_REPORT_AUTH_LOOKUPS + 1,
+    );
+    const capWarnings = result.validations.filter(
+      (v) => v.status === "warn" && v.message.includes("not verified"),
+    );
+    expect(capWarnings).toHaveLength(1);
+  });
+
+  it("does not warn or change results for a record within the cap", async () => {
+    // Two external reporting domains — well under the cap, fully analyzed.
+    mockQueryTxt.mockResolvedValueOnce({
+      entries: [
+        "v=DMARC1; p=reject; rua=mailto:a@one.example,mailto:b@two.example",
+      ],
+      raw: "v=DMARC1; p=reject; rua=mailto:a@one.example,mailto:b@two.example",
+    });
+    mockQueryTxt.mockResolvedValue({ entries: ["v=DMARC1"], raw: "v=DMARC1" });
+
+    const result = await analyzeDmarc("mydomain.com");
+
+    // 1 record lookup + 2 external auth lookups, no cap warning.
+    expect(mockQueryTxt).toHaveBeenCalledTimes(3);
+    expect(
+      result.validations.some(
+        (v) => v.status === "warn" && v.message.includes("not verified"),
+      ),
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes the confirmed DoS finding tracked in the private draft advisory **GHSA-vcw3-wvwx-6fg5**.

`checkReportingAuthorization` in the DMARC analyzer performed **one outbound DNS TXT lookup per `rua`/`ruf` reporting URI** found in the scanned domain's own `_dmarc` record, with **no cap** on how many URIs it iterates. Because the scanned domain is attacker-chosen, an attacker can publish a `_dmarc` record stuffed with many distinct external reporting domains and make a single scan request fan out into tens of serial, timeout-bounded outbound DNS lookups (up to 3s each), all charged against **one rate-limit token**.

This mirrors the patterns in the sibling PR #539 (DKIM selector cap, MTA-STS body cap): bound the attacker-controlled fan-out with a small fixed cap.

## Change

- Add a shared **`MAX_REPORT_AUTH_LOOKUPS = 10`** cap (across `rua` + `ruf` **combined**), mirroring SPF's existing `MAX_LOOKUPS = 10`.
- Thread a mutable `ReportAuthBudget` through both `checkReportingAuthorization` calls so the cap bounds their combined external DNS lookups per scan.
- **Fail-soft:** when the cap is exceeded, emit a single `warn` validation noting additional report destinations were not verified — rather than silently dropping them.
- Only *external* (cross-domain `mailto:`) URIs consume budget; same-domain and non-`mailto:` URIs are skipped without a query, as before.
- Legitimate records (typically 1–2 reporting URIs) are completely unaffected.

## Contract preservation

- Still returns `null` on NXDOMAIN and never throws for normal absence; `DnsLookupError` handling unchanged → compatible with the orchestrator's `Promise.allSettled` contract.
- Cap warning uses the `"warn"` status from the `"pass"|"warn"|"fail"` taxonomy.
- Cap warning is emitted **at most once per scan**, even though `checkReportingAuthorization` is called twice (rua + ruf), via a shared `capReported` flag.

## Tests (TDD — failing test written first)

New `test/dmarc.test.ts` cases:
- A mocked `_dmarc` record with **100 distinct external `rua` URIs** results in at most `MAX_REPORT_AUTH_LOOKUPS + 1` `queryTxt` calls (1 record lookup + ≤10 auth lookups) and emits the cap `warn`.
- The cap is **shared across `rua` + `ruf` combined** (6 + 6 external → exactly one cap warning).
- A record **within the cap** (2 external URIs) is unchanged — full analysis, no cap warning.

## Gates

- `npm test` — **1107 passing, 0 failing** (66 files)
- `npm run typecheck` — clean
- `npm run lint` (biome) — clean

## Notes

- Advisory **not** published; this PR references it only.
- The analyzer path is CODEOWNERS-gated — auto-merge intentionally **not** enabled; awaiting code-owner review.

Refs: GHSA-vcw3-wvwx-6fg5

🤖 Generated with [Claude Code](https://claude.com/claude-code)