### PR TITLE
security: add server-side single-use nonce to account-deletion re-auth proof

### DIFF
--- a/src/auth/reauth.ts
+++ b/src/auth/reauth.ts
@@ -7,16 +7,14 @@
 // attacker also re-authenticating as the victim at WorkOS.
 //
 // The proof is a compact HMAC-signed token (same primitive as session.ts /
-// unsubscribe.ts, keyed on SESSION_SECRET) carrying { sub, purpose, exp }.
+// unsubscribe.ts, keyed on SESSION_SECRET) carrying { sub, purpose, exp, jti }.
 // It is:
 //   - short-lived  — default 10-minute TTL (`exp`), enforced on validate;
-//   - effectively single-use — the deletion handler clears the cookie on
-//                    success so the legitimate flow consumes it exactly once;
-//                    there is no server-side nonce store, so a replay of a
-//                    leaked proof value is bounded only by the short TTL — but
-//                    the cookie is HttpOnly/Secure/SameSite=Lax (so JS/cross-
-//                    site can't read or resend it) and deletion is idempotent
-//                    (a replay targets an already-erased user and no-ops);
+//   - cryptographically single-use — the `jti` (UUID nonce) is recorded in the
+//                    `delete_proofs` D1 table on first use (issue #553); a
+//                    second presentation of the same token is rejected even
+//                    within the TTL. If the table is unavailable the handler
+//                    falls back to cookie-cleared-on-use + idempotent target;
 //   - purpose-scoped — the `purpose` claim prevents a plain session JWT (which
 //                    has no such claim, and a different token shape) from being
 //                    presented as a deletion proof.
@@ -29,6 +27,7 @@ interface ReauthProofPayload {
   sub: string;
   purpose: string;
   exp: number;
+  jti: string;
 }
 
 function base64UrlEncode(data: ArrayBuffer | Uint8Array): string {
@@ -72,6 +71,7 @@ export async function createReauthProof(
     sub,
     purpose: PROOF_PURPOSE,
     exp: Math.floor(Date.now() / 1000) + ttlSeconds,
+    jti: crypto.randomUUID(),
   };
   const payloadEncoded = base64UrlEncode(
     ENCODER.encode(JSON.stringify(payload)),
@@ -83,6 +83,26 @@ export async function createReauthProof(
     ENCODER.encode(payloadEncoded),
   );
   return `${payloadEncoded}.${base64UrlEncode(signature)}`;
+}
+
+// Decodes the jti and exp from a proof token without verifying the signature.
+// Safe to call only after validateReauthProof has returned true. Returns null
+// if the token cannot be parsed (which cannot happen after a passing validate,
+// but guards against programming errors).
+export function extractReauthProofJti(
+  token: string,
+): { jti: string; exp: number } | null {
+  const parts = token.split(".");
+  if (parts.length !== 2) return null;
+  try {
+    const payload: ReauthProofPayload = JSON.parse(
+      new TextDecoder().decode(base64UrlDecode(parts[0])),
+    );
+    if (typeof payload.jti !== "string" || !payload.jti) return null;
+    return { jti: payload.jti, exp: payload.exp };
+  } catch {
+    return null;
+  }
 }
 
 // Returns true only when the token is a structurally-valid, correctly-signed,

--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -10,7 +10,7 @@ import {
 } from "../api/bulk-scan.js";
 import { generateApiKey } from "../auth/api-key.js";
 import { requireAuth } from "../auth/middleware.js";
-import { validateReauthProof } from "../auth/reauth.js";
+import { extractReauthProofJti, validateReauthProof } from "../auth/reauth.js";
 import type { SessionPayload } from "../auth/session.js";
 import { dashboardBillingRoutes } from "../billing/routes.js";
 import { escapeCsvField } from "../csv.js";
@@ -1148,6 +1148,33 @@ dashboardRoutes.post("/account/delete", async (c) => {
     !(await validateReauthProof(proof, env.SESSION_SECRET, session.sub))
   ) {
     return c.redirect("/dashboard/settings");
+  }
+
+  // Server-side single-use guarantee (issue #553): consume the proof nonce in
+  // D1 so a captured cookie cannot be replayed within the ~10-minute TTL. On
+  // any D1 error (table absent in self-host, transient failure) we warn and
+  // continue — erasure must never be blocked by the nonce store.
+  const parsed = extractReauthProofJti(proof);
+  if (parsed) {
+    try {
+      const nowSec = Math.floor(Date.now() / 1000);
+      await env.DB.prepare("DELETE FROM delete_proofs WHERE expires_at < ?")
+        .bind(nowSec)
+        .run();
+      const { meta } = await env.DB.prepare(
+        "INSERT INTO delete_proofs (jti, expires_at) VALUES (?, ?) ON CONFLICT(jti) DO NOTHING",
+      )
+        .bind(parsed.jti, parsed.exp)
+        .run();
+      if (meta.changes === 0) {
+        return c.redirect("/dashboard/settings");
+      }
+    } catch (err) {
+      console.warn(
+        "[reauth] nonce store unavailable, skipping replay check:",
+        err,
+      );
+    }
   }
 
   const user = await getUserById(env.DB, session.sub);

--- a/src/db/migrations/0010_delete_proofs.sql
+++ b/src/db/migrations/0010_delete_proofs.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS delete_proofs (
+  jti TEXT PRIMARY KEY,
+  expires_at INTEGER NOT NULL
+);

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -103,6 +103,13 @@ CREATE TABLE IF NOT EXISTS webhook_deliveries (
   attempted_at INTEGER NOT NULL DEFAULT (unixepoch())
 );
 
+-- Consumed re-auth proof nonces (server-side single-use guarantee, issue #553).
+-- Rows expire with the proof TTL; lazy GC at consume time keeps this tiny.
+CREATE TABLE IF NOT EXISTS delete_proofs (
+  jti TEXT PRIMARY KEY,
+  expires_at INTEGER NOT NULL
+);
+
 -- Indexes for common queries
 CREATE INDEX IF NOT EXISTS idx_domains_user_id ON domains(user_id);
 CREATE INDEX IF NOT EXISTS idx_scan_history_domain_id ON scan_history(domain_id);

--- a/test/account-deletion-routes.test.ts
+++ b/test/account-deletion-routes.test.ts
@@ -34,13 +34,17 @@ function user(id: string, email: string): UserRow {
 }
 
 // Minimal D1 mock: resolves user lookups, records every write, and applies the
-// DELETE FROM users so we can assert the row is (or is not) gone. Everything
-// else returns empty so unrelated dashboard queries don't throw.
+// DELETE FROM users so we can assert the row is (or is not) gone. Tracks
+// consumed nonces for the delete_proofs table so replay tests work.
 function makeDB(opts: {
   users: UserRow[];
   writes: Array<{ sql: string; bindings: unknown[] }>;
+  nonceStore?: Set<string>;
+  nonceStoreThrows?: boolean;
 }) {
   const { users, writes } = opts;
+  const nonceStore = opts.nonceStore ?? new Set<string>();
+  const nonceStoreThrows = opts.nonceStoreThrows ?? false;
   const make = (sql: string, bindings: unknown[]) => ({
     bind: (...args: unknown[]) => make(sql, args),
     first: async <T>() => {
@@ -55,6 +59,17 @@ function makeDB(opts: {
       if (/^DELETE FROM users WHERE id = \?/i.test(sql)) {
         const idx = users.findIndex((u) => u.id === bindings[0]);
         if (idx >= 0) users.splice(idx, 1);
+      }
+      if (/INSERT INTO delete_proofs/i.test(sql)) {
+        if (nonceStoreThrows) throw new Error("table not found");
+        const jti = bindings[0] as string;
+        if (nonceStore.has(jti)) return { success: true, meta: { changes: 0 } };
+        nonceStore.add(jti);
+        return { success: true, meta: { changes: 1 } };
+      }
+      if (/DELETE FROM delete_proofs/i.test(sql)) {
+        if (nonceStoreThrows) throw new Error("table not found");
+        return { success: true, meta: { changes: 0 } };
       }
       return { success: true, meta: { changes: 1 } };
     },
@@ -336,6 +351,56 @@ describe("account deletion — execute (POST /dashboard/account/delete)", () => 
     expect(del?.bindings).toEqual(["user_1"]);
     // The victim's row is untouched; only the session subject was deleted.
     expect(users.map((u) => u.id)).toEqual(["victim"]);
+  });
+
+  it("rejects a replayed proof (same jti presented a second time)", async () => {
+    const nonceStore = new Set<string>();
+    const writes: Array<{ sql: string; bindings: unknown[] }> = [];
+    const users = [user("user_1", "a@b.com")];
+    const db = makeDB({ users, writes, nonceStore });
+    const app = makeApp(db);
+    const proof = await createReauthProof("user_1", SECRET);
+
+    // First submission succeeds.
+    const first = await app.request("/dashboard/account/delete", {
+      ...form({ confirm: "DELETE" }),
+      headers: {
+        ...(form({}).headers as Record<string, string>),
+        Cookie: `${await sessionCookie("user_1", "a@b.com")}; delete_proof=${proof}`,
+      },
+    });
+    expect(first.status).toBe(302);
+    expect(first.headers.get("Location")).toBe("/");
+
+    // Second submission with the same proof is rejected.
+    const second = await app.request("/dashboard/account/delete", {
+      ...form({ confirm: "DELETE" }),
+      headers: {
+        ...(form({}).headers as Record<string, string>),
+        Cookie: `${await sessionCookie("user_1", "a@b.com")}; delete_proof=${proof}`,
+      },
+    });
+    expect(second.status).toBe(302);
+    expect(second.headers.get("Location")).toBe("/dashboard/settings");
+  });
+
+  it("completes deletion even when the nonce store is unavailable (graceful fallback)", async () => {
+    const writes: Array<{ sql: string; bindings: unknown[] }> = [];
+    const users = [user("user_1", "a@b.com")];
+    const db = makeDB({ users, writes, nonceStoreThrows: true });
+    const app = makeApp(db);
+    const proof = await createReauthProof("user_1", SECRET);
+    const res = await app.request("/dashboard/account/delete", {
+      ...form({ confirm: "DELETE" }),
+      headers: {
+        ...(form({}).headers as Record<string, string>),
+        Cookie: `${await sessionCookie("user_1", "a@b.com")}; delete_proof=${proof}`,
+      },
+    });
+    // Deletion must succeed even though the nonce store threw.
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/");
+    expect(users).toHaveLength(0);
   });
 });
 

--- a/test/reauth.test.ts
+++ b/test/reauth.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { createReauthProof, validateReauthProof } from "../src/auth/reauth.js";
+import {
+  createReauthProof,
+  extractReauthProofJti,
+  validateReauthProof,
+} from "../src/auth/reauth.js";
 
 const SECRET = "test-session-secret";
 
@@ -61,5 +65,26 @@ describe("auth/reauth proof token", () => {
     expect(await validateReauthProof(sessionToken, SECRET, "user_1")).toBe(
       false,
     );
+  });
+
+  it("embeds a non-empty jti in every minted proof", async () => {
+    const token = await createReauthProof("user_1", SECRET);
+    const parsed = extractReauthProofJti(token);
+    expect(parsed).not.toBeNull();
+    expect(typeof parsed?.jti).toBe("string");
+    expect(parsed?.jti.length).toBeGreaterThan(0);
+  });
+
+  it("mints a distinct jti on each call (not re-used across proofs)", async () => {
+    const t1 = await createReauthProof("user_1", SECRET);
+    const t2 = await createReauthProof("user_1", SECRET);
+    const j1 = extractReauthProofJti(t1);
+    const j2 = extractReauthProofJti(t2);
+    expect(j1?.jti).not.toBe(j2?.jti);
+  });
+
+  it("extractReauthProofJti returns null for malformed tokens", () => {
+    expect(extractReauthProofJti("garbage")).toBeNull();
+    expect(extractReauthProofJti("a.b.c")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Embeds a `jti` UUID nonce in every re-auth proof token (`createReauthProof`)
- Records the consumed nonce in a new `delete_proofs` D1 table (migration `0010`) on first use via `INSERT … ON CONFLICT DO NOTHING`; rejects a replay when `meta.changes === 0`
- Falls back gracefully (warn + continue) when the table is unavailable, so erasure is never blocked by the nonce store

Closes #553

## Test plan

- [x] `test/reauth.test.ts` — new tests: jti is present and non-empty; two proofs mint distinct jtis; `extractReauthProofJti` returns null for malformed tokens
- [x] `test/account-deletion-routes.test.ts` — new tests: replayed proof redirects to `/dashboard/settings`; nonce-store error still completes deletion (graceful fallback)
- [x] All existing reauth and account-deletion tests pass (1368/1369; the 1 failure is a pre-existing live-network integration test unrelated to this change)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean

## Deferred

None — all Acceptance items from #553 are implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S4ztHVMqBvUpq8rrW1GNQh

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4ztHVMqBvUpq8rrW1GNQh)_