### PR TITLE
security: server-side single-use nonce for account-deletion re-auth proof

### DIFF
--- a/src/auth/reauth.ts
+++ b/src/auth/reauth.ts
@@ -29,7 +29,19 @@ interface ReauthProofPayload {
   sub: string;
   purpose: string;
   exp: number;
+  // Unique nonce for server-side single-use enforcement (issue #553).
+  // Absent on proofs minted before this field was added; those skip nonce
+  // consumption and rely on the existing TTL + idempotent-target guarantees.
+  jti?: string;
 }
+
+// Called by the deletion handler to atomically record the nonce as consumed.
+// Returns true on first use, false if already consumed. The async | sync union
+// covers both production (DO RPC → Promise) and test mocks (sync boolean).
+export type NonceConsumer = (
+  jti: string,
+  expSec: number,
+) => Promise<boolean> | boolean;
 
 function base64UrlEncode(data: ArrayBuffer | Uint8Array): string {
   const bytes = data instanceof ArrayBuffer ? new Uint8Array(data) : data;
@@ -72,6 +84,7 @@ export async function createReauthProof(
     sub,
     purpose: PROOF_PURPOSE,
     exp: Math.floor(Date.now() / 1000) + ttlSeconds,
+    jti: crypto.randomUUID(),
   };
   const payloadEncoded = base64UrlEncode(
     ENCODER.encode(JSON.stringify(payload)),
@@ -86,13 +99,21 @@ export async function createReauthProof(
 }
 
 // Returns true only when the token is a structurally-valid, correctly-signed,
-// unexpired deletion proof whose subject equals `expectedSub`. Any deviation
-// (bad shape, bad signature, wrong purpose, expired, wrong subject) returns
+// unexpired deletion proof whose subject equals `expectedSub`, AND the nonce
+// (jti) can be atomically consumed for the first time. Any deviation returns
 // false — never throws.
+//
+// `consumeNonce` is optional: when absent (self-host deploys, tests without a
+// DO binding) the nonce check is skipped and the existing TTL + idempotent-
+// target guarantees apply. When present, a second presentation of the same
+// proof within the TTL is rejected. If consumeNonce throws (transient DO
+// error), the error is swallowed and validation proceeds — erasure must never
+// depend on an optional binding.
 export async function validateReauthProof(
   token: string,
   secret: string,
   expectedSub: string,
+  consumeNonce?: NonceConsumer,
 ): Promise<boolean> {
   const parts = token.split(".");
   if (parts.length !== 2) return false;
@@ -113,6 +134,16 @@ export async function validateReauthProof(
     if (payload.purpose !== PROOF_PURPOSE) return false;
     if (payload.exp < Math.floor(Date.now() / 1000)) return false;
     if (payload.sub !== expectedSub) return false;
+
+    if (consumeNonce && payload.jti) {
+      try {
+        const consumed = await consumeNonce(payload.jti, payload.exp);
+        if (!consumed) return false;
+      } catch {
+        // DO unavailable — degrade to TTL-only protection rather than blocking.
+      }
+    }
+
     return true;
   } catch {
     return false;

--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -10,7 +10,7 @@ import {
 } from "../api/bulk-scan.js";
 import { generateApiKey } from "../auth/api-key.js";
 import { requireAuth } from "../auth/middleware.js";
-import { validateReauthProof } from "../auth/reauth.js";
+import { type NonceConsumer, validateReauthProof } from "../auth/reauth.js";
 import type { SessionPayload } from "../auth/session.js";
 import { dashboardBillingRoutes } from "../billing/routes.js";
 import { escapeCsvField } from "../csv.js";
@@ -1143,9 +1143,18 @@ dashboardRoutes.post("/account/delete", async (c) => {
   const session = c.get("user" as never) as SessionPayload;
   const env = c.env as Env;
   const proof = getCookie(c, "delete_proof");
+  const rl = env.RATE_LIMITER;
+  const consumeNonce: NonceConsumer | undefined = rl
+    ? (jti, expSec) => rl.getByName("__nonces__").consumeNonce(jti, expSec)
+    : undefined;
   if (
     !proof ||
-    !(await validateReauthProof(proof, env.SESSION_SECRET, session.sub))
+    !(await validateReauthProof(
+      proof,
+      env.SESSION_SECRET,
+      session.sub,
+      consumeNonce,
+    ))
   ) {
     return c.redirect("/dashboard/settings");
   }

--- a/src/rate-limit-do.ts
+++ b/src/rate-limit-do.ts
@@ -15,6 +15,9 @@ import type { RateLimitResult } from "./rate-limit.js";
 // `getByName("user:<id>")`, so each instance owns exactly one bucket (a single
 // row). The whole `increment` body is synchronous SQL — it runs to completion
 // without yielding, so overlapping RPCs cannot interleave their read and write.
+//
+// A singleton instance routed as `getByName("__nonces__")` also hosts the
+// consumed-nonce store for account-deletion re-auth proofs (issue #553).
 export class RateLimiterDO extends DurableObject {
   constructor(ctx: DurableObjectState, env: Cloudflare.Env) {
     super(ctx, env);
@@ -24,6 +27,12 @@ export class RateLimiterDO extends DurableObject {
           id INTEGER PRIMARY KEY,
           count INTEGER NOT NULL,
           reset_at INTEGER NOT NULL
+        )`,
+      );
+      this.ctx.storage.sql.exec(
+        `CREATE TABLE IF NOT EXISTS nonces (
+          jti TEXT PRIMARY KEY,
+          exp_sec INTEGER NOT NULL
         )`,
       );
     });
@@ -67,5 +76,20 @@ export class RateLimiterDO extends DurableObject {
       resetAt,
       count,
     };
+  }
+
+  // Records a deletion-proof nonce on first presentation. Returns true if newly
+  // recorded (first use), false if the jti was already consumed. Expired nonces
+  // are pruned opportunistically. Routed via `getByName("__nonces__")` so the
+  // single-threaded DO execution serializes concurrent replay attempts.
+  consumeNonce(jti: string, expSec: number): boolean {
+    const nowSec = Math.floor(Date.now() / 1000);
+    this.ctx.storage.sql.exec("DELETE FROM nonces WHERE exp_sec < ?", nowSec);
+    const result = this.ctx.storage.sql.exec(
+      "INSERT OR IGNORE INTO nonces (jti, exp_sec) VALUES (?, ?)",
+      jti,
+      expSec,
+    );
+    return result.rowsWritten === 1;
   }
 }

--- a/test/reauth.test.ts
+++ b/test/reauth.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { createReauthProof, validateReauthProof } from "../src/auth/reauth.js";
+import {
+  createReauthProof,
+  type NonceConsumer,
+  validateReauthProof,
+} from "../src/auth/reauth.js";
 
 const SECRET = "test-session-secret";
 
@@ -61,5 +65,39 @@ describe("auth/reauth proof token", () => {
     expect(await validateReauthProof(sessionToken, SECRET, "user_1")).toBe(
       false,
     );
+  });
+
+  it("rejects a replayed proof when a nonce store is present", async () => {
+    const consumed = new Set<string>();
+    const consumeNonce: NonceConsumer = (jti, _expSec) => {
+      if (consumed.has(jti)) return false;
+      consumed.add(jti);
+      return true;
+    };
+    const token = await createReauthProof("user_1", SECRET);
+    expect(
+      await validateReauthProof(token, SECRET, "user_1", consumeNonce),
+    ).toBe(true);
+    expect(
+      await validateReauthProof(token, SECRET, "user_1", consumeNonce),
+    ).toBe(false);
+  });
+
+  it("allows deletion when the nonce store binding is absent (graceful fallback)", async () => {
+    const token = await createReauthProof("user_1", SECRET);
+    // No consumeNonce passed — self-host / test without DO binding.
+    expect(await validateReauthProof(token, SECRET, "user_1")).toBe(true);
+    // Second call also passes (no nonce store to reject the replay).
+    expect(await validateReauthProof(token, SECRET, "user_1")).toBe(true);
+  });
+
+  it("allows deletion when the nonce store throws (transient DO error)", async () => {
+    const failingStore: NonceConsumer = () => {
+      throw new Error("DO unavailable");
+    };
+    const token = await createReauthProof("user_1", SECRET);
+    expect(
+      await validateReauthProof(token, SECRET, "user_1", failingStore),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Embeds a random `jti` (UUID) in the HMAC-signed deletion proof so each proof is uniquely identifiable
- Records consumed nonces in `RateLimiterDO`'s SQLite storage (singleton instance `__nonces__`) via a new `consumeNonce(jti, expSec): boolean` method — returns `false` if already consumed, blocking the replay
- Threads an optional `NonceConsumer` callback into `validateReauthProof`; when absent (self-host without DO binding) or when the DO throws (transient error), validation falls back to the existing TTL + idempotent-target protection — **erasure is never blocked by an optional binding**

## Test plan

- [x] `validateReauthProof` with mock nonce store: first call returns `true`, second returns `false` (replay rejected)
- [x] `validateReauthProof` without nonce store (graceful fallback): both calls return `true`
- [x] `validateReauthProof` with throwing nonce store (transient DO error): returns `true` (swallowed, not blocking)
- [x] All 7 pre-existing reauth tests still pass (10/10 total)
- [x] Full suite: 1366/1367 passing (1 pre-existing network-egress integration test excluded from container)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean

## Implementation notes

No new wrangler bindings or D1 migrations needed — the nonce table lives inside the DO's own SQLite storage alongside the existing `bucket` table. The `__nonces__` instance name routes a singleton for all deletion proofs; existing rate-limiter instances (`ip:…`, `user:…`) get the `nonces` table too (idempotent `CREATE TABLE IF NOT EXISTS`) but never use it.

Closes #553

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012h4NC5THHk6K35WcwvGrsm

---
_Generated by [Claude Code](https://claude.ai/code/session_012h4NC5THHk6K35WcwvGrsm)_