### PR TITLE
security: server-side single-use nonce for account-deletion re-auth proof

### DIFF
--- a/src/auth/reauth.ts
+++ b/src/auth/reauth.ts
@@ -7,16 +7,16 @@
 // attacker also re-authenticating as the victim at WorkOS.
 //
 // The proof is a compact HMAC-signed token (same primitive as session.ts /
-// unsubscribe.ts, keyed on SESSION_SECRET) carrying { sub, purpose, exp }.
+// unsubscribe.ts, keyed on SESSION_SECRET) carrying { sub, purpose, exp, jti }.
 // It is:
 //   - short-lived  — default 10-minute TTL (`exp`), enforced on validate;
-//   - effectively single-use — the deletion handler clears the cookie on
-//                    success so the legitimate flow consumes it exactly once;
-//                    there is no server-side nonce store, so a replay of a
-//                    leaked proof value is bounded only by the short TTL — but
-//                    the cookie is HttpOnly/Secure/SameSite=Lax (so JS/cross-
-//                    site can't read or resend it) and deletion is idempotent
-//                    (a replay targets an already-erased user and no-ops);
+//   - cryptographically single-use — each proof embeds a unique `jti` nonce;
+//                    the deletion handler records it in the RATE_LIMITER Durable
+//                    Object on first use so a replayed proof is rejected even
+//                    within its TTL. The cookie is also cleared on success.
+//                    When the DO binding is absent (self-host), the nonce check
+//                    is skipped and the short TTL + idempotent deletion remain
+//                    as the backstop;
 //   - purpose-scoped — the `purpose` claim prevents a plain session JWT (which
 //                    has no such claim, and a different token shape) from being
 //                    presented as a deletion proof.
@@ -29,6 +29,7 @@ interface ReauthProofPayload {
   sub: string;
   purpose: string;
   exp: number;
+  jti: string;
 }
 
 function base64UrlEncode(data: ArrayBuffer | Uint8Array): string {
@@ -72,6 +73,7 @@ export async function createReauthProof(
     sub,
     purpose: PROOF_PURPOSE,
     exp: Math.floor(Date.now() / 1000) + ttlSeconds,
+    jti: crypto.randomUUID(),
   };
   const payloadEncoded = base64UrlEncode(
     ENCODER.encode(JSON.stringify(payload)),
@@ -85,15 +87,15 @@ export async function createReauthProof(
   return `${payloadEncoded}.${base64UrlEncode(signature)}`;
 }
 
-// Returns true only when the token is a structurally-valid, correctly-signed,
-// unexpired deletion proof whose subject equals `expectedSub`. Any deviation
-// (bad shape, bad signature, wrong purpose, expired, wrong subject) returns
-// false — never throws.
+// Returns { jti, exp } when the token is a structurally-valid, correctly-signed,
+// unexpired deletion proof with a jti nonce whose subject equals `expectedSub`.
+// Any deviation (bad shape, bad signature, wrong purpose, expired, missing jti,
+// wrong subject) returns false — never throws.
 export async function validateReauthProof(
   token: string,
   secret: string,
   expectedSub: string,
-): Promise<boolean> {
+): Promise<{ jti: string; exp: number } | false> {
   const parts = token.split(".");
   if (parts.length !== 2) return false;
   const [payloadEncoded, signatureStr] = parts;
@@ -113,7 +115,9 @@ export async function validateReauthProof(
     if (payload.purpose !== PROOF_PURPOSE) return false;
     if (payload.exp < Math.floor(Date.now() / 1000)) return false;
     if (payload.sub !== expectedSub) return false;
-    return true;
+    if (typeof payload.jti !== "string" || payload.jti.length === 0)
+      return false;
+    return { jti: payload.jti, exp: payload.exp };
   } catch {
     return false;
   }

--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -1143,11 +1143,29 @@ dashboardRoutes.post("/account/delete", async (c) => {
   const session = c.get("user" as never) as SessionPayload;
   const env = c.env as Env;
   const proof = getCookie(c, "delete_proof");
-  if (
-    !proof ||
-    !(await validateReauthProof(proof, env.SESSION_SECRET, session.sub))
-  ) {
+  const proofResult = proof
+    ? await validateReauthProof(proof, env.SESSION_SECRET, session.sub)
+    : false;
+  if (!proofResult) {
     return c.redirect("/dashboard/settings");
+  }
+
+  // Server-side single-use nonce: consume the jti in the RATE_LIMITER DO so
+  // a captured proof cannot be replayed within its TTL. Degrades gracefully
+  // when the binding is absent (self-host) — erasure must never be blocked by
+  // an optional binding.
+  if (env.RATE_LIMITER) {
+    try {
+      const consumed = await env.RATE_LIMITER.getByName("nonces").consumeNonce(
+        proofResult.jti,
+        proofResult.exp,
+      );
+      if (!consumed) {
+        return c.redirect("/dashboard/settings");
+      }
+    } catch {
+      // DO unreachable — skip nonce check rather than blocking erasure.
+    }
   }
 
   const user = await getUserById(env.DB, session.sub);

--- a/src/rate-limit-do.ts
+++ b/src/rate-limit-do.ts
@@ -26,6 +26,12 @@ export class RateLimiterDO extends DurableObject {
           reset_at INTEGER NOT NULL
         )`,
       );
+      this.ctx.storage.sql.exec(
+        `CREATE TABLE IF NOT EXISTS consumed_nonces (
+          jti TEXT PRIMARY KEY,
+          expires_at INTEGER NOT NULL
+        )`,
+      );
     });
   }
 
@@ -67,5 +73,22 @@ export class RateLimiterDO extends DurableObject {
       resetAt,
       count,
     };
+  }
+
+  // Records a proof nonce as consumed. Returns true on first use; false if the
+  // nonce was already recorded (replay detected). Expired nonces are pruned on
+  // each call to keep storage bounded within the proof TTL.
+  consumeNonce(jti: string, expSec: number): boolean {
+    const nowSec = Math.floor(Date.now() / 1000);
+    this.ctx.storage.sql.exec(
+      "DELETE FROM consumed_nonces WHERE expires_at <= ?",
+      nowSec,
+    );
+    const result = this.ctx.storage.sql.exec(
+      "INSERT OR IGNORE INTO consumed_nonces (jti, expires_at) VALUES (?, ?)",
+      jti,
+      expSec,
+    );
+    return result.rowsWritten === 1;
   }
 }

--- a/test/account-deletion-routes.test.ts
+++ b/test/account-deletion-routes.test.ts
@@ -339,6 +339,68 @@ describe("account deletion — execute (POST /dashboard/account/delete)", () => 
   });
 });
 
+describe("account deletion — server-side single-use nonce", () => {
+  it("rejects a replayed proof when the nonce store is present", async () => {
+    const consumed = new Set<string>();
+    const mockRateLimiter = {
+      getByName: (_: string) => ({
+        consumeNonce: (jti: string, _expSec: number) => {
+          if (consumed.has(jti)) return false;
+          consumed.add(jti);
+          return true;
+        },
+      }),
+    };
+
+    const users = [user("user_1", "a@b.com")];
+    const writes: Array<{ sql: string; bindings: unknown[] }> = [];
+    const db = makeDB({ users, writes });
+    const app = makeApp(db, { RATE_LIMITER: mockRateLimiter });
+    const proof = await createReauthProof("user_1", SECRET);
+    const cookieHdr = `${await sessionCookie("user_1", "a@b.com")}; delete_proof=${proof}`;
+
+    // First use: succeeds and consumes the nonce.
+    const res1 = await app.request("/dashboard/account/delete", {
+      ...form({ confirm: "DELETE" }),
+      headers: {
+        ...(form({}).headers as Record<string, string>),
+        Cookie: cookieHdr,
+      },
+    });
+    expect(res1.status).toBe(302);
+    expect(res1.headers.get("Location")).toBe("/");
+
+    // Second use: same proof, nonce already consumed — rejected before DB.
+    const res2 = await app.request("/dashboard/account/delete", {
+      ...form({ confirm: "DELETE" }),
+      headers: {
+        ...(form({}).headers as Record<string, string>),
+        Cookie: cookieHdr,
+      },
+    });
+    expect(res2.status).toBe(302);
+    expect(res2.headers.get("Location")).toBe("/dashboard/settings");
+  });
+
+  it("still deletes when the nonce store binding is absent (graceful fallback)", async () => {
+    const writes: Array<{ sql: string; bindings: unknown[] }> = [];
+    const users = [user("user_1", "a@b.com")];
+    const db = makeDB({ users, writes });
+    const app = makeApp(db); // no RATE_LIMITER
+    const proof = await createReauthProof("user_1", SECRET);
+    const res = await app.request("/dashboard/account/delete", {
+      ...form({ confirm: "DELETE" }),
+      headers: {
+        ...(form({}).headers as Record<string, string>),
+        Cookie: `${await sessionCookie("user_1", "a@b.com")}; delete_proof=${proof}`,
+      },
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/");
+    expect(users).toHaveLength(0);
+  });
+});
+
 describe("account deletion — stale session after deletion", () => {
   it("a retained valid cookie for a deleted user does not 500 on /dashboard", async () => {
     const writes: Array<{ sql: string; bindings: unknown[] }> = [];

--- a/test/reauth.test.ts
+++ b/test/reauth.test.ts
@@ -6,7 +6,18 @@ const SECRET = "test-session-secret";
 describe("auth/reauth proof token", () => {
   it("validates a fresh proof for the matching subject", async () => {
     const token = await createReauthProof("user_1", SECRET);
-    expect(await validateReauthProof(token, SECRET, "user_1")).toBe(true);
+    expect(await validateReauthProof(token, SECRET, "user_1")).toBeTruthy();
+  });
+
+  it("returns a unique jti nonce in the validation result", async () => {
+    const t1 = await createReauthProof("user_1", SECRET);
+    const t2 = await createReauthProof("user_1", SECRET);
+    const r1 = await validateReauthProof(t1, SECRET, "user_1");
+    const r2 = await validateReauthProof(t2, SECRET, "user_1");
+    expect(r1).not.toBe(false);
+    expect(r2).not.toBe(false);
+    expect((r1 as { jti: string }).jti).toBeTruthy();
+    expect((r1 as { jti: string }).jti).not.toBe((r2 as { jti: string }).jti);
   });
 
   it("rejects a proof minted for a different subject (no cross-account reuse)", async () => {


### PR DESCRIPTION
## Summary

- Each re-auth proof now embeds a unique `jti` nonce (`crypto.randomUUID()`) in its HMAC-signed payload.
- `validateReauthProof` returns `{ jti, exp } | false` (was `boolean`); existing `!(await validateReauthProof(...))` callers work unchanged since the object is truthy.
- `POST /account/delete` consumes the nonce in the `RATE_LIMITER` Durable Object's new `consumed_nonces` SQLite table on first use; a second presentation of the same proof within its TTL is rejected. Degrades gracefully (skips the nonce check) when `RATE_LIMITER` is absent, so erasure is never blocked by an optional binding.
- `RateLimiterDO` gains a `consumeNonce(jti, expSec)` method backed by `INSERT OR IGNORE`; expired entries are pruned on each call to keep storage bounded within the proof TTL.

Closes #553

## Test plan

- [x] `test/reauth.test.ts`: updated `toBe(true)` → `toBeTruthy()`; added test asserting each proof gets a distinct `jti`
- [x] `test/account-deletion-routes.test.ts`: added replay-rejection test (same proof used twice with mock DO → second attempt redirects to `/dashboard/settings`) and graceful-fallback test (no `RATE_LIMITER` → deletion still completes)
- [x] All 24 tests in the two affected files pass; full suite: 1366 passing, 1 pre-existing integration failure (live network egress blocked in sandbox)
- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 issues

## Deferred follow-ups

None — all acceptance criteria shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNnLKwjESqce6dTWCRX2v6

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNnLKwjESqce6dTWCRX2v6)_