### PR TITLE
feat: durable WorkOS identity retry sweep for account deletion (#552)

### DIFF
--- a/src/account/deletion.ts
+++ b/src/account/deletion.ts
@@ -6,6 +6,7 @@ import { cancelSubscription } from "../billing/stripe.js";
 import { getSubscriptionByUserId, statusToPlan } from "../db/subscriptions.js";
 import { deleteUser } from "../db/users.js";
 import type { Env } from "../env.js";
+import { enqueueWorkosRetry } from "./workos-retry.js";
 
 // Confirmation emails are sent from the same verified sender as alerts. A
 // distinct "support@" identity would need its own Cloudflare Email Sending
@@ -70,12 +71,7 @@ export async function deleteAccount(
     } catch (err) {
       workosFailed = true;
       Sentry.captureException(err);
-      // Breadcrumb the orphaned identity so a retry sweep / on-call can find
-      // it; the user can't log in (no local row to provision against), so this
-      // is non-functional, just incomplete erasure of the WorkOS record.
-      console.error(
-        `WorkOS identity deletion failed for user ${user.id}; flagged for retry`,
-      );
+      await enqueueWorkosRetry(env.DB, user.id);
     }
   } else {
     workosSkipped = true;

--- a/src/account/workos-retry.ts
+++ b/src/account/workos-retry.ts
@@ -1,0 +1,99 @@
+import * as Sentry from "@sentry/cloudflare";
+import { deleteWorkosUser } from "../auth/workos.js";
+
+const MAX_ATTEMPTS = 10;
+
+export interface SweepResult {
+  retried: number;
+  cleared: number;
+  givenUp: number;
+  errors: number;
+}
+
+interface RetryRow {
+  workos_user_id: string;
+  attempt_count: number;
+  next_attempt_at: number;
+  enqueued_at: number;
+}
+
+// Persists a failed WorkOS deletion so the nightly sweep can retry it.
+// INSERT OR IGNORE is idempotent — a second enqueue for the same id is a no-op.
+export async function enqueueWorkosRetry(
+  db: D1Database,
+  workosUserId: string,
+): Promise<void> {
+  await db
+    .prepare(
+      "INSERT OR IGNORE INTO workos_identity_retry (workos_user_id) VALUES (?)",
+    )
+    .bind(workosUserId)
+    .run();
+}
+
+// Processes every due entry in the retry queue: calls deleteWorkosUser for
+// each, clears the row on success (including 404 = already-deleted), and
+// increments the retry counter + exponential backoff on transient failure.
+// After MAX_ATTEMPTS exhausted, Sentry-alerts and removes the row so the
+// table doesn't grow unbounded (bounded retention guarantee).
+//
+// No-op when apiKey is absent (self-host deploys without WorkOS configured).
+// Accepts an optional `now` (Unix seconds) for deterministic testing.
+export async function sweepWorkosRetries(
+  db: D1Database,
+  apiKey: string | undefined,
+  now = Math.floor(Date.now() / 1000),
+): Promise<SweepResult> {
+  if (!apiKey) return { retried: 0, cleared: 0, givenUp: 0, errors: 0 };
+
+  const { results } = await db
+    .prepare(
+      "SELECT workos_user_id, attempt_count, next_attempt_at, enqueued_at FROM workos_identity_retry WHERE next_attempt_at <= ? ORDER BY enqueued_at ASC",
+    )
+    .bind(now)
+    .all<RetryRow>();
+
+  let retried = 0;
+  let cleared = 0;
+  let givenUp = 0;
+  let errors = 0;
+
+  for (const row of results) {
+    retried += 1;
+    try {
+      await deleteWorkosUser(apiKey, row.workos_user_id);
+      await db
+        .prepare("DELETE FROM workos_identity_retry WHERE workos_user_id = ?")
+        .bind(row.workos_user_id)
+        .run();
+      cleared += 1;
+    } catch (err) {
+      const nextCount = row.attempt_count + 1;
+      if (nextCount >= MAX_ATTEMPTS) {
+        Sentry.captureException(
+          new Error(
+            `WorkOS identity ${row.workos_user_id} could not be deleted after ${MAX_ATTEMPTS} attempts; manual intervention required`,
+          ),
+        );
+        await db
+          .prepare("DELETE FROM workos_identity_retry WHERE workos_user_id = ?")
+          .bind(row.workos_user_id)
+          .run();
+        givenUp += 1;
+      } else {
+        // Exponential backoff: 1h × 2^attempt_count, capped at 24h.
+        const backoffSecs = Math.min(86400, 3600 * 2 ** row.attempt_count);
+        await db
+          .prepare(
+            "UPDATE workos_identity_retry SET attempt_count = ?, next_attempt_at = ? WHERE workos_user_id = ?",
+          )
+          .bind(nextCount, now + backoffSecs, row.workos_user_id)
+          .run();
+        Sentry.captureException(err);
+        errors += 1;
+      }
+    }
+  }
+
+  return { retried, cleared, givenUp, errors };
+}

--- a/src/db/migrations/0010_workos_identity_retry.sql
+++ b/src/db/migrations/0010_workos_identity_retry.sql
@@ -1,0 +1,10 @@
+-- Durable retry queue for WorkOS identity deletions that fail during
+-- self-serve account deletion (#552). Persists only the opaque WorkOS user id
+-- (not PII) + retry metadata. The nightly sweep processes due entries with
+-- exponential backoff and gives up + Sentry-alerts after MAX_ATTEMPTS.
+CREATE TABLE IF NOT EXISTS workos_identity_retry (
+  workos_user_id  TEXT    PRIMARY KEY,
+  attempt_count   INTEGER NOT NULL DEFAULT 0,
+  next_attempt_at INTEGER NOT NULL DEFAULT (unixepoch()),
+  enqueued_at     INTEGER NOT NULL DEFAULT (unixepoch())
+);

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -103,6 +103,15 @@ CREATE TABLE IF NOT EXISTS webhook_deliveries (
   attempted_at INTEGER NOT NULL DEFAULT (unixepoch())
 );
 
+-- Durable retry queue for WorkOS identity deletions that fail during account
+-- deletion (#552). Persists only the opaque WorkOS user id + retry metadata.
+CREATE TABLE IF NOT EXISTS workos_identity_retry (
+  workos_user_id  TEXT    PRIMARY KEY,
+  attempt_count   INTEGER NOT NULL DEFAULT 0,
+  next_attempt_at INTEGER NOT NULL DEFAULT (unixepoch()),
+  enqueued_at     INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
 -- Indexes for common queries
 CREATE INDEX IF NOT EXISTS idx_domains_user_id ON domains(user_id);
 CREATE INDEX IF NOT EXISTS idx_scan_history_domain_id ON scan_history(domain_id);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { type Context, Hono } from "hono";
 import { cors } from "hono/cors";
 import { csrf } from "hono/csrf";
 import { streamSSE } from "hono/streaming";
+import { sweepWorkosRetries } from "./account/workos-retry.js";
 import { dispatchPendingAlerts } from "./alerts/dispatcher.js";
 import { validateUnsubscribeToken } from "./alerts/unsubscribe.js";
 import type {
@@ -1509,6 +1510,12 @@ async function scheduled(
     scope.setTag("cron.emails_sent", String(dispatchResult.sent));
     scope.setTag("cron.emails_skipped", String(dispatchResult.skipped));
     scope.setTag("cron.emails_errors", String(dispatchResult.errors));
+
+    // Retry any WorkOS identity deletions that failed during account deletion.
+    const workosResult = await sweepWorkosRetries(env.DB, env.WORKOS_API_KEY);
+    scope.setTag("cron.workos_retried", String(workosResult.retried));
+    scope.setTag("cron.workos_cleared", String(workosResult.cleared));
+    scope.setTag("cron.workos_given_up", String(workosResult.givenUp));
   })().catch((err) => {
     Sentry.captureException(err);
   });

--- a/test/workos-retry.test.ts
+++ b/test/workos-retry.test.ts
@@ -1,0 +1,332 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { deleteAccount } from "../src/account/deletion.js";
+import {
+  enqueueWorkosRetry,
+  sweepWorkosRetries,
+} from "../src/account/workos-retry.js";
+import type { Env } from "../src/env.js";
+
+vi.mock("@sentry/cloudflare", () => ({
+  captureException: vi.fn(),
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Minimal D1 mock that drives the workos_identity_retry table in memory.
+// ---------------------------------------------------------------------------
+interface RetryRow {
+  workos_user_id: string;
+  attempt_count: number;
+  next_attempt_at: number;
+  enqueued_at: number;
+}
+
+function makeRetryDB(initialRows: RetryRow[] = []) {
+  const store: RetryRow[] = [...initialRows];
+
+  const db = {
+    prepare(sql: string) {
+      return {
+        bind(...args: unknown[]) {
+          return {
+            async run() {
+              if (/INSERT OR IGNORE INTO workos_identity_retry/i.test(sql)) {
+                const userId = args[0] as string;
+                if (!store.find((r) => r.workos_user_id === userId)) {
+                  store.push({
+                    workos_user_id: userId,
+                    attempt_count: 0,
+                    next_attempt_at: 0,
+                    enqueued_at: 1000,
+                  });
+                }
+              } else if (/DELETE FROM workos_identity_retry/i.test(sql)) {
+                const userId = args[0] as string;
+                const idx = store.findIndex((r) => r.workos_user_id === userId);
+                if (idx >= 0) store.splice(idx, 1);
+              } else if (/UPDATE workos_identity_retry/i.test(sql)) {
+                const [newCount, newAt, userId] = args;
+                const row = store.find(
+                  (r) => r.workos_user_id === (userId as string),
+                );
+                if (row) {
+                  row.attempt_count = newCount as number;
+                  row.next_attempt_at = newAt as number;
+                }
+              }
+              return {
+                success: true,
+                meta: {
+                  changes: 1,
+                  duration: 0,
+                  last_row_id: 0,
+                  rows_read: 0,
+                  rows_written: 0,
+                  size_after: 0,
+                  changed_db: true,
+                },
+              };
+            },
+            async all<T>() {
+              if (/SELECT .* FROM workos_identity_retry/i.test(sql)) {
+                const threshold = args[0] as number;
+                return {
+                  results: store.filter(
+                    (r) => r.next_attempt_at <= threshold,
+                  ) as unknown as T[],
+                  success: true,
+                  meta: {
+                    duration: 0,
+                    last_row_id: 0,
+                    rows_read: 0,
+                    rows_written: 0,
+                    size_after: 0,
+                    changed_db: false,
+                  },
+                };
+              }
+              return {
+                results: [] as T[],
+                success: true,
+                meta: {
+                  duration: 0,
+                  last_row_id: 0,
+                  rows_read: 0,
+                  rows_written: 0,
+                  size_after: 0,
+                  changed_db: false,
+                },
+              };
+            },
+            async first<T>() {
+              return null as T | null;
+            },
+          };
+        },
+      };
+    },
+  } as unknown as D1Database;
+
+  return { store, db };
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance criterion (a): WorkOS-delete failure enqueues the user id
+// ---------------------------------------------------------------------------
+describe("deleteAccount → enqueueWorkosRetry on WorkOS failure", () => {
+  it("writes the WorkOS user id into the retry table when WorkOS delete fails", async () => {
+    const { store, db } = makeRetryDB();
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 500 }),
+    );
+
+    const env: Env = {
+      DB: db,
+      WORKOS_CLIENT_ID: "",
+      WORKOS_CLIENT_SECRET: "",
+      WORKOS_REDIRECT_URI: "",
+      SESSION_SECRET: "s",
+      WORKOS_API_KEY: "sk_workos",
+    } as Env;
+
+    const result = await deleteAccount(env, {
+      id: "user_workos_01",
+      email: "alice@example.com",
+    });
+
+    expect(result.workosFailed).toBe(true);
+    expect(store).toHaveLength(1);
+    expect(store[0].workos_user_id).toBe("user_workos_01");
+  });
+
+  it("does NOT enqueue when WorkOS delete succeeds", async () => {
+    const { store, db } = makeRetryDB();
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 200 }),
+    );
+
+    const env: Env = {
+      DB: db,
+      WORKOS_CLIENT_ID: "",
+      WORKOS_CLIENT_SECRET: "",
+      WORKOS_REDIRECT_URI: "",
+      SESSION_SECRET: "s",
+      WORKOS_API_KEY: "sk_workos",
+    } as Env;
+
+    const result = await deleteAccount(env, {
+      id: "user_workos_01",
+      email: "alice@example.com",
+    });
+
+    expect(result.workosDeleted).toBe(true);
+    expect(store).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enqueueWorkosRetry unit tests
+// ---------------------------------------------------------------------------
+describe("enqueueWorkosRetry", () => {
+  it("inserts the user id into the retry table", async () => {
+    const { store, db } = makeRetryDB();
+
+    await enqueueWorkosRetry(db, "user_abc");
+
+    expect(store).toHaveLength(1);
+    expect(store[0].workos_user_id).toBe("user_abc");
+  });
+
+  it("is idempotent — a second call for the same id does not duplicate", async () => {
+    const { store, db } = makeRetryDB();
+
+    await enqueueWorkosRetry(db, "user_abc");
+    await enqueueWorkosRetry(db, "user_abc");
+
+    expect(store).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Acceptance criterion (b): sweep retries and clears on success
+// ---------------------------------------------------------------------------
+describe("sweepWorkosRetries", () => {
+  it("calls deleteWorkosUser and removes the row on success", async () => {
+    const now = 2000;
+    const { store, db } = makeRetryDB([
+      {
+        workos_user_id: "user_retry_01",
+        attempt_count: 0,
+        next_attempt_at: now - 1,
+        enqueued_at: 1000,
+      },
+    ]);
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 200 }),
+    );
+
+    const result = await sweepWorkosRetries(db, "sk_workos", now);
+
+    expect(result.retried).toBe(1);
+    expect(result.cleared).toBe(1);
+    expect(result.errors).toBe(0);
+    expect(result.givenUp).toBe(0);
+    expect(store).toHaveLength(0);
+  });
+
+  it("treats a 404 as already-deleted and clears the row", async () => {
+    const now = 2000;
+    const { store, db } = makeRetryDB([
+      {
+        workos_user_id: "user_gone",
+        attempt_count: 2,
+        next_attempt_at: now - 1,
+        enqueued_at: 1000,
+      },
+    ]);
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 404 }),
+    );
+
+    const result = await sweepWorkosRetries(db, "sk_workos", now);
+
+    expect(result.cleared).toBe(1);
+    expect(store).toHaveLength(0);
+  });
+
+  it("increments attempt_count and sets next_attempt_at on failure", async () => {
+    const now = 2000;
+    const { store, db } = makeRetryDB([
+      {
+        workos_user_id: "user_fail",
+        attempt_count: 1,
+        next_attempt_at: now - 1,
+        enqueued_at: 1000,
+      },
+    ]);
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("error", { status: 500 }),
+    );
+
+    const result = await sweepWorkosRetries(db, "sk_workos", now);
+
+    expect(result.errors).toBe(1);
+    expect(result.cleared).toBe(0);
+    expect(store).toHaveLength(1);
+    expect(store[0].attempt_count).toBe(2);
+    // Backoff at attempt_count=1 is min(86400, 3600 * 2^1) = 7200s
+    expect(store[0].next_attempt_at).toBe(now + 7200);
+  });
+
+  it("gives up and removes the row after MAX_ATTEMPTS", async () => {
+    const now = 2000;
+    const { store, db } = makeRetryDB([
+      {
+        workos_user_id: "user_exhaust",
+        attempt_count: 9,
+        next_attempt_at: now - 1,
+        enqueued_at: 1000,
+      },
+    ]);
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("error", { status: 503 }),
+    );
+
+    const result = await sweepWorkosRetries(db, "sk_workos", now);
+
+    expect(result.givenUp).toBe(1);
+    expect(result.errors).toBe(0);
+    expect(store).toHaveLength(0);
+  });
+
+  it("skips rows whose next_attempt_at is in the future", async () => {
+    const now = 2000;
+    const { store, db } = makeRetryDB([
+      {
+        workos_user_id: "user_future",
+        attempt_count: 0,
+        next_attempt_at: now + 3600,
+        enqueued_at: 1000,
+      },
+    ]);
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    const result = await sweepWorkosRetries(db, "sk_workos", now);
+
+    expect(result.retried).toBe(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(store).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Acceptance criterion (c): no-op when WORKOS_API_KEY is absent
+  // -------------------------------------------------------------------------
+  it("is a no-op and makes no DB calls when apiKey is absent", async () => {
+    const { store, db } = makeRetryDB([
+      {
+        workos_user_id: "user_skipped",
+        attempt_count: 0,
+        next_attempt_at: 0,
+        enqueued_at: 1000,
+      },
+    ]);
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const result = await sweepWorkosRetries(db, undefined);
+
+    expect(result).toEqual({ retried: 0, cleared: 0, givenUp: 0, errors: 0 });
+    expect(fetchSpy).not.toHaveBeenCalled();
+    // Store untouched — no DB queries ran
+    expect(store).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `workos_identity_retry` D1 table (migration `0010`) to durably store WorkOS user ids whose identity deletion failed during self-serve account deletion
- `deleteAccount` now calls `enqueueWorkosRetry(env.DB, user.id)` on WorkOS failure (replaces the `console.error` breadcrumb that was the only retention)
- Nightly cron (`scheduled()`) runs `sweepWorkosRetries` which retries due entries with exponential backoff (1h × 2^n, capped 24h), clears on success/404, Sentry-alerts + removes rows that exhaust 10 attempts — closing the GDPR/CCPA erasure gap from a transient WorkOS 5xx

Closes #552

## Test plan

- [ ] `npm test` — 1380 passing, 1 pre-existing failure (`test/integration/mta-sts-runtime.test.ts` — live network, blocked by container egress policy, unrelated to this PR)
- [ ] New test file `test/workos-retry.test.ts` covers all three acceptance criteria:
  - (a) WorkOS failure in `deleteAccount` writes user id to retry table
  - (b) `sweepWorkosRetries` calls `deleteWorkosUser`, clears row on success; increments backoff on failure; gives up + removes row after MAX_ATTEMPTS
  - (c) `sweepWorkosRetries` is a no-op (returns zero counts, no DB/network calls) when `WORKOS_API_KEY` absent
- [ ] `npm run typecheck` — clean
- [ ] `npm run lint` — clean
- [ ] D1 migration `src/db/migrations/0010_workos_identity_retry.sql` is additive-only (new table, no drops/renames) per `src/db/CLAUDE.md`; `schema.sql` updated in parallel

## Deferred follow-ups

None — all Acceptance items from #552 are shipped in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvZMWSiKnRbX8Gqra4rc8K

---
_Generated by [Claude Code](https://claude.ai/code/session_01CvZMWSiKnRbX8Gqra4rc8K)_