### PR TITLE
fix: decouple MCP handler from full ExecutionContext type

### DIFF
--- a/src/mcp/handler.ts
+++ b/src/mcp/handler.ts
@@ -109,7 +109,11 @@ function rpcError(
 }
 
 export interface McpEnv {
-  executionCtx: ExecutionContext;
+  // Only waitUntil is used (to flush the scan-cache write), so narrow to that
+  // surface rather than the full ExecutionContext. Newer @cloudflare/workers-types
+  // make ExecutionContext.tracing required, which Hono's c.executionCtx type does
+  // not carry; depending on the whole shape here breaks the call site in index.ts.
+  executionCtx: Pick<ExecutionContext, "waitUntil">;
   // Self-host scoring rubric override, forwarded to scan() (issue #25).
   scoringConfig: Partial<ScoringConfig>;
 }


### PR DESCRIPTION
## What

Narrows `McpEnv.executionCtx` ([src/mcp/handler.ts:111](src/mcp/handler.ts#L111)) from the full global `ExecutionContext` to `Pick<ExecutionContext, "waitUntil">` — the only member the MCP handler uses ([src/mcp/handler.ts:196](src/mcp/handler.ts#L196)).

## Why

Newer `@cloudflare/workers-types` (`4.20260623+`, pulled transitively by `wrangler >= ^4.103`) make `ExecutionContext.tracing` a **required** property. Hono's `c.executionCtx` type doesn't carry it, so the `POST /mcp` call site at [src/index.ts:895](src/index.ts#L895) fails typecheck:

```
src/index.ts(895,5): error TS2741: Property 'tracing' is missing in type 'ExecutionContext' but required in type 'ExecutionContext<unknown>'.
```

This blocks Dependabot #569 (root `undici` bump, whose lockfile regen incidentally bumps `wrangler`/`workers-types`) and would recur on every future wrangler bump. Current `main` typechecks clean only because it still pins `workers-types 4.20260611.1`. Expressing the real contract decouples the handler from the full `ExecutionContext` shape.

## Verification

- ✅ Reproduced under #569's lockfile (`workers-types 4.20260623.1`): typecheck fails with `TS2741` **before** the fix, passes **after**.
- ✅ Typecheck passes on the currently-shipped lockfile (`workers-types 4.20260611.1`) — no regression.
- ✅ `npm run lint` clean; `npm test` → 1370 pass. The lone failure is the live MTA-STS network canary (`test/integration/mta-sts-runtime.test.ts`), unrelated to this change and a local-connectivity artifact — it passes in CI.

Type-only change; no runtime behavior change.

Closes #572.
