### PR TITLE
feat: DNSBL/IP-reputation analyzer via Spamhaus DQS (issue #587)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -931,9 +931,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -951,9 +948,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -971,9 +965,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -991,9 +982,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1011,9 +999,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1031,9 +1016,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1051,9 +1033,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1071,9 +1050,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1091,9 +1067,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1117,9 +1090,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1143,9 +1113,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1169,9 +1136,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1195,9 +1159,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1221,9 +1182,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1247,9 +1205,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1273,9 +1228,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1576,9 +1528,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1596,9 +1545,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1616,9 +1562,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1636,9 +1579,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1656,9 +1596,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1676,9 +1613,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2352,9 +2286,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2376,9 +2307,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2400,9 +2328,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2424,9 +2349,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2601,9 +2523,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2621,9 +2540,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2641,9 +2557,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2661,9 +2574,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2681,9 +2591,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2701,9 +2608,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2721,9 +2625,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2741,9 +2642,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2761,9 +2659,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2787,9 +2682,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2813,9 +2705,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2839,9 +2728,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2865,9 +2751,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2891,9 +2774,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2917,9 +2797,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2943,9 +2820,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [

--- a/src/analyzers/dnsbl.ts
+++ b/src/analyzers/dnsbl.ts
@@ -1,0 +1,184 @@
+import { DnsLookupError, queryDoh } from "../dns/client.js";
+import type { ScanBudget } from "../dns/scan-budget.js";
+import type {
+  DnsblListing,
+  DnsblResult,
+  MxResult,
+  SpfIncludeNode,
+  SpfResult,
+  Validation,
+} from "./types.js";
+
+const MAX_DNSBL_IPS = 10;
+const DQS_ZONE = "zen.dq.spamhaus.net";
+
+function extractIpsFromTree(
+  node: SpfIncludeNode | null,
+  out: Set<string>,
+): void {
+  if (!node) return;
+  for (const mech of node.mechanisms) {
+    const bare = mech.replace(/^[+\-~?]/, "");
+    if (bare.startsWith("ip4:") || bare.startsWith("ip6:")) {
+      const ip = bare.slice(4).split("/")[0];
+      if (ip) out.add(ip);
+    }
+  }
+  for (const inc of node.includes) extractIpsFromTree(inc, out);
+}
+
+function reverseIpv4(ip: string): string | null {
+  const parts = ip.split(".");
+  if (parts.length !== 4) return null;
+  if (parts.some((p) => !/^\d+$/.test(p) || Number(p) > 255)) return null;
+  return parts.slice().reverse().join(".");
+}
+
+function expandIPv6(ip: string): string | null {
+  const trimmed = ip.split("%")[0];
+  const halves = trimmed.split("::");
+  if (halves.length > 2) return null;
+  const left = halves[0] ? halves[0].split(":") : [];
+  const right = halves.length === 2 && halves[1] ? halves[1].split(":") : [];
+  const missing = 8 - left.length - right.length;
+  if (missing < 0) return null;
+  if (halves.length === 1 && left.length !== 8) return null;
+  const groups = [...left, ...Array(missing).fill("0"), ...right];
+  if (groups.length !== 8) return null;
+  for (const g of groups) {
+    if (!/^[0-9a-f]{1,4}$/i.test(g)) return null;
+  }
+  return groups
+    .map((g) => g.padStart(4, "0"))
+    .join("")
+    .toLowerCase();
+}
+
+function reverseIPv6(ip: string): string | null {
+  const expanded = expandIPv6(ip.toLowerCase());
+  if (!expanded) return null;
+  return expanded.split("").reverse().join(".");
+}
+
+export async function analyzeDnsbl(
+  _domain: string,
+  mxResult: MxResult,
+  spfResult: SpfResult,
+  dqsKey: string | undefined,
+  budget?: ScanBudget,
+): Promise<DnsblResult> {
+  if (!dqsKey) {
+    return {
+      status: "info",
+      checked: 0,
+      listed: [],
+      validations: [
+        {
+          status: "info",
+          message:
+            "DNSBL check not configured — set DNSBL_DQS_KEY to enable Spamhaus ZEN lookups",
+        },
+      ],
+    };
+  }
+
+  const candidateIps = new Set<string>();
+  extractIpsFromTree(spfResult.include_tree, candidateIps);
+
+  // Resolve MX hostnames to A records for additional sending IPs.
+  await Promise.allSettled(
+    mxResult.records.map(async (rec) => {
+      try {
+        const response = await queryDoh(rec.exchange, "A", budget);
+        if (response?.Answer) {
+          for (const a of response.Answer) {
+            if (typeof a.data === "string" && a.data.trim()) {
+              candidateIps.add(a.data.trim());
+            }
+          }
+        }
+      } catch {
+        // Per-host resolution failures are ignored — we still check
+        // whatever IPs we have from other sources.
+      }
+    }),
+  );
+
+  const ips = [...candidateIps].slice(0, MAX_DNSBL_IPS);
+  if (ips.length === 0) {
+    return {
+      status: "info",
+      checked: 0,
+      listed: [],
+      validations: [
+        {
+          status: "info",
+          message: "No sending IPs derivable for DNSBL check",
+        },
+      ],
+    };
+  }
+
+  const listedIps: Array<{ ip: string; returnCode: string }> = [];
+  const validations: Validation[] = [];
+  let lookupError: { code: string; message: string } | undefined;
+
+  await Promise.allSettled(
+    ips.map(async (ip) => {
+      const isIPv6 = ip.includes(":");
+      const reversed = isIPv6 ? reverseIPv6(ip) : reverseIpv4(ip);
+      if (!reversed) return;
+      // Query name embeds dqsKey — queryDoh draws from the shared budget.
+      const queryName = `${reversed}.${dqsKey}.${DQS_ZONE}`;
+      try {
+        const response = await queryDoh(queryName, "A", budget);
+        if (response?.Answer && response.Answer.length > 0) {
+          listedIps.push({ ip, returnCode: response.Answer[0].data });
+        }
+      } catch (err) {
+        if (err instanceof DnsLookupError && !lookupError) {
+          lookupError = { code: err.code, message: err.message };
+        }
+      }
+    }),
+  );
+
+  if (listedIps.length > 0) {
+    const listedStr = listedIps
+      .map((l) => `${l.ip} (${l.returnCode})`)
+      .join(", ");
+    validations.push({
+      status: "warn",
+      message: `${listedIps.length} sending IP${listedIps.length !== 1 ? "s" : ""} listed on Spamhaus ZEN: ${listedStr}`,
+    });
+    validations.push({
+      status: "info",
+      message: `${ips.length} IP${ips.length !== 1 ? "s" : ""} checked`,
+    });
+    const listed: DnsblListing[] = listedIps.map((l) => ({
+      ip: l.ip,
+      zones: ["zen"],
+    }));
+    return { status: "warn", checked: ips.length, listed, validations };
+  }
+
+  if (lookupError) {
+    validations.push({
+      status: "warn",
+      message: `DNSBL lookup failed (${lookupError.code}) — could not verify sending IPs`,
+    });
+    return {
+      status: "warn",
+      checked: ips.length,
+      listed: [],
+      validations,
+      lookup_error: lookupError,
+    };
+  }
+
+  validations.push({
+    status: "pass",
+    message: `${ips.length} sending IP${ips.length !== 1 ? "s" : ""} checked — none listed on Spamhaus ZEN`,
+  });
+  return { status: "pass", checked: ips.length, listed: [], validations };
+}

--- a/src/analyzers/types.ts
+++ b/src/analyzers/types.ts
@@ -158,6 +158,19 @@ export interface DaneResult {
   lookup_error?: { code: string; message: string };
 }
 
+export interface DnsblListing {
+  ip: string;
+  zones: string[];
+}
+
+export interface DnsblResult {
+  status: Status;
+  checked: number;
+  listed: DnsblListing[];
+  validations: Validation[];
+  lookup_error?: { code: string; message: string };
+}
+
 export interface ScanResult {
   domain: string;
   timestamp: string;
@@ -175,5 +188,6 @@ export interface ScanResult {
     tls_rpt?: TlsRptResult;
     dnssec?: DnssecResult;
     dane?: DaneResult;
+    dnsbl?: DnsblResult;
   };
 }

--- a/src/env.ts
+++ b/src/env.ts
@@ -45,4 +45,9 @@ export interface Env {
   // domain (`dmarc.mx`) is not affected by these vars.
   ACCESS_AUD?: string;
   ACCESS_TEAM_DOMAIN?: string;
+  // Spamhaus DQS key for DNSBL/IP-reputation checks (issue #587). Optional:
+  // when absent, the DNSBL analyzer returns a clean "not configured" info
+  // result and no outbound DNS queries are issued. Set via `wrangler secret
+  // put DNSBL_DQS_KEY` — never add to [vars] (key must stay out of source).
+  DNSBL_DQS_KEY?: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import type {
   DaneResult,
   DkimResult,
   DmarcResult,
+  DnsblResult,
   DnssecResult,
   MtaStsResult,
   MxResult,
@@ -79,6 +80,7 @@ import {
   renderDaneCard,
   renderDkimCard,
   renderDmarcCard,
+  renderDnsblCard,
   renderDnssecCard,
   renderError,
   renderLandingPage,
@@ -557,6 +559,7 @@ const protocolRenderers: Record<
   tls_rpt: (r) => renderTlsRptCard(r as TlsRptResult),
   dnssec: (r) => renderDnssecCard(r as DnssecResult),
   dane: (r) => renderDaneCard(r as DaneResult),
+  dnsbl: (r) => renderDnsblCard(r as DnsblResult),
 };
 
 function tagScanResult(result: ScanResult): void {
@@ -649,6 +652,8 @@ app.get("/api/check/stream", async (c) => {
         if (pending) protocolWrites.push(pending);
       },
       parseScoringConfig(c.env?.SCORING_CONFIG),
+      undefined,
+      c.env?.DNSBL_DQS_KEY,
     );
     await Promise.all(protocolWrites);
 
@@ -750,7 +755,13 @@ app.get("/badge", async (c) => {
     const cached = await getCachedScan(domain, []);
     const result =
       cached ??
-      (await scan(domain, [], parseScoringConfig(c.env?.SCORING_CONFIG)));
+      (await scan(
+        domain,
+        [],
+        parseScoringConfig(c.env?.SCORING_CONFIG),
+        undefined,
+        c.env?.DNSBL_DQS_KEY,
+      ));
     if (!cached) {
       const pendingCacheWrite = setCachedScan(domain, [], result);
       if (pendingCacheWrite) {
@@ -1088,6 +1099,8 @@ app.get("/api/check", async (c) => {
         domain,
         selectors,
         parseScoringConfig(c.env?.SCORING_CONFIG),
+        undefined,
+        c.env?.DNSBL_DQS_KEY,
       ));
     tagScanResult(result);
     if (!cached) {
@@ -1286,6 +1299,8 @@ app.get("/check/score", async (c) => {
       domain,
       selectors,
       parseScoringConfig(c.env?.SCORING_CONFIG),
+      undefined,
+      c.env?.DNSBL_DQS_KEY,
     );
     tagScanResult(result);
     return c.html(renderScoreBreakdown(result));
@@ -1343,6 +1358,8 @@ app.get("/check", async (c) => {
           domain,
           selectors,
           parseScoringConfig(c.env?.SCORING_CONFIG),
+          undefined,
+          c.env?.DNSBL_DQS_KEY,
         ));
       tagScanResult(result);
       if (!cached) {
@@ -1371,6 +1388,8 @@ app.get("/check", async (c) => {
         domain,
         selectors,
         parseScoringConfig(c.env?.SCORING_CONFIG),
+        undefined,
+        c.env?.DNSBL_DQS_KEY,
       );
       tagScanResult(result);
       return c.json(result);
@@ -1393,6 +1412,8 @@ app.get("/check", async (c) => {
         domain,
         selectors,
         parseScoringConfig(c.env?.SCORING_CONFIG),
+        undefined,
+        c.env?.DNSBL_DQS_KEY,
       );
       tagScanResult(result);
       return c.body(generateCsv(result), 200, {
@@ -1428,6 +1449,8 @@ app.get("/check", async (c) => {
           domain,
           selectors,
           parseScoringConfig(c.env?.SCORING_CONFIG),
+          undefined,
+          c.env?.DNSBL_DQS_KEY,
         ));
       tagScanResult(result);
       if (!cached) {

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -3,6 +3,7 @@ import { analyzeBimi, prefetchBimiDns } from "./analyzers/bimi.js";
 import { analyzeDane } from "./analyzers/dane.js";
 import { analyzeDkim } from "./analyzers/dkim.js";
 import { analyzeDmarc } from "./analyzers/dmarc.js";
+import { analyzeDnsbl } from "./analyzers/dnsbl.js";
 import { analyzeDnssec } from "./analyzers/dnssec.js";
 import { analyzeMtaSts } from "./analyzers/mta-sts.js";
 import { analyzeMx } from "./analyzers/mx.js";
@@ -15,6 +16,7 @@ import type {
   DaneResult,
   DkimResult,
   DmarcResult,
+  DnsblResult,
   DnssecResult,
   MtaStsResult,
   MxResult,
@@ -42,7 +44,8 @@ export type ProtocolId =
   | "security_txt"
   | "tls_rpt"
   | "dnssec"
-  | "dane";
+  | "dane"
+  | "dnsbl";
 export type ProtocolResult =
   | MxResult
   | DmarcResult
@@ -53,7 +56,8 @@ export type ProtocolResult =
   | SecurityTxtResult
   | TlsRptResult
   | DnssecResult
-  | DaneResult;
+  | DaneResult
+  | DnsblResult;
 
 export const PROTOCOL_LABEL: Record<ProtocolId, string> = {
   mx: "MX",
@@ -66,6 +70,7 @@ export const PROTOCOL_LABEL: Record<ProtocolId, string> = {
   tls_rpt: "TLS-RPT",
   dnssec: "DNSSEC",
   dane: "DANE/TLSA",
+  dnsbl: "DNSBL/Spamhaus",
 };
 
 function analyzerErrorValidation(id: ProtocolId, message: string): Validation {
@@ -146,6 +151,13 @@ const ERROR_RESULTS = {
     status: "fail",
     hosts: [],
     validations: [analyzerErrorValidation("dane", m)],
+    lookup_error: { code: "analyzer_error", message: m },
+  }),
+  dnsbl: (m: string): DnsblResult => ({
+    status: "fail",
+    checked: 0,
+    listed: [],
+    validations: [analyzerErrorValidation("dnsbl", m)],
     lookup_error: { code: "analyzer_error", message: m },
   }),
 } as const;
@@ -265,8 +277,10 @@ export async function scan(
   domain: string,
   customSelectors: string[],
   config: Partial<ScoringConfig>,
-  limits: ScanLimits = DEFAULT_SCAN_LIMITS,
+  limits?: ScanLimits,
+  dqsKey?: string,
 ): Promise<ScanResult> {
+  const { maxDnsQueries, deadlineMs } = limits ?? DEFAULT_SCAN_LIMITS;
   // GHSA-f828-8wf8-vqp2 — bound the whole scan with one deadline + one shared
   // DNS-query pool, so neither total outbound queries nor wall-clock can scale
   // with attacker-controlled input (huge selector lists, rua/ruf-stuffed
@@ -274,8 +288,8 @@ export async function scan(
   // ScanBudget from issuing any further query once it trips.
   const controller = new AbortController();
   const { signal } = controller;
-  const deadlineTimer = setTimeout(() => controller.abort(), limits.deadlineMs);
-  const budget = new ScanBudget(limits.maxDnsQueries, signal);
+  const deadlineTimer = setTimeout(() => controller.abort(), deadlineMs);
+  const budget = new ScanBudget(maxDnsQueries, signal);
 
   // settle (isolate one analyzer's rejection, #378) THEN race the deadline:
   // a slow analyzer yields its synthetic fallback instead of stalling the scan.
@@ -319,6 +333,12 @@ export async function scan(
       ),
     );
 
+    // Chain DNSBL off MX + SPF — IPs come from SPF include tree and MX A records
+    const dnsblPromise = Promise.all([mxPromise, spfPromise]).then(
+      ([mxResult, spfResult]) =>
+        analyzeDnsbl(domain, mxResult, spfResult, dqsKey, budget),
+    );
+
     const bimiPromise = Promise.all([dmarcPromise, bimiDnsPromise]).then(
       ([dmarcResult, bimiDns]) => {
         const dmarcPolicy = dmarcResult.tags?.p?.toLowerCase() ?? null;
@@ -340,6 +360,7 @@ export async function scan(
       tlsRptResult,
       dnssecResult,
       daneResult,
+      dnsblResult,
     ] = await Promise.all([
       bounded("dmarc", dmarcPromise, ERROR_RESULTS.dmarc),
       bounded("spf", spfPromise, ERROR_RESULTS.spf),
@@ -351,6 +372,7 @@ export async function scan(
       bounded("tls_rpt", tlsRptPromise, ERROR_RESULTS.tls_rpt),
       bounded("dnssec", dnssecPromise, ERROR_RESULTS.dnssec),
       bounded("dane", danePromise, ERROR_RESULTS.dane),
+      bounded("dnsbl", dnsblPromise, ERROR_RESULTS.dnsbl),
     ]);
 
     Sentry.addBreadcrumb({
@@ -407,6 +429,12 @@ export async function scan(
       data: { protocol: "dane", status: daneResult.status },
       level: "info",
     });
+    Sentry.addBreadcrumb({
+      category: "analyzer.complete",
+      message: `dnsbl: ${dnsblResult.status}`,
+      data: { protocol: "dnsbl", status: dnsblResult.status },
+      level: "info",
+    });
 
     return await buildScanResult(
       domain,
@@ -421,6 +449,7 @@ export async function scan(
         tls_rpt: tlsRptResult,
         dnssec: dnssecResult,
         dane: daneResult,
+        dnsbl: dnsblResult,
       },
       config,
       budget,
@@ -437,8 +466,10 @@ export async function scanStreaming(
   customSelectors: string[],
   onResult: (id: ProtocolId, result: ProtocolResult) => void,
   config: Partial<ScoringConfig>,
-  limits: ScanLimits = DEFAULT_SCAN_LIMITS,
+  limits?: ScanLimits,
+  dqsKey?: string,
 ): Promise<ScanResult> {
+  const { maxDnsQueries, deadlineMs } = limits ?? DEFAULT_SCAN_LIMITS;
   // GHSA-f828-8wf8-vqp2 — same deadline + shared DNS-query pool as scan() (see
   // there). The SSE contract is preserved under the deadline: protocols that
   // settled early already streamed; any still in flight when the deadline fires
@@ -446,8 +477,8 @@ export async function scanStreaming(
   // and the client never waits past the deadline.
   const controller = new AbortController();
   const { signal } = controller;
-  const deadlineTimer = setTimeout(() => controller.abort(), limits.deadlineMs);
-  const budget = new ScanBudget(limits.maxDnsQueries, signal);
+  const deadlineTimer = setTimeout(() => controller.abort(), deadlineMs);
+  const budget = new ScanBudget(maxDnsQueries, signal);
 
   // Emit each protocol's card at most once, and never after the scan has been
   // finalized — guards against both a deadline-fallback/real-result double emit
@@ -515,6 +546,12 @@ export async function scanStreaming(
       ),
     );
 
+    // Chain DNSBL off MX + SPF — IPs come from SPF include tree and MX A records
+    const dnsblPromise = Promise.all([mxPromise, spfPromise]).then(
+      ([mxResult, spfResult]) =>
+        analyzeDnsbl(domain, mxResult, spfResult, dqsKey, budget),
+    );
+
     // Chain BIMI off DMARC and BIMI DNS
     const bimiPromise = Promise.all([dmarcPromise, bimiDnsPromise]).then(
       ([dmarcResult, bimiDns]) => {
@@ -545,6 +582,7 @@ export async function scanStreaming(
       tlsRptResult,
       dnssecResult,
       daneResult,
+      dnsblResult,
     ] = await Promise.all([
       streamBounded("dmarc", dmarcPromise, ERROR_RESULTS.dmarc),
       streamBounded("spf", spfPromise, ERROR_RESULTS.spf),
@@ -564,6 +602,7 @@ export async function scanStreaming(
       streamBounded("tls_rpt", tlsRptPromise, ERROR_RESULTS.tls_rpt),
       streamBounded("dnssec", dnssecPromise, ERROR_RESULTS.dnssec),
       streamBounded("dane", danePromise, ERROR_RESULTS.dane),
+      streamBounded("dnsbl", dnsblPromise, ERROR_RESULTS.dnsbl),
     ]);
 
     const result = await buildScanResult(
@@ -579,6 +618,7 @@ export async function scanStreaming(
         tls_rpt: tlsRptResult,
         dnssec: dnssecResult,
         dane: daneResult,
+        dnsbl: dnsblResult,
       },
       config,
       budget,

--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -4,6 +4,7 @@ import type {
   DaneResult,
   DkimResult,
   DmarcResult,
+  DnsblResult,
   DnssecResult,
   MtaStsResult,
   MxResult,
@@ -386,6 +387,26 @@ export function renderDnssecCard(d: DnssecResult): string {
   return protocolCard("DNSSEC", d.status, subtitle, body, false, "dnssec");
 }
 
+export function renderDnsblCard(d: DnsblResult): string {
+  let subtitle: string;
+  if (d.checked === 0) {
+    subtitle = d.status === "info" ? "Not configured" : "No IPs to check";
+  } else if (d.listed.length > 0) {
+    subtitle = `${d.listed.length} IP${d.listed.length !== 1 ? "s" : ""} listed`;
+  } else {
+    subtitle = `${d.checked} IP${d.checked !== 1 ? "s" : ""} checked — clean`;
+  }
+  const body = validationList(d.validations);
+  return protocolCard(
+    "DNSBL/Spamhaus",
+    d.status,
+    subtitle,
+    body,
+    false,
+    "dnsbl",
+  );
+}
+
 export function renderDaneCard(d: DaneResult): string {
   const hostsWithTlsa = d.hosts.filter((h) => h.tlsaRecords.length > 0);
   const subtitle =
@@ -422,6 +443,7 @@ function reportBody(result: ScanResult): string {
     tls_rpt,
     dnssec,
     dane,
+    dnsbl,
   } = result.protocols;
 
   return `<main class="report">
@@ -453,6 +475,7 @@ function reportBody(result: ScanResult): string {
   ${tls_rpt ? renderTlsRptCard(tls_rpt) : ""}
   ${dnssec ? renderDnssecCard(dnssec) : ""}
   ${dane ? renderDaneCard(dane) : ""}
+  ${dnsbl ? renderDnsblCard(dnsbl) : ""}
   ${monitorSnapshotCard(result)}
   <div class="learn-link" style="margin-top:2.5rem">Analyze message headers: <a href="https://toolbox.googleapps.com/apps/messageheader/" target="_blank" rel="noopener">Google &#8599;</a> &middot; <a href="https://mha.azurewebsites.net/" target="_blank" rel="noopener">Microsoft &#8599;</a></div>
   <div class="learn-link" style="margin-top:0.4rem;margin-bottom:1rem"><a href="/scoring">How is my score calculated?</a> &middot; <a href="https://www.cloudflare.com/learning/email-security/dmarc-dkim-spf/" target="_blank" rel="noopener">What is email security? &#8599;</a> &middot; <a href="https://github.com/schmug/dmarcheck/releases" target="_blank" rel="noopener">Changelog &#8599;</a></div>
@@ -563,6 +586,7 @@ export function renderStreamingLoading(
     ${skeletonCard("TLS-RPT", false, "tls_rpt")}
     ${skeletonCard("DNSSEC", false)}
     ${skeletonCard("DANE/TLSA", false, "dane")}
+    ${skeletonCard("DNSBL/Spamhaus", false, "dnsbl")}
   </div>
   <noscript><meta http-equiv="refresh" content="0;url=/check?${esc(qs)}&_direct=1"></noscript>
 </main>

--- a/test/api-check-stream.test.ts
+++ b/test/api-check-stream.test.ts
@@ -144,6 +144,12 @@ const CACHED_SCAN = {
       hosts: [],
       validations: [],
     },
+    dnsbl: {
+      status: "info" as const,
+      checked: 0,
+      listed: [],
+      validations: [],
+    },
   },
 };
 
@@ -458,6 +464,8 @@ describe("GET /api/check/stream — custom selectors", () => {
       ["google", "microsoft"],
       expect.any(Function),
       {},
+      undefined,
+      undefined,
     );
   });
 

--- a/test/dnsbl.test.ts
+++ b/test/dnsbl.test.ts
@@ -1,0 +1,269 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { analyzeDnsbl } from "../src/analyzers/dnsbl.js";
+import type { MxResult, SpfResult } from "../src/analyzers/types.js";
+
+vi.mock("../src/dns/client.js", () => ({
+  queryDoh: vi.fn(),
+  DnsLookupError: class DnsLookupError extends Error {
+    constructor(
+      public readonly code: string,
+      message: string,
+    ) {
+      super(message);
+      this.name = "DnsLookupError";
+    }
+  },
+}));
+
+vi.mock("@sentry/cloudflare", () => ({
+  addBreadcrumb: vi.fn(),
+  captureException: vi.fn(),
+}));
+
+const { queryDoh, DnsLookupError } = (await import("../src/dns/client.js")) as {
+  queryDoh: ReturnType<typeof vi.fn>;
+  DnsLookupError: new (
+    code: string,
+    message: string,
+  ) => Error & { code: string };
+};
+
+const MX_RESULT: MxResult = {
+  status: "info",
+  records: [{ priority: 10, exchange: "mx.example.com" }],
+  providers: [],
+  validations: [],
+};
+
+const SPF_RESULT: SpfResult = {
+  status: "pass",
+  record: "v=spf1 ip4:1.2.3.4 -all",
+  lookups_used: 0,
+  lookup_limit: 10,
+  include_tree: {
+    domain: "example.com",
+    record: "v=spf1 ip4:1.2.3.4 -all",
+    mechanisms: ["ip4:1.2.3.4", "-all"],
+    includes: [],
+  },
+  validations: [],
+};
+
+const EMPTY_MX: MxResult = {
+  status: "info",
+  records: [],
+  providers: [],
+  validations: [],
+};
+
+const EMPTY_SPF: SpfResult = {
+  status: "pass",
+  record: "v=spf1 -all",
+  lookups_used: 0,
+  lookup_limit: 10,
+  include_tree: {
+    domain: "example.com",
+    record: "v=spf1 -all",
+    mechanisms: ["-all"],
+    includes: [],
+  },
+  validations: [],
+};
+
+beforeEach(() => {
+  queryDoh.mockReset();
+});
+
+describe("analyzeDnsbl — no DQS key", () => {
+  it("returns info with not-configured message when key is absent", async () => {
+    const result = await analyzeDnsbl(
+      "example.com",
+      MX_RESULT,
+      SPF_RESULT,
+      undefined,
+    );
+    expect(result.status).toBe("info");
+    expect(result.checked).toBe(0);
+    expect(result.listed).toHaveLength(0);
+    expect(result.validations[0].message).toMatch(/not configured/i);
+    expect(queryDoh).not.toHaveBeenCalled();
+  });
+});
+
+describe("analyzeDnsbl — no derivable IPs", () => {
+  it("returns info when SPF has no IPs and MX resolution yields none", async () => {
+    // MX A-record resolution returns nothing
+    queryDoh.mockResolvedValue(null);
+    const result = await analyzeDnsbl(
+      "example.com",
+      EMPTY_MX,
+      EMPTY_SPF,
+      "testkey",
+    );
+    expect(result.status).toBe("info");
+    expect(result.checked).toBe(0);
+    expect(result.validations[0].message).toMatch(/no sending IPs/i);
+  });
+});
+
+describe("analyzeDnsbl — clean IPs (pass)", () => {
+  it("returns pass when DNSBL query returns null (NXDOMAIN)", async () => {
+    // MX A-record lookup returns nothing; SPF has 1.2.3.4
+    queryDoh.mockImplementation((name: string) => {
+      if (name === "mx.example.com") return Promise.resolve(null);
+      // DNSBL lookup → NXDOMAIN = not listed
+      return Promise.resolve(null);
+    });
+    const result = await analyzeDnsbl(
+      "example.com",
+      MX_RESULT,
+      SPF_RESULT,
+      "testkey",
+    );
+    expect(result.status).toBe("pass");
+    expect(result.checked).toBeGreaterThan(0);
+    expect(result.listed).toHaveLength(0);
+    expect(result.validations[0].message).toMatch(/none listed/i);
+  });
+});
+
+describe("analyzeDnsbl — listed IP (warn)", () => {
+  it("returns warn with listing details when an IP is on Spamhaus ZEN", async () => {
+    queryDoh.mockImplementation((name: string) => {
+      if (name === "mx.example.com") return Promise.resolve(null);
+      // DNSBL listing response for 4.3.2.1.testkey.zen.dq.spamhaus.net
+      return Promise.resolve({
+        Status: 0,
+        AD: false,
+        Answer: [{ name, type: 1, TTL: 300, data: "127.0.0.2" }],
+      });
+    });
+    const result = await analyzeDnsbl(
+      "example.com",
+      MX_RESULT,
+      SPF_RESULT,
+      "testkey",
+    );
+    expect(result.status).toBe("warn");
+    expect(result.listed).toHaveLength(1);
+    expect(result.listed[0].ip).toBe("1.2.3.4");
+    expect(result.listed[0].zones).toContain("zen");
+    expect(result.validations[0].message).toMatch(/spamhaus zen/i);
+  });
+});
+
+describe("analyzeDnsbl — DnsLookupError degradation", () => {
+  it("returns warn with lookup_error when DNSBL query throws DnsLookupError", async () => {
+    queryDoh.mockImplementation((name: string) => {
+      if (name === "mx.example.com") return Promise.resolve(null);
+      return Promise.reject(
+        new DnsLookupError("ESERVFAIL", "DNS server failure (SERVFAIL)"),
+      );
+    });
+    const result = await analyzeDnsbl(
+      "example.com",
+      MX_RESULT,
+      SPF_RESULT,
+      "testkey",
+    );
+    expect(result.status).toBe("warn");
+    expect(result.lookup_error).toBeDefined();
+    expect(result.lookup_error?.code).toBe("ESERVFAIL");
+    expect(result.validations[0].message).toMatch(/could not verify/i);
+  });
+});
+
+describe("analyzeDnsbl — IP cap enforcement", () => {
+  it("checks at most 10 IPs even when SPF declares more", async () => {
+    // Build SPF with 20 ip4 mechanisms
+    const mechanisms = Array.from(
+      { length: 20 },
+      (_, i) => `ip4:10.0.0.${i + 1}`,
+    );
+    const spfResult: SpfResult = {
+      status: "pass",
+      record: `v=spf1 ${mechanisms.join(" ")} -all`,
+      lookups_used: 0,
+      lookup_limit: 10,
+      include_tree: {
+        domain: "example.com",
+        record: "",
+        mechanisms: [...mechanisms, "-all"],
+        includes: [],
+      },
+      validations: [],
+    };
+    // All DNSBL lookups return clean (null)
+    queryDoh.mockResolvedValue(null);
+    const result = await analyzeDnsbl(
+      "example.com",
+      EMPTY_MX,
+      spfResult,
+      "testkey",
+    );
+    // At most 10 IPs checked despite 20 available
+    expect(result.checked).toBeLessThanOrEqual(10);
+    expect(result.status).toBe("pass");
+  });
+});
+
+describe("analyzeDnsbl — IPv6 reversal", () => {
+  it("handles IPv6 IPs from SPF ip6 mechanisms", async () => {
+    const spfResult: SpfResult = {
+      status: "pass",
+      record: "v=spf1 ip6:2001:db8::1 -all",
+      lookups_used: 0,
+      lookup_limit: 10,
+      include_tree: {
+        domain: "example.com",
+        record: "",
+        mechanisms: ["ip6:2001:db8::1", "-all"],
+        includes: [],
+      },
+      validations: [],
+    };
+    queryDoh.mockResolvedValue(null);
+    const result = await analyzeDnsbl(
+      "example.com",
+      EMPTY_MX,
+      spfResult,
+      "testkey",
+    );
+    expect(result.status).toBe("pass");
+    expect(result.checked).toBe(1);
+  });
+});
+
+describe("analyzeDnsbl — MX A-record resolution adds IPs", () => {
+  it("resolves MX hostnames and checks those IPs too", async () => {
+    queryDoh.mockImplementation((name: string) => {
+      if (name === "mx.example.com") {
+        return Promise.resolve({
+          Status: 0,
+          AD: false,
+          Answer: [{ name, type: 1, TTL: 300, data: "5.6.7.8" }],
+        });
+      }
+      // DNSBL lookup → clean
+      return Promise.resolve(null);
+    });
+    const spfNoIps: SpfResult = {
+      ...EMPTY_SPF,
+      include_tree: {
+        domain: "example.com",
+        record: "v=spf1 -all",
+        mechanisms: ["-all"],
+        includes: [],
+      },
+    };
+    const result = await analyzeDnsbl(
+      "example.com",
+      MX_RESULT,
+      spfNoIps,
+      "testkey",
+    );
+    // 5.6.7.8 was derived from MX A-record resolution
+    expect(result.checked).toBe(1);
+    expect(result.status).toBe("pass");
+  });
+});

--- a/test/orchestrator-budget.test.ts
+++ b/test/orchestrator-budget.test.ts
@@ -237,6 +237,7 @@ describe("scanStreaming() bounds fan-out and streams every protocol once", () =>
       "tls_rpt",
       "dnssec",
       "dane",
+      "dnsbl",
     ]) {
       expect(counts.get(id)).toBe(1);
     }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -33,6 +33,11 @@ ACCESS_TEAM_DOMAIN = "coryrankin.cloudflareaccess.com"
 # Example (self-hosters uncomment and edit):
 # SCORING_CONFIG = '{"requireBimiForAPlus":false,"dkimKeyMinBits":4096}'
 
+# Spamhaus DQS key for DNSBL/IP-reputation checks (issue #587). Optional:
+# when absent, the DNSBL card shows "not configured" and no DNS queries are
+# issued. Set via: wrangler secret put DNSBL_DQS_KEY
+# (never add to [vars] — the key must not appear in source control)
+
 [triggers]
 crons = ["17 6 * * *"]
 


### PR DESCRIPTION
## Summary

- Adds a new `dnsbl` protocol card that checks domain sending IPs against the Spamhaus ZEN blocklist via the DQS API
- Credential-gated: requires `DNSBL_DQS_KEY` secret (`wrangler secret put DNSBL_DQS_KEY`); shows "not configured" info card when absent — no DNS queries issued
- Informational only: does **not** affect the letter grade

## What changed

### New analyzer (`src/analyzers/dnsbl.ts`)
- Extracts candidate IPs from the SPF `include_tree` (`ip4:`/`ip6:` mechanisms, recursive) and MX hostname A-record resolution
- Caps checked IPs at 10 per scan (`MAX_DNSBL_IPS`) to bound DNS fan-out
- Reverses IPv4 (`1.2.3.4` → `4.3.2.1`) and IPv6 (expand `::`, pad groups, reverse 32 hex chars, dot-separate) for DNSBL query construction
- Queries `<reversed>.<key>.zen.dq.spamhaus.net` via `queryDoh` — draws from the shared `ScanBudget` (GHSA-f828-8wf8-vqp2 invariant preserved)
- Degrades gracefully on `DnsLookupError` — returns `warn` + `lookup_error`, not a false "clean" result

### Orchestrator (`src/orchestrator.ts`)
- Adds `"dnsbl"` to `ProtocolId`; `analyzeDnsbl` is settled via the existing `settle()`/`raceDeadline()` pattern
- Waits on both `mxResult` and `spfResult` (feeds IP derivation) then runs in parallel with all other late analyzers
- `scan()` and `scanStreaming()` gain an optional `dqsKey?: string` parameter (6th arg); all callers in `src/index.ts` pass `c.env?.DNSBL_DQS_KEY`

### Types / env / views
- `src/analyzers/types.ts`: `DnsblListing`, `DnsblResult`, `dnsbl?` in `ScanResult.protocols`
- `src/env.ts`: documents the optional `DNSBL_DQS_KEY` binding
- `src/views/html.ts`: `renderDnsblCard()` + skeleton streaming placeholder
- `src/index.ts`: `dnsbl` renderer in `protocolRenderers`; all `scan`/`scanStreaming` call sites thread `c.env?.DNSBL_DQS_KEY` using safe optional chaining

### Tests
- `test/dnsbl.test.ts`: 7 describe blocks — no key (info/no-op), no derivable IPs, clean IPs (pass), listed IP (warn), `DnsLookupError` degradation, IP cap at 10, IPv6 reversal, MX A-record resolution
- `test/orchestrator-budget.test.ts`: adds `dnsbl` to the `scanStreaming` emit-once parity assertion
- `test/api-check-stream.test.ts`: adds `dnsbl` to `CACHED_SCAN` fixture; updates `scanStreaming` call-arg count

## Security notes

- The DQS key is embedded in DNS query names (`<reversed>.<key>.zen.dq.spamhaus.net`). It is never logged, returned in responses, or stored in cached keys — the query name is constructed in memory and passed directly to `queryDoh`.
- All `queryDoh` calls pass `budget`, preserving the GHSA-f828-8wf8-vqp2 per-scan DNS-query cap.
- `c.env?.DNSBL_DQS_KEY` uses optional chaining consistently — safe when `env` is absent (test environments, self-host deploys without the binding).

## ⚠️ CODEOWNERS gate

This PR touches `src/analyzers/**` and `src/orchestrator.ts` — paths gated by `.github/CODEOWNERS`. A code-owner approving review is required before merge. **Do not enable auto-merge.**

Closes #587

---
_Generated by [Claude Code](https://claude.ai/code/session_01SacL5DQ1kTXd7EgBgTBZK7)_