### PR TITLE
chore: add a minimal pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+<!--
+Minimal, optional layout. Fill in what applies and delete the rest — the
+sections are prompts, not requirements. Routine/autonomous PRs can keep this
+short; security-sensitive PRs (analyzers, orchestration, scoring, input
+validation, CI, rate limiting, DB migrations) benefit from the Security notes.
+-->
+
+## Summary
+
+<!-- What this PR does and why, in 1-3 sentences. -->
+
+## Owner / zone steps
+
+<!-- Non-committable provisioning required before this works in production —
+     KV namespaces, Email Routing, Cloudflare/Stripe/WorkOS secrets, DNS, etc.
+     Delete this section if there are none. Do not paste secret values here. -->
+
+## Security notes
+
+<!-- Input validation, HTML escaping, auth/redirect posture, rate limiting, or
+     "none" if this PR has no security-relevant surface. -->
+
+## Testing
+
+<!-- How this was verified: npm test / npm run typecheck / npm run lint, plus
+     any manual steps. -->
+
+## Refs
+
+<!-- Closes #123 / Refs #123 -->


### PR DESCRIPTION
## Summary

Adds `.github/pull_request_template.md` — a lightweight, optional layout (Summary / Owner-zone steps / Security notes / Testing / Refs). Sections are prompts, not requirements: routine and autonomous PRs can keep it short, while security-sensitive PRs (analyzers, orchestration, scoring, input validation, CI, rate limiting, DB migrations) and owner-provisioned ones get a consistent place to call out their non-committable steps.

## Owner / zone steps

None.

## Security notes

None — adds a docs-only Markdown file under `.github/`; no code, routes, or config change. The template comment explicitly warns against pasting secret values.

## Testing

No code paths touched. `.github/pull_request_template.md` is GitHub-rendered Markdown; verified it renders and that the section headings match the layout. (Body of this PR is written against the template itself.)

## Refs

Follow-up to #592 (per maintainer request to standardize PR descriptions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jkxZhrM2swL9bMPgJnsd4)_