### PR TITLE
fix: surface the DMARC-relevant SPF + From-aligned DKIM in inbox verdicts (#417)

### DIFF
--- a/src/inbox/store.ts
+++ b/src/inbox/store.ts
@@ -214,6 +214,72 @@ function deriveAlignment(dmarc: string | null): string | null {
   return null;
 }
 
+// Charset-validate + cap an attacker-controlled tag value (selector/domain)
+// pulled from a header. Returns null if it doesn't match the allowed charset.
+function cleanTag(value: string | null, charset: RegExp): string | null {
+  if (!value) return null;
+  const v = value.trim();
+  if (!charset.test(v)) return null;
+  return cap(v, MAX_SELECTOR_LEN);
+}
+
+// Split an Authentication-Results value into its `;`-separated method clauses.
+// Cloudflare's parenthetical comments don't contain `;`, so a plain split is
+// enough to isolate each `method=result ...` clause for the verdict we trust.
+function authClauses(authResults: string): string[] {
+  return authResults
+    .split(";")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+// Relaxed-ish domain alignment: exact match or a parent/child relationship.
+// Good enough to pick which signature to *surface*; Cloudflare's `dmarc=`
+// result is the authoritative alignment verdict.
+function domainsAlign(a: string, b: string): boolean {
+  const x = a.toLowerCase();
+  const y = b.toLowerCase();
+  return x === y || x.endsWith(`.${y}`) || y.endsWith(`.${x}`);
+}
+
+// A message carries multiple SPF/DKIM results (the relay's and the author
+// domain's). The DMARC-relevant ones are the SPF check tied to `smtp.mailfrom`
+// (the envelope identity) and the DKIM signature whose `header.d` aligns with
+// `header.from`. We surface those rather than the first clause, so the verdict
+// reflects the *user's own* domain, not the forwarding relay.
+
+function selectSpf(authResults: string, receivedSpf: string): string | null {
+  const spfClauses = authClauses(authResults).filter((c) => /^spf=/i.test(c));
+  if (spfClauses.length > 0) {
+    const chosen =
+      spfClauses.find((c) => /smtp\.mailfrom=/i.test(c)) ?? spfClauses[0];
+    const m = chosen.match(/^spf=([a-zA-Z]+)/i);
+    if (m) return m[1].toLowerCase();
+  }
+  // No SPF in Authentication-Results — fall back to a Received-SPF header.
+  return receivedSpf.match(/^\s*([a-zA-Z]+)/)?.[1]?.toLowerCase() ?? null;
+}
+
+interface DkimClause {
+  result: string;
+  domain: string | null;
+  selector: string | null;
+}
+
+function parseDkimClauses(authResults: string): DkimClause[] {
+  const out: DkimClause[] = [];
+  for (const clause of authClauses(authResults)) {
+    const m = clause.match(/^dkim=([a-zA-Z]+)/i);
+    if (!m) continue;
+    out.push({
+      result: m[1].toLowerCase(),
+      domain: clause.match(/header\.d=([^\s;]+)/i)?.[1] ?? null,
+      selector: clause.match(/header\.s=([^\s;]+)/i)?.[1] ?? null,
+    });
+  }
+  return out;
+}
+
 /**
  * Parse the authentication verdict out of an inbound message's headers.
  * Cloudflare stamps `Authentication-Results` at ingest; no MIME body parse is
@@ -229,11 +295,26 @@ export function parseVerdict(
   const receivedSpf = headers.get("Received-SPF") ?? "";
 
   const dmarc = extractMethodResult(authResultsRaw, "dmarc");
-  const spf =
-    extractMethodResult(authResultsRaw, "spf") ??
-    receivedSpf.match(/^\s*([a-zA-Z]+)/)?.[1]?.toLowerCase() ??
-    null;
-  const dkim = extractMethodResult(authResultsRaw, "dkim");
+  const spf = selectSpf(authResultsRaw, receivedSpf);
+
+  // Prefer the DKIM signature aligned with the DMARC From domain (the user's
+  // own), then any signature, then the raw DKIM-Signature header as a fallback.
+  const fromDomain =
+    authResultsRaw.match(/header\.from=([^\s;]+)/i)?.[1]?.toLowerCase() ?? null;
+  const dkimClauses = parseDkimClauses(authResultsRaw);
+  const chosenDkim =
+    (fromDomain
+      ? dkimClauses.find((c) => c.domain && domainsAlign(c.domain, fromDomain))
+      : undefined) ?? dkimClauses[0];
+
+  const dkim =
+    chosenDkim?.result ?? extractMethodResult(authResultsRaw, "dkim");
+  const dkim_selector =
+    cleanTag(chosenDkim?.selector ?? null, /^[A-Za-z0-9._-]+$/) ??
+    extractDkimTag(dkimSig, "s", /^[A-Za-z0-9._-]+$/);
+  const dkim_domain =
+    cleanTag(chosenDkim?.domain ?? null, /^[A-Za-z0-9.-]+$/) ??
+    extractDkimTag(dkimSig, "d", /^[A-Za-z0-9.-]+$/);
 
   return {
     status: "received",
@@ -242,8 +323,8 @@ export function parseVerdict(
     dmarc,
     alignment: deriveAlignment(dmarc),
     from: from ? cap(from, MAX_FROM_LEN) : null,
-    dkim_selector: extractDkimTag(dkimSig, "s", /^[A-Za-z0-9._-]+$/),
-    dkim_domain: extractDkimTag(dkimSig, "d", /^[A-Za-z0-9.-]+$/),
+    dkim_selector,
+    dkim_domain,
     auth_results: authResultsRaw
       ? cap(authResultsRaw, MAX_AUTH_RESULTS_LEN)
       : null,

--- a/test/inbox-store.test.ts
+++ b/test/inbox-store.test.ts
@@ -160,6 +160,38 @@ describe("inbox store — parseVerdict", () => {
     expect(v.size_bytes).toBe(1234);
   });
 
+  it("picks the DMARC-relevant SPF (mailfrom) and From-aligned DKIM from a multi-result header", () => {
+    // Real shape: a forwarding relay's results plus the author domain's. The
+    // first spf= is the HELO check (none); the mailfrom check (pass) is what
+    // DMARC used. The first dkim= is the relay (cloudflare-smtp.net); the
+    // From-aligned signature is the author domain (cortech.online).
+    const headers = new Headers({
+      "Authentication-Results":
+        "mx.cloudflare.net; dkim=pass header.d=cloudflare-smtp.net header.s=cf2024-1 header.b=haR8eT2T; dkim=pass header.d=cortech.online header.s=cf-bounce header.b=TkrLHPRk; dmarc=pass header.from=cortech.online policy.dmarc=reject; spf=none (mx.cloudflare.net: no SPF records found for postmaster@bg-he.cloudflare-smtp.net) smtp.helo=bg-he.cloudflare-smtp.net; spf=pass (mx.cloudflare.net: domain of bounces@cf-bounce.cortech.online designates 104.30.16.74 as permitted sender) smtp.mailfrom=bounces@cf-bounce.cortech.online; arc=none smtp.remote-ip=104.30.16.74",
+    });
+    const v = parseVerdict(headers, "bounces@cf-bounce.cortech.online", 4096);
+    expect(v.spf).toBe("pass"); // mailfrom, not the HELO "none"
+    expect(v.dkim).toBe("pass");
+    expect(v.dmarc).toBe("pass");
+    expect(v.alignment).toBe("pass");
+    // The user's own signature, not the Cloudflare relay's cf2024-1.
+    expect(v.dkim_selector).toBe("cf-bounce");
+    expect(v.dkim_domain).toBe("cortech.online");
+  });
+
+  it("falls back to the first DKIM result when none aligns with the From domain", () => {
+    const headers = new Headers({
+      "Authentication-Results":
+        "mx; dkim=pass header.d=relay.example header.s=r1; dmarc=fail header.from=victim.example; spf=fail smtp.mailfrom=relay.example",
+    });
+    const v = parseVerdict(headers, "x@relay.example", 1);
+    expect(v.dkim).toBe("pass");
+    expect(v.dkim_selector).toBe("r1");
+    expect(v.dkim_domain).toBe("relay.example");
+    expect(v.spf).toBe("fail");
+    expect(v.dmarc).toBe("fail");
+  });
+
   it("derives alignment=fail when dmarc fails", () => {
     const headers = new Headers({
       "Authentication-Results": "mx; spf=fail; dkim=fail; dmarc=fail",


### PR DESCRIPTION
## Summary

Follow-up to #592 (inbound test-email scanning). #592 was merged before this fix landed, so it's a small standalone PR — touches only `src/inbox/store.ts` (`parseVerdict`) and `test/inbox-store.test.ts`.

A forwarded message carries **multiple** SPF and DKIM results in `Authentication-Results` — one set for the forwarding relay and one for the author's own domain. The original `parseVerdict` took the *first* of each, which surfaced the wrong line to the user:

- **SPF** showed the **HELO** check (e.g. `none`) instead of the `smtp.mailfrom` check (e.g. `pass`) — the one DMARC actually evaluates.
- **DKIM selector/domain** showed the **relay's** signature (e.g. `cf2024-1` / `cloudflare-smtp.net`) instead of the signature aligned with the From domain (e.g. `cf-bounce` / `cortech.online`) — i.e. the user's own selector, which is the entire point of the feature.

(Found via a real end-to-end test of a `cortech.online` message routed through Cloudflare's SMTP relay.)

## Change

`parseVerdict` now selects the **DMARC-relevant** results, with safe fallbacks:

- **SPF** → the `spf=` clause tied to `smtp.mailfrom` → else the first `spf=` clause → else a `Received-SPF` header.
- **DKIM** → the signature whose `header.d` aligns with the DMARC `header.from` domain (relaxed parent/child match), surfacing *that* signature's selector + domain → else the first `dkim=` clause → else the raw `DKIM-Signature` header.

Selector/domain values pulled from the header are still charset-validated + capped (attacker-controlled), and this remains header-parsing only — **cryptographic DKIM re-verification stays deferred** per the slice's scope.

On the test message above, the verdict card now reads SPF `pass` (not `none`) and selector `cf-bounce (cortech.online)` (not the relay's `cf2024-1`). DMARC `pass` / Alignment `pass` were already correct.

## Testing

Two new cases in `test/inbox-store.test.ts`:
- the real multi-result `cortech.online` header → asserts SPF `pass`, DKIM `pass`, selector `cf-bounce`, domain `cortech.online`, DMARC + alignment `pass`;
- a header with no From-aligned signature → asserts it falls back to the first DKIM result.

`npm test` (inbox suites), `npm run typecheck`, `npm run lint` all green against current `main`.

## Notes
- Touches `src/inbox/**` → **CODEOWNERS-gated**; no auto-merge.
- The hosted Worker picks up the corrected parsing on the next deploy after merge.

Refs #417.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jkxZhrM2swL9bMPgJnsd4)_