### PR TITLE
security: gate src/account/ in CODEOWNERS for human review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,3 +38,10 @@
 /src/analyzers/                 @schmug
 /src/orchestrator.ts            @schmug
 /src/shared/scoring.ts          @schmug
+
+# Account deletion & billing — self-serve erasure orchestration (deletion.ts)
+# cancels Stripe subscriptions, hard-deletes the user row, and removes the
+# WorkOS identity behind a step-up re-auth + IDOR guard (CLAUDE.md "Account
+# deletion (#550, T1/T4/T12)"). Covered broadly so new files under the
+# directory are gated too. Surfaced by #599/#600.
+/src/account/                   @schmug


### PR DESCRIPTION
## Summary
- Add a `/src/account/` entry to `.github/CODEOWNERS` (owner `@schmug`), gating the self-serve account-deletion + Stripe-cancellation flow behind a required code-owner review — mirroring the existing `/src/analyzers/` directory pattern so new files under the directory are covered automatically.
- Comment explains the rationale (Stripe-cancel-before-delete ordering, IDOR guard, step-up re-auth — `CLAUDE.md` "Account deletion (#550, T1/T4/T12)") and cross-references the triage origin (#599).

Closes #600

## Test plan
- [x] `npm run lint` — Biome check, 186 files, no issues
- [x] `npm run typecheck` — `tsc --noEmit`, clean
- [x] `npm test` — 1464/1465 passing; the 1 failure (`test/integration/mta-sts-runtime.test.ts`, a live-network MTA-STS regression guard) reproduces identically on `main` with this diff stashed out, confirming it's a pre-existing sandbox-network failure unrelated to this change
- [x] Manually verified the new entry's column alignment matches every other CODEOWNERS line (39 chars, `@schmug` right-aligned)

## Choices made
- Mirrored the `/src/analyzers/` "directory, not individual files" pattern per the issue's explicit instruction, so future files added under `src/account/` are covered without further edits.
- Comment cites the same CLAUDE.md security-invariants section (`#550, T1/T4/T12`) the issue pointed to, plus both #599 (triage origin) and #600 (this issue) for traceability.

## Deferred
- Auditing/changing the deletion logic itself — out of scope per the issue.
- Gating other ungated directories (`src/auth/`, `src/inbox/`) — explicitly out of scope per the issue; worth a separate follow-up if desired.
- No change made to `.github/workflows/` or the `main-protection` ruleset, per the issue's constraints.

## Note on review routing
This PR touches `.github/CODEOWNERS`, which is itself a CODEOWNERS-gated path (`/.github/ @schmug`). Per repo policy this requires a human code-owner approval and **cannot** be admin-bypassed or self-approved by the bot identity — auto-merge has intentionally **not** been enabled.


---
_Generated by [Claude Code](https://claude.ai/code/session_015iWSgzNutCtayA6mf2KExW)_