### PR TITLE
security: require POST + CSRF for logout, reject cross-site GET

### DIFF
--- a/src/auth/routes.ts
+++ b/src/auth/routes.ts
@@ -3,7 +3,11 @@ import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 import { createDomain } from "../db/domains.js";
 import { createUser, getUserByEmail } from "../db/users.js";
 import { createReauthProof } from "./reauth.js";
-import { createSessionToken, validateSessionToken } from "./session.js";
+import {
+  clearSessionAndRedirect,
+  createSessionToken,
+  validateSessionToken,
+} from "./session.js";
 
 export const authRoutes = new Hono();
 
@@ -146,7 +150,6 @@ authRoutes.get("/callback", async (c) => {
   return c.redirect("/dashboard");
 });
 
-authRoutes.get("/logout", (c) => {
-  deleteCookie(c, "session", { path: "/" });
-  return c.redirect("/");
-});
+authRoutes.get("/logout", (c) => c.text("Method Not Allowed", 405));
+
+authRoutes.post("/logout", (c) => clearSessionAndRedirect(c));

--- a/src/auth/session.ts
+++ b/src/auth/session.ts
@@ -1,7 +1,19 @@
+import type { Context } from "hono";
+import { deleteCookie } from "hono/cookie";
+
 export interface SessionPayload {
   sub: string;
   email: string;
   exp: number;
+}
+
+// Clears the session cookie and sends the user home. Used by the POST
+// /auth/logout handler and by call sites that need to force-log-out a
+// stale session directly (a c.redirect("/auth/logout") would hit that
+// route via a browser GET, which no longer clears cookies post-#621).
+export function clearSessionAndRedirect(c: Context) {
+  deleteCookie(c, "session", { path: "/" });
+  return c.redirect("/");
 }
 
 const ENCODER = new TextEncoder();

--- a/src/billing/routes.ts
+++ b/src/billing/routes.ts
@@ -1,6 +1,9 @@
 import { Hono } from "hono";
 import { requireAuth } from "../auth/middleware.js";
-import type { SessionPayload } from "../auth/session.js";
+import {
+  clearSessionAndRedirect,
+  type SessionPayload,
+} from "../auth/session.js";
 import {
   getSubscriptionByUserId,
   isStripeEventRecorded,
@@ -42,7 +45,7 @@ dashboardBillingRoutes.get("/subscribe", async (c) => {
   const db = env.DB;
   const user = await getUserById(db, session.sub);
   if (!user) {
-    return c.redirect("/auth/logout");
+    return clearSessionAndRedirect(c);
   }
 
   let customerId = user.stripe_customer_id;

--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -15,7 +15,10 @@ import {
   type NonceConsumer,
   validateReauthProof,
 } from "../auth/reauth.js";
-import type { SessionPayload } from "../auth/session.js";
+import {
+  clearSessionAndRedirect,
+  type SessionPayload,
+} from "../auth/session.js";
 import { dashboardBillingRoutes } from "../billing/routes.js";
 import { escapeCsvField } from "../csv.js";
 import {
@@ -1137,7 +1140,7 @@ dashboardRoutes.get("/account/delete", async (c) => {
   const user = await getUserById(env.DB, session.sub);
   if (!user) {
     // Valid session but the row is already gone — treat as logged out.
-    return c.redirect("/auth/logout");
+    return clearSessionAndRedirect(c);
   }
   return c.html(renderDeleteAccountPage({ email: user.email }));
 });
@@ -1165,7 +1168,7 @@ dashboardRoutes.post("/account/delete", async (c) => {
   if (!user) {
     // Already deleted (retained cookie) — clear the proof and log them out.
     deleteCookie(c, "delete_proof", { path: "/" });
-    return c.redirect("/auth/logout");
+    return clearSessionAndRedirect(c);
   }
 
   const body = await c.req.parseBody();
@@ -1217,7 +1220,7 @@ dashboardRoutes.get("/settings", async (c) => {
   const db = (c.env as { DB: D1Database }).DB;
   const user = await getUserById(db, session.sub);
   if (!user) {
-    return c.redirect("/auth/logout");
+    return clearSessionAndRedirect(c);
   }
   const webhook = await db
     .prepare("SELECT url, format FROM webhooks WHERE user_id = ?")
@@ -1296,7 +1299,7 @@ dashboardRoutes.get("/settings/api-keys", async (c) => {
   const db = (c.env as { DB: D1Database }).DB;
   const user = await getUserById(db, session.sub);
   if (!user) {
-    return c.redirect("/auth/logout");
+    return clearSessionAndRedirect(c);
   }
   const showRetirementBanner = user.api_key_retirement_acknowledged_at === null;
   // First visit dismisses the banner — the user has now seen the explanation

--- a/src/index.ts
+++ b/src/index.ts
@@ -324,6 +324,9 @@ app.onError((err, c) => {
 app.use("/api/*", cors());
 
 // Auth routes (public) — login, WorkOS callback, logout
+// Logout is state-changing, so it gets the same Origin/CSRF check as
+// /dashboard/* even though it lives outside that path prefix.
+app.use("/auth/logout", csrf());
 app.route("/auth", authRoutes);
 
 // Dashboard routes (auth enforced inside dashboardRoutes via requireAuth)

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -65,6 +65,20 @@ const DASHBOARD_CSS = `
 .dashboard-nav .nav-user a:hover {
   color: var(--clr-accent);
 }
+.dashboard-nav .nav-logout-form {
+  display: inline;
+}
+.dashboard-nav .nav-logout-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  color: var(--clr-text-muted);
+}
+.dashboard-nav .nav-logout-btn:hover {
+  color: var(--clr-accent);
+}
 .dashboard-body {
   max-width: 900px;
   margin: 2rem auto;
@@ -1399,7 +1413,9 @@ function dashboardPage(title: string, body: string, email: string): string {
   </div>
   <div class="nav-user">
     <span>${esc(email)}</span>
-    <a href="/auth/logout">Logout</a>
+    <form method="POST" action="/auth/logout" class="nav-logout-form">
+      <button type="submit" class="nav-logout-btn">Logout</button>
+    </form>
     ${themeToggle()}
   </div>
 </nav>

--- a/test/account-deletion-routes.test.ts
+++ b/test/account-deletion-routes.test.ts
@@ -503,7 +503,7 @@ describe("account deletion — stale session after deletion", () => {
     expect(res.status).toBe(200);
   });
 
-  it("a retained valid cookie for a deleted user is bounced to logout on /dashboard/settings", async () => {
+  it("a retained valid cookie for a deleted user is logged out on /dashboard/settings", async () => {
     const writes: Array<{ sql: string; bindings: unknown[] }> = [];
     const db = makeDB({ users: [], writes });
     const app = makeApp(db);
@@ -511,6 +511,7 @@ describe("account deletion — stale session after deletion", () => {
       headers: { Cookie: await sessionCookie("ghost", "ghost@b.com") },
     });
     expect(res.status).toBe(302);
-    expect(res.headers.get("Location")).toBe("/auth/logout");
+    expect(res.headers.get("Location")).toBe("/");
+    expect(res.headers.get("Set-Cookie")).toMatch(/session=.*Max-Age=0/);
   });
 });

--- a/test/auth-routes.test.ts
+++ b/test/auth-routes.test.ts
@@ -1,9 +1,11 @@
 import { Hono } from "hono";
+import { csrf } from "hono/csrf";
 import { describe, expect, it } from "vitest";
 import { authRoutes } from "../src/auth/routes.js";
 
 function createTestApp() {
   const app = new Hono();
+  app.use("/auth/logout", csrf());
   app.route("/auth", authRoutes);
   return app;
 }
@@ -126,9 +128,22 @@ describe("auth/routes", () => {
   });
 
   describe("GET /auth/logout", () => {
-    it("clears the session cookie", async () => {
+    it("rejects with 405 and does not clear the session cookie", async () => {
       const app = createTestApp();
       const res = await app.request("/auth/logout", {}, ENV);
+      expect(res.status).toBe(405);
+      expect(res.headers.get("Set-Cookie")).toBeNull();
+    });
+  });
+
+  describe("POST /auth/logout", () => {
+    it("clears the session cookie on a same-origin request", async () => {
+      const app = createTestApp();
+      const req = new Request("http://localhost/auth/logout", {
+        method: "POST",
+        headers: { Origin: "http://localhost" },
+      });
+      const res = await app.request(req, ENV);
       const setCookieHeader = res.headers.get("Set-Cookie");
       expect(setCookieHeader).not.toBeNull();
       // Cookie should be cleared (Max-Age=0 or expires in the past)
@@ -136,11 +151,29 @@ describe("auth/routes", () => {
       expect(setCookieHeader).toMatch(/Max-Age=0/);
     });
 
-    it("redirects to /", async () => {
+    it("redirects to / on a same-origin request", async () => {
       const app = createTestApp();
-      const res = await app.request("/auth/logout", {}, ENV);
+      const req = new Request("http://localhost/auth/logout", {
+        method: "POST",
+        headers: { Origin: "http://localhost" },
+      });
+      const res = await app.request(req, ENV);
       expect(res.status).toBe(302);
       expect(res.headers.get("Location")).toBe("/");
+    });
+
+    it("rejects a cross-site form POST and does not clear the session", async () => {
+      const app = createTestApp();
+      const req = new Request("http://localhost/auth/logout", {
+        method: "POST",
+        headers: {
+          Origin: "https://evil.example",
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+      });
+      const res = await app.request(req, ENV);
+      expect(res.status).toBe(403);
+      expect(res.headers.get("Set-Cookie")).toBeNull();
     });
   });
 });

--- a/test/dashboard-routes.test.ts
+++ b/test/dashboard-routes.test.ts
@@ -1510,7 +1510,7 @@ describe("dashboard/routes", () => {
       expect(body).toContain("https://hooks.example.com/notify");
     });
 
-    it("redirects to logout when user record is missing", async () => {
+    it("clears the session and redirects home when user record is missing", async () => {
       const db = createMockDB({ users: [] });
       const app = createTestApp(db);
       const cookie = await makeSessionCookie("ghost_user", "ghost@example.com");
@@ -1518,7 +1518,8 @@ describe("dashboard/routes", () => {
         headers: { Cookie: cookie },
       });
       expect(res.status).toBe(302);
-      expect(res.headers.get("Location")).toBe("/auth/logout");
+      expect(res.headers.get("Location")).toBe("/");
+      expect(res.headers.get("Set-Cookie")).toMatch(/session=.*Max-Age=0/);
     });
   });
 

--- a/test/dashboard-views.test.ts
+++ b/test/dashboard-views.test.ts
@@ -90,6 +90,15 @@ describe("renderDashboardPage", () => {
     expect(html).toContain("Logout");
   });
 
+  it("submits logout as a POST form, not a GET link", () => {
+    const html = renderDashboardPage({
+      email: "test@example.com",
+      domains: [],
+    });
+    expect(html).toContain('<form method="POST" action="/auth/logout"');
+    expect(html).not.toContain('<a href="/auth/logout">');
+  });
+
   it("links to domain detail pages", () => {
     const html = renderDashboardPage({
       email: "user@example.com",


### PR DESCRIPTION
## Summary

- Logout was a state-changing `GET` with no CSRF/Origin protection, so a cross-site request (e.g. an `<img>` tag) could force-log-out an authenticated user. `GET /auth/logout` now returns 405 without touching the session cookie; `POST /auth/logout` is the real endpoint, guarded by `hono/csrf`'s Origin/`Sec-Fetch-Site` check (the same middleware already mounted on `/dashboard/*`).
- The in-app logout control (`src/views/dashboard.ts`) now submits a `POST` form instead of linking to the GET endpoint, styled to look identical to the old link.
- Several internal routes (`dashboard/routes.ts` ×4, `billing/routes.ts` ×1) redirected to `GET /auth/logout` to force-clear a stale session (e.g. a valid cookie for an already-deleted user). Since browsers follow redirects with GET, those would have hit the new 405 instead of logging the user out. Extracted a `clearSessionAndRedirect()` helper in `src/auth/session.ts` and switched those call sites to invoke it directly.

## Owner / zone steps

None.

## Security notes

This *is* the security fix (issue #621) — hardens a logout-CSRF weakness (denial-of-session only, not account compromise). `SameSite=Lax` on the session cookie is unchanged. `src/index.ts` is touched only to mount the existing `csrf()` middleware on `/auth/logout` (same pattern as `/dashboard/*`); no other behavior in that file changes.

**Note for reviewer:** this diff touches `src/index.ts`, which is CODEOWNERS-gated per `.github/CODEOWNERS` — opening for human review rather than enabling auto-merge.

## Testing

- `npm test` — 1474 passing, 1 failing (pre-existing, unrelated: `test/integration/mta-sts-runtime.test.ts` does a live network fetch and fails identically on a clean `main` checkout in this sandbox — no network egress to dmarc.mx).
- `npm run typecheck` — clean.
- `npm run lint` — clean (186 files, no issues).
- New/updated tests: `GET /auth/logout` → 405, no cookie mutation; `POST /auth/logout` same-origin → clears cookie + redirects to `/`; `POST /auth/logout` cross-site (mismatched Origin + form content-type) → 403, no cookie mutation; dashboard view renders a POST form instead of a GET link; the four internal force-logout call sites now redirect to `/` with the session cookie cleared instead of round-tripping through `/auth/logout`.

## Choices made

- Used the existing `hono/csrf` middleware (Origin + `Sec-Fetch-Site` check) rather than a bespoke token, mirroring the pattern already used on `/dashboard/*` — the issue's pointers suggested this explicitly.
- `GET /auth/logout` returns a plain 405 rather than a redirect, since acceptance criteria explicitly listed "405/redirect" as acceptable and 405 is the more accurate status for a wrong-method request.

## Deferred

None — the issue's three acceptance items are all shipped; "broader CSRF review of other routes" was explicitly out of scope.

## Refs

Closes #621


---
_Generated by [Claude Code](https://claude.ai/code/session_018YH3qaWKDvTzopGthJzrFR)_