### PR TITLE
security: charge bulk-scan rate limit proportional to in-band scan count

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -428,15 +428,27 @@ type RateLimitBlockedResponder = (
   headers: Record<string, string>,
 ) => Response | Promise<Response>;
 
-export function rateLimitMiddleware(onBlocked: RateLimitBlockedResponder) {
+export function rateLimitMiddleware(
+  onBlocked: RateLimitBlockedResponder,
+  // Optional per-route weight resolver (issue #619). Omitted → every request
+  // costs 1 token, the historical behavior. Bulk-scan uses this to charge
+  // proportional to its in-band scan count instead of counting as one request.
+  weightFn?: (c: Context) => Promise<number>,
+) {
   return async (c: Context, next: () => Promise<void>) => {
     const { identity, config } = await resolveRateLimitScope(c);
+    const weight = weightFn ? await weightFn(c) : 1;
     // The Durable Object RPC is awaited end-to-end, so the counter is durably
     // updated before the decision is used — no deferred write to drain.
     // `c.env` is always present at runtime; the optional chain keeps the
     // limiter working in lightweight unit tests that call `app.request(path)`
     // without an env (falls back to the in-memory limiter).
-    const result = await checkRateLimit(identity, config, c.env?.RATE_LIMITER);
+    const result = await checkRateLimit(
+      identity,
+      config,
+      c.env?.RATE_LIMITER,
+      weight,
+    );
 
     const headers = rateLimitHeaders(result);
 
@@ -457,6 +469,34 @@ export function rateLimitMiddleware(onBlocked: RateLimitBlockedResponder) {
 function blockedMessage(result: RateLimitResult): string {
   const waitSec = Math.max(1, result.resetAt - Math.floor(Date.now() / 1000));
   return `Rate limit exceeded. Try again in ${waitSec} seconds.`;
+}
+
+// Rate-limit weight for /api/bulk-scan (issue #619): the number of distinct
+// valid domains in the request body, capped at BULK_IN_BAND_CAP — mirrors the
+// normalize+dedupe step `processBulkScan` runs before dispatching in-band
+// scans, without its DB-backed watchlist-cap lookup, so the charge is known
+// before the expensive work runs. `c.req.json()` is cached by Hono, so the
+// handler's own body parse below reuses this same parse rather than
+// re-reading the request stream. Malformed/absent bodies fall back to the
+// default weight of 1 — the handler's own validation still rejects them.
+async function bulkScanWeight(c: Context): Promise<number> {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return 1;
+  }
+  const rawDomains = (body as { domains?: unknown })?.domains;
+  if (!Array.isArray(rawDomains)) return 1;
+  const distinct = new Set<string>();
+  for (const d of rawDomains) {
+    if (typeof d !== "string") continue;
+    const trimmed = d.trim();
+    if (!trimmed) continue;
+    const normalized = normalizeDomain(trimmed);
+    if (normalized) distinct.add(normalized);
+  }
+  return Math.min(Math.max(distinct.size, 1), BULK_IN_BAND_CAP);
 }
 
 // Rate limit scan endpoints (not the landing page)
@@ -516,14 +556,16 @@ app.use(
 );
 
 // Bulk scan also runs N analyzers in-band per request — same rate-limit
-// posture as /api/check (Pro bearer → user bucket; everyone else → IP).
-// TODO(phase-4-pr3-followup): once per-plan limits expose a "weight" knob,
-// charge bulk requests proportionally to the in-band scan count instead of
-// counting as a single request.
+// posture as /api/check (Pro bearer → user bucket; everyone else → IP), but
+// charged proportionally to the in-band scan count rather than 1 token per
+// request (issue #619), since a 30-domain request fans out ~30x the outbound
+// DNS/fetch of a single scan.
 app.use(
   "/api/bulk-scan",
-  rateLimitMiddleware((c, result, headers) =>
-    c.json({ error: blockedMessage(result) }, { status: 429, headers }),
+  rateLimitMiddleware(
+    (c, result, headers) =>
+      c.json({ error: blockedMessage(result) }, { status: 429, headers }),
+    bulkScanWeight,
   ),
 );
 

--- a/src/rate-limit-do.ts
+++ b/src/rate-limit-do.ts
@@ -42,7 +42,10 @@ export class RateLimiterDO extends DurableObject {
   // returns the resulting decision. `limit`/`windowSec` are passed per call so
   // the same DO class serves both tiers (free 10/60, pro 60/3600) — the bucket
   // is keyed entirely by the DO instance (identity), not the window size.
-  increment(limit: number, windowSec: number): RateLimitResult {
+  // `weight` lets a single request charge more than one token (e.g. bulk-scan
+  // charging proportional to its in-band scan count, issue #619); defaults to
+  // 1 so every other caller is unaffected.
+  increment(limit: number, windowSec: number, weight = 1): RateLimitResult {
     const nowSec = Math.floor(Date.now() / 1000);
     const existing = this.ctx.storage.sql
       .exec<{ count: number; reset_at: number }>(
@@ -53,11 +56,11 @@ export class RateLimiterDO extends DurableObject {
     let count: number;
     let resetAt: number;
     if (existing && existing.reset_at > nowSec) {
-      count = existing.count + 1;
+      count = existing.count + weight;
       resetAt = existing.reset_at;
     } else {
       // Fresh window: no row yet, or the previous window has elapsed.
-      count = 1;
+      count = weight;
       resetAt = nowSec + windowSec;
     }
 

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -40,6 +40,7 @@ export async function checkRateLimit(
   identity: string,
   config: RateLimitConfig,
   namespace?: DurableObjectNamespace<RateLimiterDO>,
+  weight = 1,
 ): Promise<RateLimitResult> {
   // Durable Object is the only atomic primitive on Workers: its single-threaded
   // RPC serializes the read-modify-write so a concurrent burst under one
@@ -48,7 +49,7 @@ export async function checkRateLimit(
   // ceiling.
   if (namespace) {
     try {
-      return await checkRateLimitDO(identity, config, namespace);
+      return await checkRateLimitDO(identity, config, namespace, weight);
     } catch {
       // DO unreachable (transient error, or no binding at runtime). Fall back
       // to the in-memory limiter so requests stay bounded rather than failing
@@ -58,24 +59,26 @@ export async function checkRateLimit(
   // Graceful fallback for environments without the DO binding (self-host
   // deploys that strip it, and the Node test pool). Atomic within a single
   // isolate; not shared across isolates/colos.
-  return checkRateLimitMemory(identity, config);
+  return checkRateLimitMemory(identity, config, weight);
 }
 
 async function checkRateLimitDO(
   identity: string,
   config: RateLimitConfig,
   namespace: DurableObjectNamespace<RateLimiterDO>,
+  weight: number,
 ): Promise<RateLimitResult> {
   // One DO instance per identity bucket (`ip:<x>` / `user:<id>`). `getByName`
   // maps the identity string to a stable instance; the RPC returns the
   // post-increment decision for the current window.
   const stub = namespace.getByName(identity);
-  return stub.increment(config.limit, config.windowSec);
+  return stub.increment(config.limit, config.windowSec, weight);
 }
 
 function checkRateLimitMemory(
   identity: string,
   config: RateLimitConfig,
+  weight = 1,
 ): RateLimitResult {
   const now = Date.now();
   const nowSec = Math.floor(now / 1000);
@@ -92,10 +95,10 @@ function checkRateLimitMemory(
   let count: number;
   let resetAt: number;
   if (entry && entry.expires > now) {
-    count = entry.count + 1;
+    count = entry.count + weight;
     resetAt = entry.resetAt;
   } else {
-    count = 1;
+    count = weight;
     resetAt = nowSec + config.windowSec;
   }
 

--- a/test/bulk-scan-route.test.ts
+++ b/test/bulk-scan-route.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { _memoryStore, _resetCallCount } from "../src/rate-limit.js";
 
 // resolveBearer is stubbed before importing app to keep the route's bearer
 // signal independent of api-key cryptography in this test file.
@@ -195,6 +196,8 @@ beforeEach(() => {
   overrideStore = new Map();
   nextId = 1;
   bearerStub = null;
+  _memoryStore.clear();
+  _resetCallCount();
 });
 
 afterEach(() => {
@@ -313,5 +316,51 @@ describe("POST /api/bulk-scan", () => {
     expect(body.results).toEqual([
       { domain: "new26.example", status: "scanned", grade: "B" },
     ]);
+  });
+
+  describe("rate-limit weight (issue #619)", () => {
+    it("charges one token per distinct submitted domain, not one per request", async () => {
+      bearerStub = { userId: "user_pro", keyId: "k1" };
+      subStore.push({ user_id: "user_pro", status: "active" });
+
+      const first = await fetchBulk({
+        domains: ["a1.example", "a2.example", "a3.example"],
+      });
+      expect(first.status).toBe(200);
+      expect(first.headers.get("X-RateLimit-Remaining")).toBe("57"); // 60 - 3
+
+      const second = await fetchBulk({ domains: ["b1.example"] });
+      expect(second.headers.get("X-RateLimit-Remaining")).toBe("56"); // 60 - 3 - 1
+    });
+
+    it("caps the charged weight at BULK_IN_BAND_CAP for large requests", async () => {
+      bearerStub = { userId: "user_pro", keyId: "k1" };
+      subStore.push({ user_id: "user_pro", status: "active" });
+
+      const many = Array.from({ length: 35 }, (_, i) => `w${i}.example`);
+      const res = await fetchBulk({ domains: many });
+      expect(res.status).toBe(200);
+      expect(res.headers.get("X-RateLimit-Remaining")).toBe("30"); // 60 - 30
+    });
+
+    it("deduplicates domains before charging weight", async () => {
+      bearerStub = { userId: "user_pro", keyId: "k1" };
+      subStore.push({ user_id: "user_pro", status: "active" });
+
+      const res = await fetchBulk({
+        domains: ["dupe.example", "dupe.example", "dupe.example"],
+      });
+      expect(res.status).toBe(200);
+      expect(res.headers.get("X-RateLimit-Remaining")).toBe("59"); // 60 - 1
+    });
+
+    it("charges the default 1-token weight when the body is malformed", async () => {
+      bearerStub = { userId: "user_pro", keyId: "k1" };
+      subStore.push({ user_id: "user_pro", status: "active" });
+
+      const res = await fetchBulk("not json", {});
+      expect(res.status).toBe(400);
+      expect(res.headers.get("X-RateLimit-Remaining")).toBe("59"); // 60 - 1
+    });
   });
 });

--- a/test/integration/rate-limit-do.test.ts
+++ b/test/integration/rate-limit-do.test.ts
@@ -124,6 +124,38 @@ describe("RateLimiterDO (runs inside real workerd runtime)", () => {
     expect(otherIp.remaining).toBe(FREE.limit - 1);
   });
 
+  it("increment() accepts a weight, charging more than one token per call (issue #619)", async () => {
+    const stub = env.RATE_LIMITER.getByName("ip:weighted");
+    const first = await stub.increment(PRO.limit, PRO.windowSec, 30);
+    expect(first.count).toBe(30);
+    expect(first.allowed).toBe(true);
+    expect(first.remaining).toBe(PRO.limit - 30);
+
+    const second = await stub.increment(PRO.limit, PRO.windowSec, 30);
+    expect(second.count).toBe(60);
+    expect(second.allowed).toBe(true);
+    expect(second.remaining).toBe(0);
+
+    // A third weighted request pushes the count past the limit in one shot —
+    // it's correctly blocked, and the count still reflects the full charge
+    // rather than clamping, consistent with the unweighted (default) behavior.
+    const third = await stub.increment(PRO.limit, PRO.windowSec, 30);
+    expect(third.allowed).toBe(false);
+    expect(third.count).toBe(90);
+  });
+
+  it("checkRateLimit() routed through the DO threads the weight through", async () => {
+    const result = await checkRateLimit(
+      "ip:wired-weighted",
+      FREE,
+      env.RATE_LIMITER,
+      3,
+    );
+    expect(result.count).toBe(3);
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(FREE.limit - 3);
+  });
+
   it("rolls the window: an expired bucket resets to count 1 on the next increment", async () => {
     // Time travel is not available inside workerd, so seed an already-expired
     // window directly via runInDurableObject and assert the reset branch.

--- a/test/rate-limit.test.ts
+++ b/test/rate-limit.test.ts
@@ -202,6 +202,38 @@ describe("rate-limit", () => {
     });
   });
 
+  describe("weighted charging (issue #619)", () => {
+    it("charges the given weight instead of 1 per call", async () => {
+      const result = await checkRateLimit("ip:1.2.3.4", FREE, undefined, 5);
+      expect(result.allowed).toBe(true);
+      expect(result.remaining).toBe(FREE.limit - 5);
+      expect(result.count).toBe(5);
+    });
+
+    it("accumulates weighted charges within the same window", async () => {
+      await checkRateLimit("ip:1.2.3.4", FREE, undefined, 4);
+      const second = await checkRateLimit("ip:1.2.3.4", FREE, undefined, 4);
+      expect(second.count).toBe(8);
+      expect(second.remaining).toBe(FREE.limit - 8);
+    });
+
+    it("blocks once a single weighted request exceeds the limit", async () => {
+      const result = await checkRateLimit(
+        "ip:1.2.3.4",
+        FREE,
+        undefined,
+        FREE.limit + 1,
+      );
+      expect(result.allowed).toBe(false);
+      expect(result.remaining).toBe(0);
+    });
+
+    it("defaults to weight 1 when omitted, unchanged from prior behavior", async () => {
+      const result = await checkRateLimit("ip:1.2.3.4", FREE);
+      expect(result.count).toBe(1);
+    });
+  });
+
   describe("rateLimitHeaders", () => {
     it("returns all four headers including X-RateLimit-Reset", async () => {
       const result = await checkRateLimit("ip:1.2.3.4", FREE);


### PR DESCRIPTION
## Summary

- `POST /api/bulk-scan` consumed a single rate-limit token per request while running up to `BULK_IN_BAND_CAP` (30) full in-band scans, letting a 30-domain bulk request draw the same budget as a single-domain scan.
- Threads an optional `weight` parameter through `checkRateLimit` → `checkRateLimitDO`/`checkRateLimitMemory` and `RateLimiterDO.increment()` (defaults to 1, so every other route — `/check`, `/check/score`, `/check/email`, `/api/check`, `/api/domain/*` — is unaffected).
- `/api/bulk-scan`'s middleware now charges weight = the number of distinct, valid (normalized), deduped domains in the request body, capped at `BULK_IN_BAND_CAP` — computed from the same cached `c.req.json()` parse the handler already does (no extra body read), so the charge is known before the expensive scan work runs.

## Owner / zone steps

None.

## Security notes

This is a rate-limit-accounting hardening fix (abuse/DoS-adjacent, low severity per the linked issue). No new attack surface: the weight function only reads and normalizes the same `domains` array the handler already validates, reuses the existing atomic Durable-Object counter (`RATE_LIMITER`) per `CLAUDE.md`'s DoS-backstop conventions, and doesn't change the public request/response contract.

## Testing

- `npm test` — 1481 passing (1 pre-existing failure in `test/integration/mta-sts-runtime.test.ts` doing a live network fetch to the real dmarc.mx MTA-STS policy; reproduces identically on `main` before this change — unrelated to this diff, environment network-sandbox artifact).
- `npm run typecheck` — clean.
- `npm run lint` — clean (186 files, no issues).
- New tests: `test/rate-limit.test.ts` (weighted charging via `checkRateLimit`, accumulation, over-limit blocking, default-weight-1 unchanged), `test/integration/rate-limit-do.test.ts` (real Durable Object `increment()` with weight, and `checkRateLimit` routed through the DO), `test/bulk-scan-route.test.ts` (route-level: a K-domain bulk request charges K tokens reflected in `X-RateLimit-Remaining`, weight caps at `BULK_IN_BAND_CAP`, dedup before charging, malformed body falls back to weight 1).

## Choices made

- Weight is computed from the submitted domains after normalize+dedupe (mirroring `processBulkScan`'s own normalize/dedupe step) but **without** its DB-backed watchlist-cap lookup — so an unusual request that trips the per-plan watchlist cap may be charged slightly more than the domains actually scanned in-band. This keeps the charge computable before any DB round-trip (so the rate gate still fires before the expensive work), at the cost of being an upper-bound approximation rather than an exact post-hoc count. Given the issue's own framing ("weight = scan count, capped at `BULK_IN_BAND_CAP`") and its low-severity classification, this trade-off seemed like the right default; happy to adjust if an exact count is preferred.

## Deferred

None — this issue's acceptance criteria are fully addressed in this PR.

## Refs

Closes #619

---

**Note on merge:** this diff touches `src/index.ts` and `src/rate-limit.ts`, both gated in `.github/CODEOWNERS` (rate limiting / input-validation paths). Per repo policy this PR is opened for human code-owner review rather than auto-merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01S9cL5VjAYvbpnHtdau9uZS)_