### PR TITLE
fix: enforce watchlist domain cap atomically

### DIFF
--- a/src/api/bulk-scan.ts
+++ b/src/api/bulk-scan.ts
@@ -1,7 +1,6 @@
 import {
   countDomainsByUser,
-  createDomain,
-  createDomains,
+  createDomainUnderCap,
   findExistingDomainsForUser,
   getDomainByUserAndName,
   queueDomainsForRescan,
@@ -167,13 +166,21 @@ export async function processBulkScan(
   for (let i = 0; i < inBand.length; i += batchSize) {
     const batch = inBand.slice(i, i + batchSize);
     const outcomes = await Promise.allSettled(
-      batch.map((domain) => scanOne(input.db, input.userId, domain, scanFn)),
+      batch.map((domain) =>
+        scanOne(input.db, input.userId, domain, cap, scanFn),
+      ),
     );
     for (let j = 0; j < outcomes.length; j++) {
       const outcome = outcomes[j];
       const domain = batch[j];
       if (outcome.status === "fulfilled") {
         inBandResults.push(outcome.value);
+      } else if (outcome.reason instanceof WatchlistCapExceededError) {
+        inBandResults.push({
+          domain,
+          status: "error",
+          error: "Watchlist limit reached",
+        });
       } else {
         inBandResults.push({
           domain,
@@ -203,41 +210,34 @@ export async function processBulkScan(
       existingSet.has(domain),
     );
 
-    try {
-      if (queuedToInsert.length > 0) {
-        await createDomains(
+    // Inserted one at a time (not a single multi-row INSERT) so each row's
+    // cap check is atomic with its own insert (issue #617) — a concurrent
+    // add/bulk request for the same user can't push the total past `cap`.
+    for (const domain of queuedToInsert) {
+      try {
+        const inserted = await createDomainUnderCap(
           input.db,
-          queuedToInsert.map((domain) => ({
-            userId: input.userId,
-            domain,
-            isFree: false,
-          })),
+          { userId: input.userId, domain, isFree: false },
+          cap,
         );
+        queuedResults.push(
+          inserted
+            ? { domain, status: "queued" }
+            : { domain, status: "error", error: "Watchlist limit reached" },
+        );
+      } catch {
+        queuedResults.push({
+          domain,
+          status: "error",
+          error: "Could not queue domain",
+        });
       }
-      if (queuedExisting.length > 0) {
-        await queueDomainsForRescan(input.db, input.userId, queuedExisting);
-      }
+    }
 
-      for (const domain of uniqueQueued) {
+    if (queuedExisting.length > 0) {
+      await queueDomainsForRescan(input.db, input.userId, queuedExisting);
+      for (const domain of queuedExisting) {
         queuedResults.push({ domain, status: "queued" });
-      }
-    } catch {
-      // Fallback: If the bulk insert fails (e.g. D1 error), try inserting them one by one.
-      for (const domain of uniqueQueued) {
-        try {
-          // ensureDomainRow is idempotent and handles conflicts
-          await ensureDomainRow(input.db, input.userId, domain);
-          if (existingSet.has(domain)) {
-            await queueDomainsForRescan(input.db, input.userId, [domain]);
-          }
-          queuedResults.push({ domain, status: "queued" });
-        } catch {
-          queuedResults.push({
-            domain,
-            status: "error",
-            error: "Could not queue domain",
-          });
-        }
       }
     }
   }
@@ -258,13 +258,20 @@ export async function processBulkScan(
   return { accepted: acceptedCount, rejected: rejectedCount, results };
 }
 
+// Thrown by ensureDomainRow when the atomic cap-guarded insert reports the
+// user's watchlist is already full — distinguished from a generic scan/DB
+// failure so the caller can surface "Watchlist limit reached" instead of
+// "Scan failed" (issue #617).
+class WatchlistCapExceededError extends Error {}
+
 async function scanOne(
   db: D1Database,
   userId: string,
   domain: string,
+  cap: number,
   scanFn: (domain: string) => Promise<ScanLike>,
 ): Promise<BulkResultEntry> {
-  const owned = await ensureDomainRow(db, userId, domain);
+  const owned = await ensureDomainRow(db, userId, domain, cap);
   const result = await scanFn(domain);
   await recordScan(db, {
     domainId: owned.id,
@@ -275,18 +282,27 @@ async function scanOne(
   return { domain, status: "scanned", grade: result.grade };
 }
 
-// Idempotent watchlist insert: returns the existing row if present, otherwise
-// creates one (Pro plan, weekly cadence) and re-fetches to get the row id. We
-// look up after insert rather than relying on D1's last_row_id because the
-// helper is async and other concurrent inserts could race the cursor.
+// Idempotent, cap-guarded watchlist insert: returns the existing row if
+// present, otherwise atomically inserts one (Pro plan, weekly cadence) only if
+// the user is still under `cap`, and re-fetches to get the row id. We look up
+// after insert rather than relying on D1's last_row_id because the helper is
+// async and other concurrent inserts could race the cursor.
 async function ensureDomainRow(
   db: D1Database,
   userId: string,
   domain: string,
+  cap: number,
 ): Promise<{ id: number }> {
   const existing = await getDomainByUserAndName(db, userId, domain);
   if (existing) return { id: existing.id };
-  await createDomain(db, { userId, domain, isFree: false });
+  const inserted = await createDomainUnderCap(
+    db,
+    { userId, domain, isFree: false },
+    cap,
+  );
+  if (!inserted) {
+    throw new WatchlistCapExceededError();
+  }
   const created = await getDomainByUserAndName(db, userId, domain);
   if (!created) {
     throw new Error("Domain row missing after insert");

--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -31,7 +31,7 @@ import {
 } from "../db/api-keys.js";
 import {
   countDomainsByUser,
-  createDomain,
+  createDomainUnderCap,
   type DomainSortColumn,
   type DomainSortDirection,
   deleteDomain,
@@ -816,7 +816,16 @@ dashboardRoutes.post("/domain/add", async (c) => {
     );
   }
 
-  if (currentCount >= cap) {
+  // Cap enforcement happens inside createDomainUnderCap's single guarded SQL
+  // statement, not via this pre-check — a concurrent add for the same user
+  // can't race past `cap` (issue #617). `currentCount` above is only used to
+  // word the error message below.
+  const inserted = await createDomainUnderCap(
+    db,
+    { userId: session.sub, domain: normalized, isFree: false },
+    cap,
+  );
+  if (!inserted) {
     const overCap = currentCount > cap;
     const error =
       override != null
@@ -834,11 +843,6 @@ dashboardRoutes.post("/domain/add", async (c) => {
     );
   }
 
-  await createDomain(db, {
-    userId: session.sub,
-    domain: normalized,
-    isFree: false,
-  });
   return c.redirect(`/dashboard/domain/${encodeURIComponent(normalized)}`, 303);
 });
 

--- a/src/db/domains.ts
+++ b/src/db/domains.ts
@@ -24,23 +24,33 @@ export async function createDomain(
     .run();
 }
 
-export async function createDomains(
+// Atomic, cap-guarded insert (issue #617). The count check and the insert
+// happen inside a single SQL statement rather than as separate JS-level
+// read-then-write calls, so D1's per-database write serialization — not
+// application code — is what prevents a concurrent burst for one user from
+// inserting past `cap`. Returns whether the row was actually inserted.
+export async function createDomainUnderCap(
   db: D1Database,
-  inputs: { userId: string; domain: string; isFree: boolean }[],
-): Promise<void> {
-  if (inputs.length === 0) return;
-  const values = inputs.map(() => "(?, ?, ?, ?)").join(", ");
-  const binds: unknown[] = [];
-  for (const input of inputs) {
-    const frequency = input.isFree ? "monthly" : "weekly";
-    binds.push(input.userId, input.domain, input.isFree ? 1 : 0, frequency);
-  }
-  await db
+  input: { userId: string; domain: string; isFree: boolean },
+  cap: number,
+): Promise<boolean> {
+  const frequency = input.isFree ? "monthly" : "weekly";
+  const result = await db
     .prepare(
-      `INSERT INTO domains (user_id, domain, is_free, scan_frequency) VALUES ${values} ON CONFLICT DO NOTHING`,
+      `INSERT INTO domains (user_id, domain, is_free, scan_frequency)
+       SELECT ?, ?, ?, ?
+       WHERE (SELECT COUNT(*) FROM domains WHERE user_id = ?) < ?`,
     )
-    .bind(...binds)
+    .bind(
+      input.userId,
+      input.domain,
+      input.isFree ? 1 : 0,
+      frequency,
+      input.userId,
+      cap,
+    )
     .run();
+  return (result.meta?.changes ?? 0) > 0;
 }
 
 export async function getDomainsByUser(

--- a/test/bulk-scan-route.test.ts
+++ b/test/bulk-scan-route.test.ts
@@ -88,6 +88,34 @@ function makeDb(): D1Database {
 
   const applyWrite = async (sql: string, params: unknown[]) => {
     if (/^INSERT INTO domains/i.test(sql)) {
+      // Guarded insert (createDomainUnderCap, issue #617): cap check and
+      // insert happen together, mirroring D1's single-statement atomicity.
+      if (/WHERE \(SELECT COUNT/i.test(sql)) {
+        const [userId, domain, isFree, frequency, capUserId, cap] = params as [
+          string,
+          string,
+          number,
+          string,
+          string,
+          number,
+        ];
+        const currentCount = domainStore.filter(
+          (d) => d.user_id === capUserId,
+        ).length;
+        if (currentCount >= cap) {
+          return { success: true as const, meta: { changes: 0 } };
+        }
+        domainStore.push({
+          id: nextId++,
+          user_id: userId,
+          domain,
+          is_free: isFree,
+          scan_frequency: frequency,
+          last_scanned_at: null,
+          last_grade: null,
+        });
+        return { success: true as const, meta: { changes: 1 } };
+      }
       const [userId, domain, isFree, frequency] = params as [
         string,
         string,

--- a/test/bulk-scan.test.ts
+++ b/test/bulk-scan.test.ts
@@ -41,32 +41,24 @@ function makeDb(): D1Database {
 
   const applyWrite = async (sql: string, params: unknown[]) => {
     if (/^INSERT INTO domains/i.test(sql)) {
-      // Check if it's the multiple row insert
-      if (sql.includes("VALUES (?, ?, ?, ?),")) {
-        // It's a batched insert
-        const CHUNK_SIZE = 4;
-        for (let i = 0; i < params.length; i += CHUNK_SIZE) {
-          const userId = params[i] as string;
-          const domain = params[i + 1] as string;
-          const isFree = params[i + 2] as number;
-          const frequency = params[i + 3] as string;
-          domainStore.push({
-            id: nextId++,
-            user_id: userId,
-            domain,
-            is_free: isFree,
-            scan_frequency: frequency,
-            last_scanned_at: null,
-            last_grade: null,
-          });
-        }
-      } else {
-        const [userId, domain, isFree, frequency] = params as [
+      // Guarded insert (createDomainUnderCap, issue #617): cap check and
+      // insert happen together, mirroring D1's single-statement atomicity —
+      // re-evaluate the count against the store synchronously here too.
+      if (/WHERE \(SELECT COUNT/i.test(sql)) {
+        const [userId, domain, isFree, frequency, capUserId, cap] = params as [
           string,
           string,
           number,
           string,
+          string,
+          number,
         ];
+        const currentCount = domainStore.filter(
+          (d) => d.user_id === capUserId,
+        ).length;
+        if (currentCount >= cap) {
+          return { success: true as const, meta: { changes: 0 } };
+        }
         domainStore.push({
           id: nextId++,
           user_id: userId,
@@ -76,7 +68,23 @@ function makeDb(): D1Database {
           last_scanned_at: null,
           last_grade: null,
         });
+        return { success: true as const, meta: { changes: 1 } };
       }
+      const [userId, domain, isFree, frequency] = params as [
+        string,
+        string,
+        number,
+        string,
+      ];
+      domainStore.push({
+        id: nextId++,
+        user_id: userId,
+        domain,
+        is_free: isFree,
+        scan_frequency: frequency,
+        last_scanned_at: null,
+        last_grade: null,
+      });
     } else if (/^INSERT INTO scan_history/i.test(sql)) {
       const [domainId, grade, , , scannedAt] = params as [
         number,

--- a/test/dashboard-routes.test.ts
+++ b/test/dashboard-routes.test.ts
@@ -353,6 +353,32 @@ function createMockDB(data: {
       // then re-fetch" pattern (avoids relying on last_row_id) finds the new
       // row when it does the SELECT lookup right after.
       if (/^INSERT INTO domains/i.test(sql)) {
+        // Guarded insert (createDomainUnderCap, issue #617): cap check and
+        // insert happen together, mirroring D1's single-statement atomicity.
+        if (/WHERE \(SELECT COUNT/i.test(sql)) {
+          const [userId, domain, isFree, frequency, capUserId, cap] =
+            bindings as [string, string, number, string, string, number];
+          const currentCount = domains.filter(
+            (d) => d.user_id === capUserId,
+          ).length;
+          if (currentCount >= cap) {
+            return { success: true, meta: { changes: 0 } };
+          }
+          domains.push({
+            id:
+              domains.length > 0
+                ? Math.max(...domains.map((d) => d.id)) + 1
+                : 1,
+            user_id: userId,
+            domain,
+            is_free: isFree,
+            scan_frequency: frequency,
+            last_scanned_at: null,
+            last_grade: null,
+            created_at: 1700000000,
+          });
+          return { success: true, meta: { changes: 1 } };
+        }
         const [userId, domain, isFree, frequency] = bindings as [
           string,
           string,
@@ -1999,11 +2025,15 @@ describe("dashboard/routes", () => {
         w.sql.includes("INSERT INTO domains"),
       );
       expect(inserted).toBeDefined();
+      // Guarded insert (issue #617): the trailing two bindings are the cap
+      // check's own [user_id, cap] pair, not row data.
       expect(inserted?.bindings).toEqual([
         "user_1",
         "example.com",
         0, // isFree=false → 0
         "weekly",
+        "user_1",
+        3, // FREE_WATCHLIST_CAP
       ]);
     });
 
@@ -2095,10 +2125,48 @@ describe("dashboard/routes", () => {
       const html = await res.text();
       expect(html).toMatch(/Free plan limit reached/);
       expect(html).toMatch(/Upgrade to Pro/);
-      const inserted = writes.find((w) =>
-        w.sql.includes("INSERT INTO domains"),
+      // The atomic guarded insert (issue #617) still issues an INSERT
+      // statement — the cap check lives inside it — but it must not add a
+      // row: the SQL itself guards the count, not a JS-level pre-check.
+      expect(seedDomains).toHaveLength(3);
+    });
+
+    it("never lets a concurrent burst of adds push one user past the cap (issue #617)", async () => {
+      const seedDomains: Array<{
+        id: number;
+        user_id: string;
+        domain: string;
+        is_free: number;
+        scan_frequency: string;
+        last_scanned_at: number | null;
+        last_grade: string | null;
+        created_at: number;
+      }> = [];
+      const db = createMockDB({ domains: seedDomains });
+      const app = createTestApp(db);
+      const cookie = await makeSessionCookie("user_1", "alice@example.com");
+
+      const responses = await Promise.all(
+        Array.from({ length: 10 }, (_, i) => {
+          const body = new URLSearchParams({ domain: `burst${i}.example` });
+          return app.request("/dashboard/domain/add", {
+            method: "POST",
+            headers: {
+              Cookie: cookie,
+              "Content-Type": "application/x-www-form-urlencoded",
+            },
+            body: body.toString(),
+          });
+        }),
       );
-      expect(inserted).toBeUndefined();
+
+      // Free plan cap is 3 — exactly 3 requests should succeed (303) and the
+      // rest rejected (400), regardless of the 10-way concurrent burst.
+      const statuses = responses.map((r) => r.status).sort();
+      expect(statuses).toEqual([
+        303, 303, 303, 400, 400, 400, 400, 400, 400, 400,
+      ]);
+      expect(seedDomains).toHaveLength(3);
     });
 
     it("rejects net-new domain with 400 when a Pro user is at the cap", async () => {
@@ -2134,10 +2202,8 @@ describe("dashboard/routes", () => {
       const html = await res.text();
       expect(html).toMatch(/Pro plan limit of 25 domains/);
       expect(html).toContain("support@dmarc.mx");
-      const inserted = writes.find((w) =>
-        w.sql.includes("INSERT INTO domains"),
-      );
-      expect(inserted).toBeUndefined();
+      // Guarded insert (issue #617) still runs but must not add a row.
+      expect(seedDomains).toHaveLength(25);
     });
 
     it("still redirects to the existing domain detail page for a duplicate even when at cap", async () => {
@@ -2239,10 +2305,8 @@ describe("dashboard/routes", () => {
       expect(html).toMatch(/Pro plan includes 25 domains/);
       expect(html).toMatch(/already have 30/);
       expect(html).toMatch(/grandfathered/);
-      const inserted = writes.find((w) =>
-        w.sql.includes("INSERT INTO domains"),
-      );
-      expect(inserted).toBeUndefined();
+      // Guarded insert (issue #617) still runs but must not add a row.
+      expect(seedDomains).toHaveLength(30);
     });
 
     it("renders the add-domain form with usage hint for a free user under cap", async () => {

--- a/test/db-domains.test.ts
+++ b/test/db-domains.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   createDomain,
+  createDomainUnderCap,
   type Domain,
   deleteDomain,
   getDomainByUserAndName,
@@ -22,6 +23,32 @@ function makeD1Mock(): D1Database {
         return {
           run: async () => {
             if (/^INSERT INTO domains/i.test(sql)) {
+              // Guarded insert (createDomainUnderCap, issue #617): the SQL
+              // itself carries the cap check, so the mock re-evaluates the
+              // count against the store synchronously (no intermediate
+              // await), mirroring D1's single-statement atomicity.
+              if (/WHERE \(SELECT COUNT/i.test(sql)) {
+                const [userId, domain, isFree, scanFrequency, capUserId, cap] =
+                  params as [string, string, number, string, string, number];
+                const currentCount = [...store.values()].filter(
+                  (row) => row.user_id === capUserId,
+                ).length;
+                if (currentCount >= cap) {
+                  return { success: true, meta: { changes: 0 } };
+                }
+                const id = nextId++;
+                store.set(id, {
+                  id,
+                  user_id: userId,
+                  domain,
+                  is_free: isFree,
+                  scan_frequency: scanFrequency,
+                  last_scanned_at: null,
+                  last_grade: null,
+                  created_at: Math.floor(Date.now() / 1000),
+                });
+                return { success: true, meta: { changes: 1 } };
+              }
               const [userId, domain, isFree, scanFrequency] = params as [
                 string,
                 string,
@@ -62,7 +89,7 @@ function makeD1Mock(): D1Database {
                 });
               }
             }
-            return { success: true };
+            return { success: true, meta: { changes: 1 } };
           },
           first: async <T>(): Promise<T | null> => {
             if (/WHERE user_id = \? AND domain = \?/i.test(sql)) {
@@ -202,6 +229,60 @@ describe("db/domains", () => {
       const user1Domains = await getDomainsByUser(db, "user-1");
       expect(user1Domains).toHaveLength(1);
       expect(user1Domains[0].domain).toBe("alice.com");
+    });
+  });
+
+  describe("createDomainUnderCap", () => {
+    it("inserts and returns true when under the cap", async () => {
+      const inserted = await createDomainUnderCap(
+        db,
+        { userId: "user-1", domain: "under-cap.com", isFree: false },
+        3,
+      );
+      expect(inserted).toBe(true);
+      expect(await getDomainsByUser(db, "user-1")).toHaveLength(1);
+    });
+
+    it("refuses to insert and returns false once the user is at the cap", async () => {
+      await createDomain(db, {
+        userId: "user-1",
+        domain: "a.com",
+        isFree: false,
+      });
+      await createDomain(db, {
+        userId: "user-1",
+        domain: "b.com",
+        isFree: false,
+      });
+
+      const inserted = await createDomainUnderCap(
+        db,
+        { userId: "user-1", domain: "c.com", isFree: false },
+        2,
+      );
+      expect(inserted).toBe(false);
+      expect(await getDomainsByUser(db, "user-1")).toHaveLength(2);
+    });
+
+    it("never lets a concurrent burst push a user's domain count past the cap (issue #617)", async () => {
+      // 10 simultaneous adds for one identity at a cap of 3. The cap check and
+      // the insert live in a single SQL statement (no separate JS-level
+      // count-then-insert), so — unlike the old two-step read-modify-write —
+      // a concurrent burst cannot all read the same pre-insert count and all
+      // succeed.
+      const cap = 3;
+      const results = await Promise.all(
+        Array.from({ length: 10 }, (_, i) =>
+          createDomainUnderCap(
+            db,
+            { userId: "user-1", domain: `burst${i}.com`, isFree: false },
+            cap,
+          ),
+        ),
+      );
+
+      expect(results.filter(Boolean)).toHaveLength(cap);
+      expect(await getDomainsByUser(db, "user-1")).toHaveLength(cap);
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds `createDomainUnderCap` (`src/db/domains.ts`): a single guarded SQL statement — `INSERT INTO domains (...) SELECT ... WHERE (SELECT COUNT(*) FROM domains WHERE user_id = ?) < cap` — so the cap check and the insert happen atomically in one round trip instead of as two separate JS-level `await`s (the count-then-insert TOCTOU).
- Wires it into `POST /dashboard/domain/add` (`src/dashboard/routes.ts`), replacing the pre-check-then-insert flow. The pre-fetched `currentCount` is now used only to word the error message; the SQL statement is the actual gate.
- Wires it into `processBulkScan` (`src/api/bulk-scan.ts`) for both in-band scans (`ensureDomainRow`, now cap-aware and throwing a distinguishable `WatchlistCapExceededError` so a race surfaces as "Watchlist limit reached" rather than "Scan failed") and the queued-overflow insert path (now a per-domain atomic-insert loop instead of a multi-row `createDomains` batch insert + one-by-one fallback — the fallback is now redundant since every insert is already per-domain and cap-guarded).
- The existing JS-level pre-slice in `processBulkScan` (which domains get scanned/queued vs. rejected as over-cap) is unchanged — it still avoids wasting DNS lookups on domains that are obviously over cap in the non-race case. The atomic insert is the correctness backstop underneath it for genuine concurrent races.

## Test plan

- [x] `npm test` — 1475 passing (1 pre-existing, unrelated failure: `test/integration/mta-sts-runtime.test.ts` does a real network fetch to dmarc.mx and fails the same way on `main` with no changes, due to this environment's network policy — not caused by this diff).
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — clean, no fixes needed.
- [x] New concurrency test in `test/db-domains.test.ts` (`createDomainUnderCap`): fires 10 concurrent inserts at a cap of 3 and asserts exactly 3 succeed.
- [x] New concurrency test in `test/dashboard-routes.test.ts` (`POST /dashboard/domain/add`): fires 10 concurrent add requests for one identity at the free-plan cap (3) and asserts exactly 3 succeed (303) and 7 are rejected (400), with the final domain count staying at 3.
- [x] Existing watchlist add/bulk cap tests updated where they asserted "no INSERT statement issued at all" — the guarded insert is now always attempted (that's the point: the cap check lives inside the SQL, not before it), so those tests now assert the guarded insert doesn't add a row instead.

Closes #617

## Choices made

- Removed `createDomains` (the multi-row batch insert with `ON CONFLICT DO NOTHING`) since it became dead code — the bulk queued-insert path now does per-domain atomic inserts instead, both for cap-correctness and because the existing fallback path already inserted one-by-one on batch failure.
- Kept the JS-level pre-slice/messaging logic in `processBulkScan` as-is rather than restructuring the whole bulk flow around post-hoc insert results, to preserve existing behavior (e.g. `scanFn` is still never called for domains that are obviously over cap) and keep the diff scoped to the atomicity fix.

## Deferred

- Not in scope for this issue: the sibling TOCTOU issues opened alongside #617 — inbox live-token cap (#618), watchlist domain *ownership* verification (explicitly out of scope per #617's issue body), bulk-scan rate-limit weighting (#619), inbox SSE poll bounding (#620), logout CSRF (#621).

## Review note

This PR touches `src/db/**`, which is CODEOWNERS-gated per `.github/CODEOWNERS` (`/src/db/ @schmug`). **Auto-merge is intentionally not enabled** — this needs a human code-owner approval before merge, per the repo's hybrid autonomous/gated merge policy.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Sr346JJiuEfZHhuikp6R6s)_