### PR TITLE
security: bound concurrent inbox SSE poll loops per token

### DIFF
--- a/src/inbox/store.ts
+++ b/src/inbox/store.ts
@@ -22,6 +22,13 @@ export const TOKEN_TTL_SECONDS = 30 * 60;
 // once — a backstop on top of the issuance rate limiter (free 10/60s).
 export const MAX_LIVE_TOKENS_PER_IDENTITY = 5;
 
+// Per-token ceiling on concurrently open SSE long-poll loops (issue #620).
+// Each loop holds a KV poll running for up to TOKEN_TTL_SECONDS, so without a
+// cap a client could fan out unboundedly many connections for one token and
+// amplify KV reads. A handful of legitimate simultaneous connections (a page
+// reload racing the old tab's stream) should still succeed.
+export const MAX_CONCURRENT_STREAMS_PER_TOKEN = 3;
+
 // We never read `message.raw` (headers only), so memory is bounded regardless
 // of message size. This is a defensive ceiling recorded for transparency; the
 // platform hard max is 25 MiB.
@@ -423,6 +430,48 @@ interface StreamOptions {
   maxWaitMs?: number;
   sleep?: (ms: number) => Promise<void>;
   nowMs?: () => number;
+  rateLimiterNamespace?: DurableObjectNamespace<RateLimiterDO>;
+}
+
+// ---------------------------------------------------------------------------
+// Per-token concurrent-stream cap
+// ---------------------------------------------------------------------------
+
+// Degrades open (never blocks a stream) when the DO binding is absent — same
+// graceful-fallback shape as checkRateLimit — so self-host deploys without the
+// binding and the Node test pool are unaffected.
+async function acquireStreamSlot(
+  token: string,
+  slotId: string,
+  namespace: DurableObjectNamespace<RateLimiterDO> | undefined,
+): Promise<boolean> {
+  if (!namespace) return true;
+  try {
+    const stub = namespace.getByName(`stream:${token}`);
+    return await stub.acquireStreamSlot(
+      slotId,
+      MAX_CONCURRENT_STREAMS_PER_TOKEN,
+      TOKEN_TTL_SECONDS * 1000,
+    );
+  } catch {
+    // DO unreachable (transient error) — fail open rather than dropping a
+    // legitimate stream.
+    return true;
+  }
+}
+
+async function releaseStreamSlot(
+  token: string,
+  slotId: string,
+  namespace: DurableObjectNamespace<RateLimiterDO> | undefined,
+): Promise<void> {
+  if (!namespace) return;
+  try {
+    const stub = namespace.getByName(`stream:${token}`);
+    await stub.releaseStreamSlot(slotId);
+  } catch {
+    // Best-effort; the stale-slot reclaim in acquireStreamSlot recovers this.
+  }
 }
 
 /**
@@ -462,20 +511,38 @@ export async function streamInboxResult(
     return;
   }
 
-  await emit("waiting", { status: "pending" });
-
-  const deadline = nowMs() + maxWaitMs;
-  while (nowMs() < deadline) {
-    await sleep(pollIntervalMs);
-    const rec = await getRecord(kv, token);
-    if (!rec) {
-      await emit("closed", { status: "expired" });
-      return;
-    }
-    if (rec.status === "received") {
-      await emit("result", buildResultPayload(rec, opts.renderCard));
-      return;
-    }
+  // Only the long poll loop below holds a slot — the immediate-response paths
+  // above never enter it, so a resolved/expired token is never blocked by the
+  // cap.
+  const slotId = crypto.randomUUID();
+  const acquired = await acquireStreamSlot(
+    token,
+    slotId,
+    opts.rateLimiterNamespace,
+  );
+  if (!acquired) {
+    await emit("closed", { status: "busy" });
+    return;
   }
-  await emit("closed", { status: "timeout" });
+
+  try {
+    await emit("waiting", { status: "pending" });
+
+    const deadline = nowMs() + maxWaitMs;
+    while (nowMs() < deadline) {
+      await sleep(pollIntervalMs);
+      const rec = await getRecord(kv, token);
+      if (!rec) {
+        await emit("closed", { status: "expired" });
+        return;
+      }
+      if (rec.status === "received") {
+        await emit("result", buildResultPayload(rec, opts.renderCard));
+        return;
+      }
+    }
+    await emit("closed", { status: "timeout" });
+  } finally {
+    await releaseStreamSlot(token, slotId, opts.rateLimiterNamespace);
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -799,6 +799,7 @@ app.get("/api/check/email/stream", async (c) => {
     }
     await streamInboxResult(stream, kv, token, {
       renderCard: renderInboxVerdict,
+      rateLimiterNamespace: c.env?.RATE_LIMITER,
     });
   });
 });

--- a/src/rate-limit-do.ts
+++ b/src/rate-limit-do.ts
@@ -47,6 +47,12 @@ export class RateLimiterDO extends DurableObject {
           exp_ms INTEGER NOT NULL
         )`,
       );
+      this.ctx.storage.sql.exec(
+        `CREATE TABLE IF NOT EXISTS stream_slots (
+          slot_id TEXT PRIMARY KEY,
+          opened_at INTEGER NOT NULL
+        )`,
+      );
     });
   }
 
@@ -133,5 +139,44 @@ export class RateLimiterDO extends DurableObject {
       expSec,
     );
     return result.rowsWritten === 1;
+  }
+
+  // Bounds concurrent SSE poll loops for one inbox token (issue #620). Callers
+  // route via `getByName(\`stream:<token>\`)`, so each DO instance's
+  // `stream_slots` table tracks exactly one token's open long-poll loops.
+  // `staleAfterMs` (the token's own TTL) reclaims slots left behind by a
+  // stream that never released one — a worker eviction or an unhandled
+  // exception — so an abandoned connection can't permanently wedge out future
+  // legitimate ones.
+  acquireStreamSlot(
+    slotId: string,
+    max: number,
+    staleAfterMs: number,
+  ): boolean {
+    const nowMs = Date.now();
+    this.ctx.storage.sql.exec(
+      "DELETE FROM stream_slots WHERE opened_at < ?",
+      nowMs - staleAfterMs,
+    );
+    const count =
+      this.ctx.storage.sql
+        .exec<{ n: number }>("SELECT COUNT(*) as n FROM stream_slots")
+        .toArray()[0]?.n ?? 0;
+    if (count >= max) return false;
+    this.ctx.storage.sql.exec(
+      "INSERT INTO stream_slots (slot_id, opened_at) VALUES (?, ?)",
+      slotId,
+      nowMs,
+    );
+    return true;
+  }
+
+  // Releases a slot acquired above. A stream calls this from a `finally` so
+  // its slot frees immediately rather than waiting for the stale-reclaim path.
+  releaseStreamSlot(slotId: string): void {
+    this.ctx.storage.sql.exec(
+      "DELETE FROM stream_slots WHERE slot_id = ?",
+      slotId,
+    );
   }
 }

--- a/test/inbox-store.test.ts
+++ b/test/inbox-store.test.ts
@@ -3,6 +3,7 @@ import {
   buildResultPayload,
   getRecord,
   handleInboundEmail,
+  MAX_CONCURRENT_STREAMS_PER_TOKEN,
   MAX_LIVE_TOKENS_PER_IDENTITY,
   parseVerdict,
   putPending,
@@ -12,6 +13,7 @@ import {
   TOKEN_TTL_SECONDS,
   type VerdictRecord,
 } from "../src/inbox/store.js";
+import type { RateLimiterDO } from "../src/rate-limit-do.js";
 import { renderInboxVerdict } from "../src/views/inbox.js";
 import { FakeKV } from "./helpers/fake-kv.js";
 
@@ -451,6 +453,131 @@ describe("inbox store — streamInboxResult", () => {
     });
     expect(stream.events.map((e) => e.event)).toEqual(["waiting", "closed"]);
     expect(JSON.parse(stream.events[1].data).status).toBe("expired");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// streamInboxResult — per-token concurrent-stream cap (issue #620)
+// ---------------------------------------------------------------------------
+// The atomic cap itself lives in RateLimiterDO and is exercised under real
+// concurrency in test/integration/inbox-stream-slots-do.test.ts (only workerd
+// has the DO binding). These tests verify streamInboxResult is wired to it
+// correctly: it asks for a slot before entering the poll loop, backs off
+// cleanly when denied, and always releases what it acquired.
+function fakeStreamSlotNamespace(acquireResult: boolean) {
+  const acquireStreamSlot = vi.fn().mockResolvedValue(acquireResult);
+  const releaseStreamSlot = vi.fn().mockResolvedValue(undefined);
+  const namespace = {
+    getByName: () => ({ acquireStreamSlot, releaseStreamSlot }),
+  } as unknown as DurableObjectNamespace<RateLimiterDO>;
+  return { namespace, acquireStreamSlot, releaseStreamSlot };
+}
+
+describe("inbox store — streamInboxResult concurrent-stream cap", () => {
+  it("emits 'closed:busy' without polling once the per-token slot cap is full", async () => {
+    const kv = new FakeKV();
+    await putPending(kv.asKv(), TOKEN);
+    const { namespace, acquireStreamSlot, releaseStreamSlot } =
+      fakeStreamSlotNamespace(false);
+    const stream = fakeStream();
+    await streamInboxResult(stream, kv.asKv(), TOKEN, {
+      renderCard,
+      rateLimiterNamespace: namespace,
+    });
+    expect(stream.events.map((e) => e.event)).toEqual(["closed"]);
+    expect(JSON.parse(stream.events[0].data).status).toBe("busy");
+    expect(acquireStreamSlot).toHaveBeenCalledWith(
+      expect.any(String),
+      MAX_CONCURRENT_STREAMS_PER_TOKEN,
+      TOKEN_TTL_SECONDS * 1000,
+    );
+    // Denied — never held a slot, so nothing to release.
+    expect(releaseStreamSlot).not.toHaveBeenCalled();
+  });
+
+  it("acquires and releases the same slot around a normal poll-to-result flow", async () => {
+    const kv = new FakeKV();
+    await putPending(kv.asKv(), TOKEN);
+    const { namespace, acquireStreamSlot, releaseStreamSlot } =
+      fakeStreamSlotNamespace(true);
+    const stream = fakeStream();
+    await streamInboxResult(stream, kv.asKv(), TOKEN, {
+      renderCard,
+      rateLimiterNamespace: namespace,
+      pollIntervalMs: 1,
+      maxWaitMs: 10_000,
+      sleep: async () => {
+        await putVerdict(kv.asKv(), TOKEN, {
+          status: "received",
+          spf: "pass",
+          dkim: "pass",
+          dmarc: "pass",
+          alignment: "pass",
+          from: "x@y.com",
+          dkim_selector: null,
+          dkim_domain: null,
+          auth_results: "mx; spf=pass",
+          size_bytes: 1,
+          received_at: "2026-06-28T00:00:00.000Z",
+        });
+      },
+    });
+    expect(stream.events.map((e) => e.event)).toEqual(["waiting", "result"]);
+    expect(acquireStreamSlot).toHaveBeenCalledTimes(1);
+    expect(releaseStreamSlot).toHaveBeenCalledTimes(1);
+    const slotId = acquireStreamSlot.mock.calls[0][0];
+    expect(releaseStreamSlot).toHaveBeenCalledWith(slotId);
+  });
+
+  it("still releases the held slot when the stream times out", async () => {
+    const kv = new FakeKV();
+    await putPending(kv.asKv(), TOKEN);
+    const { namespace, acquireStreamSlot, releaseStreamSlot } =
+      fakeStreamSlotNamespace(true);
+    const stream = fakeStream();
+    let clock = 0;
+    await streamInboxResult(stream, kv.asKv(), TOKEN, {
+      renderCard,
+      rateLimiterNamespace: namespace,
+      pollIntervalMs: 1,
+      maxWaitMs: 5,
+      sleep: async () => {
+        clock += 10;
+      },
+      nowMs: () => clock,
+    });
+    expect(stream.events.map((e) => e.event)).toEqual(["waiting", "closed"]);
+    expect(JSON.parse(stream.events[1].data).status).toBe("timeout");
+    expect(acquireStreamSlot).toHaveBeenCalledTimes(1);
+    expect(releaseStreamSlot).toHaveBeenCalledWith(
+      acquireStreamSlot.mock.calls[0][0],
+    );
+  });
+
+  it("never asks for a slot when the verdict is already stored (no poll loop entered)", async () => {
+    const kv = new FakeKV();
+    await putPending(kv.asKv(), TOKEN);
+    await putVerdict(kv.asKv(), TOKEN, {
+      status: "received",
+      spf: "pass",
+      dkim: "pass",
+      dmarc: "pass",
+      alignment: "pass",
+      from: "x@y.com",
+      dkim_selector: null,
+      dkim_domain: null,
+      auth_results: "mx; spf=pass",
+      size_bytes: 1,
+      received_at: "2026-06-28T00:00:00.000Z",
+    });
+    const { namespace, acquireStreamSlot } = fakeStreamSlotNamespace(true);
+    const stream = fakeStream();
+    await streamInboxResult(stream, kv.asKv(), TOKEN, {
+      renderCard,
+      rateLimiterNamespace: namespace,
+    });
+    expect(stream.events.map((e) => e.event)).toEqual(["result"]);
+    expect(acquireStreamSlot).not.toHaveBeenCalled();
   });
 });
 

--- a/test/integration/inbox-stream-slots-do.test.ts
+++ b/test/integration/inbox-stream-slots-do.test.ts
@@ -1,0 +1,79 @@
+import { env, runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import type { RateLimiterDO } from "../../src/rate-limit-do.js";
+
+// These tests run inside the real Cloudflare Workers runtime via
+// `@cloudflare/vitest-pool-workers`, which is the only place the
+// `RATE_LIMITER` Durable Object binding exists. They cover issue #620: the
+// inbox SSE poll loop (`streamInboxResult`) had no ceiling on concurrent
+// long-lived loops per token, so a client could fan out unboundedly many
+// connections and amplify KV reads. `acquireStreamSlot`/`releaseStreamSlot`
+// bound that via the DO's single-threaded RPC — something the Node-pool
+// tests (single isolate, synchronous JS) cannot exercise under real
+// concurrency.
+
+declare module "cloudflare:test" {
+  interface ProvidedEnv {
+    RATE_LIMITER: DurableObjectNamespace<RateLimiterDO>;
+  }
+}
+
+const STALE_AFTER_MS = 30 * 60 * 1000; // matches TOKEN_TTL_SECONDS * 1000
+
+describe("RateLimiterDO stream slots (runs inside real workerd runtime)", () => {
+  it("bounds concurrent acquireStreamSlot calls for one token — only `max` succeed", async () => {
+    const N = 12;
+    const max = 3;
+    const stub = env.RATE_LIMITER.getByName("stream:atomic-token");
+    const results = await Promise.all(
+      Array.from({ length: N }, (_, i) =>
+        stub.acquireStreamSlot(`slot-${i}`, max, STALE_AFTER_MS),
+      ),
+    );
+    expect(results.filter(Boolean).length).toBe(max);
+    expect(results.filter((r) => !r).length).toBe(N - max);
+  });
+
+  it("keeps different tokens' slot counts independent", async () => {
+    const max = 1;
+    const stubA = env.RATE_LIMITER.getByName("stream:token-a");
+    const stubB = env.RATE_LIMITER.getByName("stream:token-b");
+    expect(await stubA.acquireStreamSlot("a1", max, STALE_AFTER_MS)).toBe(true);
+    expect(await stubB.acquireStreamSlot("b1", max, STALE_AFTER_MS)).toBe(true);
+    // token-a is already at its own cap; token-b's slot doesn't count against it.
+    expect(await stubA.acquireStreamSlot("a2", max, STALE_AFTER_MS)).toBe(
+      false,
+    );
+  });
+
+  it("releasing a slot frees capacity for a subsequent acquire", async () => {
+    const max = 1;
+    const stub = env.RATE_LIMITER.getByName("stream:release-token");
+    expect(await stub.acquireStreamSlot("a", max, STALE_AFTER_MS)).toBe(true);
+    expect(await stub.acquireStreamSlot("b", max, STALE_AFTER_MS)).toBe(false);
+    await stub.releaseStreamSlot("a");
+    expect(await stub.acquireStreamSlot("b", max, STALE_AFTER_MS)).toBe(true);
+  });
+
+  it("reclaims a slot abandoned by a stream that never released it", async () => {
+    const max = 1;
+    const stub = env.RATE_LIMITER.getByName("stream:stale-token");
+    // Seed a slot as opened well past the stale window — simulates a worker
+    // eviction that skipped the `finally` release.
+    await runInDurableObject(stub, (_instance, state) => {
+      state.storage.sql.exec(
+        "INSERT INTO stream_slots (slot_id, opened_at) VALUES (?, ?)",
+        "abandoned",
+        Date.now() - 60_000,
+      );
+    });
+    expect(await stub.acquireStreamSlot("fresh", max, 1_000)).toBe(true);
+  });
+
+  it("does not reclaim a slot that is still within its stale window", async () => {
+    const max = 1;
+    const stub = env.RATE_LIMITER.getByName("stream:fresh-token");
+    expect(await stub.acquireStreamSlot("a", max, STALE_AFTER_MS)).toBe(true);
+    expect(await stub.acquireStreamSlot("b", max, STALE_AFTER_MS)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- `streamInboxResult` (the inbox test-email SSE stream) held a 30-minute KV poll loop per connection with no per-token concurrency cap — a client could open many concurrent streams for one token (or many tokens) and amplify KV reads / worker time without limit.
- Added `acquireStreamSlot`/`releaseStreamSlot` RPC methods to the existing `RateLimiterDO` (a new `stream_slots` SQLite table; instances are routed via `getByName(\`stream:<token>\`)` so each DO instance tracks exactly one token's open long-poll loops), reusing the same atomic single-threaded-counter pattern already used for the rate-limit `bucket` table.
- `streamInboxResult` now acquires a slot before entering the poll loop and releases it in a `finally`. A denied acquire emits a clean `closed`/`"busy"` event instead of blocking. The immediate-response paths (verdict already landed, or the token is unknown/expired) never enter the loop, so they're never gated by the cap.
- Degrades open when the DO binding is absent (self-host deploys without it, the Node test pool) — same fallback shape as `checkRateLimit`.

## Owner / zone steps

None — reuses the existing `RATE_LIMITER` Durable Object binding; no new bindings, KV namespaces, or migrations (the new table is created via `CREATE TABLE IF NOT EXISTS` in the DO's existing constructor, same as the `nonces` table).

## Security notes

This is itself a hardening fix (issue #620, resource/KV-read amplification, low severity per the linked issue — no data exposure). No new input surface: the DO instance name is built from the already-validated, charset-restricted inbox token. A stale-reclaim window (the token's own 30-minute TTL) prevents an abandoned connection (worker eviction, unhandled exception) from permanently wedging out capacity for future legitimate streams.

**Note for reviewer:** this diff touches `src/index.ts`, which is CODEOWNERS-gated per `.github/CODEOWNERS` — opening for human review rather than enabling auto-merge.

## Testing

- `npm test` — 1480 passing, 1 failing (pre-existing, unrelated: `test/integration/mta-sts-runtime.test.ts` does a live network fetch and fails identically on a clean `main` checkout in this sandbox — no network egress to dmarc.mx).
- `npm run typecheck` — clean.
- `npm run lint` — clean (187 files, no issues).
- New tests:
  - `test/integration/inbox-stream-slots-do.test.ts` (real `RateLimiterDO` via `@cloudflare/vitest-pool-workers`): fires 12 concurrent `acquireStreamSlot` calls at one token and asserts exactly `MAX_CONCURRENT_STREAMS_PER_TOKEN` (3) succeed; independent per-token counts; release frees capacity; stale-slot reclaim; a fresh slot is not reclaimed early.
  - `test/inbox-store.test.ts`: verifies `streamInboxResult` asks for a slot before polling and backs off to `closed`/`"busy"` when denied; acquires-then-releases the same slot id on a normal poll-to-result flow and on a timeout; never requests a slot when the verdict is already stored (immediate-response path is ungated).

## Choices made

- Capped at `MAX_CONCURRENT_STREAMS_PER_TOKEN = 3` — enough slack for a legitimate page-reload racing an old tab's stream, without allowing unbounded fan-out.
- Reused the existing `RateLimiterDO` class (new `stream_slots` table) rather than a new DO class or a new KV namespace, per the issue's explicit constraint and mirroring how the same class already hosts the rate-limit `bucket` and account-deletion `nonces` tables.
- Only the long poll loop holds a slot; the immediate-response paths (verdict already landed, unknown/expired token) return before acquiring one, since they never hold KV-polling work open.

## Deferred

None — this issue's three acceptance criteria are fully addressed in this PR.

## Refs

Closes #620


---
_Generated by [Claude Code](https://claude.ai/code/session_018YH3qaWKDvTzopGthJzrFR)_