### PR TITLE
feat(factory): wire the software factory — gate config, Action, issue template

### DIFF
--- a/.factory/README.md
+++ b/.factory/README.md
@@ -1,0 +1,49 @@
+# `.factory/` — software factory configuration
+
+The autonomous issue→fix→merge loop. The engine lives in the
+[shipofclaudius](https://github.com/schmug/shipofclaudius) plugin
+(`factory-issue-fix` / `factory-land` / `packages/factory-gate`); this directory holds only
+**this repo's** configuration, and `.github/workflows/factory.yml` is the scheduler.
+
+| File | What it is |
+|---|---|
+| `gate.json` | The merge gate's config. Read from **`main`** on every run, never from the PR. |
+| `setup-labels.sh` | Creates the label state machine. Idempotent; already run. |
+
+## Status: WIRED, NOT ARMED
+
+The plumbing is in place and can be exercised end to end, but the factory **cannot auto-merge
+anything today** and that is deliberate. Three independent things still gate it:
+
+1. **`fix-verified` is human-minted.** `requireFixtureEvidence` is `false` because this repo has no
+   reproduction harness yet (see the issue tracker). Until it does, the reproduce phase has no
+   mechanical definition of done, so a human applies the trust token after reviewing the draft PR.
+2. **`secrets.FACTORY_GH_TOKEN` does not exist yet**, and it must be a **distinct identity from
+   @schmug**. GitHub forbids self-approval, so a token acting as the code owner can never satisfy
+   the `require_code_owner_review` rule on `main-protection`. Until that identity exists the
+   `advance` and `land` jobs cannot run.
+3. **There is no rollback lever.** Production deploys currently leave GitHub entirely via the
+   Cloudflare Git integration, so a bad auto-merged change cannot be reverted from here. A factory
+   without a revert path is not a factory.
+
+Do not raise `allowlistAuthors` off a reviewed list, and do not set `requireFixtureEvidence: true`,
+until those are resolved.
+
+## `gate.json` mirrors CODEOWNERS on purpose
+
+Anything a code owner must approve is also something the gate refuses to auto-merge. The denylist
+is a **superset** of `.github/CODEOWNERS`, adding paths that are security- or money-sensitive but
+not currently code-owned: `src/auth/**`, `src/account/**`, `src/billing/**`, `src/webhooks/**`,
+`src/rate-limit-do.ts`, `mta-sts-worker/**`, `scripts/routine-gate/**`.
+
+`.factory/**`, `.github/workflows/**`, `.github/CODEOWNERS` and `CODEOWNERS` are added
+**automatically** by the gate and cannot be removed by this file — a PR must never be able to widen
+the rules it is judged by. Every condition **fails closed**: missing data, ambiguous data, and an
+`UNKNOWN` CI state all mean "no".
+
+## The two human-only labels
+
+- **`fix-verified`** — the trust token, and the only thing that unlocks the merge gate. Apply it
+  only after reviewing the draft PR and its preview.
+- **`pipeline-paused`** — the kill switch. Apply it to any open issue and the whole factory halts on
+  its next run. No PR, no redeploy, no waiting.

--- a/.factory/gate.json
+++ b/.factory/gate.json
@@ -1,0 +1,42 @@
+{
+  "allowlistAuthors": ["schmug"],
+  "requiredLabels": ["fix-verified"],
+  "blockingLabels": [
+    "needs-you",
+    "pipeline-paused",
+    "impl-blocked",
+    "awaiting-human",
+    "needs-decision",
+    "routine-pause",
+    "wontfix",
+    "duplicate"
+  ],
+  "riskPathDenylist": [
+    ".github/**",
+    ".claude/settings.json",
+    "CLAUDE.md",
+    "SECURITY.md",
+    "package.json",
+    "package-lock.json",
+    "wrangler.toml",
+    "src/index.ts",
+    "src/rate-limit.ts",
+    "src/rate-limit-do.ts",
+    "src/db/**",
+    "src/auth/**",
+    "src/account/**",
+    "src/billing/**",
+    "src/webhooks/**",
+    "src/analyzers/**",
+    "src/orchestrator.ts",
+    "src/shared/scoring.ts",
+    "mta-sts-worker/**",
+    "scripts/routine-gate/**"
+  ],
+  "maxChangedLines": 250,
+  "maxChangedFiles": 8,
+  "requireScopeBlock": true,
+  "requireGreenCI": true,
+  "requireFixtureEvidence": false,
+  "gateFromRef": "main"
+}

--- a/.factory/setup-labels.sh
+++ b/.factory/setup-labels.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Create the factory's label state machine. Idempotent — safe to re-run.
+# Source: shipofclaudius .factory/templates/setup-labels.sh
+#
+#   ./.factory/setup-labels.sh [owner/repo]
+#
+# The label set IS the state machine (design spec §5). The driver is stateless: each run reads
+# labels, advances at most one transition, and writes them back — which is what makes the loop
+# restartable, inspectable, and interruptible at every transition.
+set -euo pipefail
+
+REPO="${1:-}"
+ARGS=()
+[ -n "$REPO" ] && ARGS=(--repo "$REPO")
+
+# name|colour|description
+LABELS=(
+  "factory|0e8a16|Opted into the autonomous factory pipeline"
+  "needs-repro|fbca04|Factory: awaiting a reproduction"
+  "repro-ok|c2e0c6|Factory: reproduced — a fixture fails on the base"
+  "repro-failed|d93f0b|Factory: could NOT reproduce; needs a human"
+  "diagnosed|1d76db|Factory: root cause identified and independently verified"
+  "not-a-bug|ededed|Factory: verified as intended behaviour, not a defect"
+  "fix-proposed|5319e7|Factory: a draft PR with a fix is open"
+  "fix-verified|0e8a16|TRUST TOKEN — a human confirmed the fix. The ONLY thing that unlocks the merge gate"
+  "needs-you|b60205|Escalated: the factory will not touch this"
+  "pipeline-paused|000000|KILL SWITCH — pauses the entire factory, checked first on every run"
+)
+
+for entry in "${LABELS[@]}"; do
+  IFS='|' read -r name colour desc <<< "$entry"
+  if gh label create "$name" --color "$colour" --description "$desc" "${ARGS[@]+"${ARGS[@]}"}" 2>/dev/null; then
+    echo "created  $name"
+  else
+    gh label edit "$name" --color "$colour" --description "$desc" "${ARGS[@]+"${ARGS[@]}"}" >/dev/null
+    echo "updated  $name"
+  fi
+done
+
+echo
+echo "Done. Two labels are load-bearing and human-only:"
+echo "  fix-verified     — the trust token. Apply it ONLY after reviewing the draft PR and its preview."
+echo "  pipeline-paused  — the kill switch. Apply it to any open issue to halt the whole factory."

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Something in dmarc.mx behaves incorrectly.
-labels: ["bug"]
+labels: ["bug", "factory", "needs-repro"]
 body:
   - type: markdown
     attributes:
@@ -47,8 +47,9 @@ body:
         Paths that are code-owned (`src/index.ts`, `src/analyzers/**`, `src/db/**`, `src/auth/**`,
         and friends — see `.factory/gate.json`) always require human review regardless of scope.
       value: |
+        ```scope
         src/**
-      render: text
+        ```
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,75 @@
+name: Bug report
+description: Something in dmarc.mx behaves incorrectly.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting. The two fields marked **required for the factory** are what let the
+        autonomous fix loop pick this up — without them a fix has to be written and merged by hand.
+
+  - type: input
+    id: domain
+    attributes:
+      label: Domain or URL
+      description: The exact domain you scanned, or the page you were on. This is what makes the bug reproducible.
+      placeholder: example.com
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+      placeholder: example.com should grade A — it publishes p=reject with full alignment.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: What actually happened
+      description: Paste the exact output, grade, or error text. Verbatim beats paraphrase.
+      placeholder: It graded B, with "policy not enforcing" in the DMARC row.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope — which files may a fix touch?
+      description: |
+        **Required for the factory.** One glob per line. The deterministic merge gate refuses any PR
+        that changes a file outside this list, so an over-broad scope is not more helpful — it is
+        less safe. If you do not know, leave the default and a maintainer will narrow it; a fix will
+        then need a human to merge it.
+
+        Paths that are code-owned (`src/index.ts`, `src/analyzers/**`, `src/db/**`, `src/auth/**`,
+        and friends — see `.factory/gate.json`) always require human review regardless of scope.
+      value: |
+        src/**
+      render: text
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: How wrong is it?
+      options:
+        - Cosmetic — looks off, result is correct
+        - Wrong result — a grade, policy, or record is reported incorrectly
+        - Broken — the scan fails or the page errors
+        - Security — please report privately instead, see SECURITY.md
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: Before you file
+      options:
+        - label: I checked this reproduces on https://dmarc.mx (not a cached or older deployment).
+          required: true
+        - label: This is not a security vulnerability. (If it is, follow SECURITY.md instead — do not file it here.)
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/schmug/dmarcheck/security/policy
+    about: Report privately via the security policy — never as a public issue.

--- a/.github/workflows/factory.yml
+++ b/.github/workflows/factory.yml
@@ -211,6 +211,12 @@ jobs:
 
       # Exit 0 = merge, 2 = escalate, 1 = the gate itself broke. Three DISTINCT codes on purpose:
       # "the gate broke" must never be read as either answer. Only 0 reaches the merge step.
+      #
+      # ⚠️ `|| code=$?` IS LOAD-BEARING. GitHub runs `run:` blocks as `bash -e {0}`, and
+      # `set -uo pipefail` does NOT clear that inherited `-e`. Without the `||`, the normal
+      # ESCALATE path (exit 2) aborts this step before the code is captured, which then skips the
+      # comment and escalate steps via their implicit `success()` — so the gate would post no
+      # verdict and apply no label exactly when it says NO. Do not "simplify" this away.
       - name: Run the gate
         id: gate
         env:
@@ -220,13 +226,18 @@ jobs:
           CONFIG_ARG=""
           # `.factory/gate.json` here came from the BASE checkout above, not from the PR.
           [ -f .factory/gate.json ] && CONFIG_ARG="--config .factory/gate.json"
+          code=0
           node .factory-plugin/packages/factory-gate/bin/gate.mjs \
             --input gate-input.json $CONFIG_ARG \
             --config-source "${BASE_REF}@${GITHUB_SHA}" \
-            --verdict-out verdict.json --comment-out comment.md
-          echo "code=$?" >> "$GITHUB_OUTPUT"
+            --verdict-out verdict.json --comment-out comment.md || code=$?
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+          echo "Gate exit: $code (0=merge, 2=escalate, 1=the gate itself broke)"
 
+      # `always()` so the audit comment is posted even if the gate step itself died — a PR must
+      # never be left with no explanation of why the factory did not land it.
       - name: Post the audit comment
+        if: always() && steps.gate.conclusion != 'skipped'
         env:
           GH_TOKEN: ${{ secrets.FACTORY_GH_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -252,7 +263,7 @@ jobs:
           gh pr merge "$PR_NUMBER" --repo "$TARGET_REPO" --squash
 
       - name: Escalate
-        if: steps.gate.outputs.code != '0'
+        if: always() && steps.gate.conclusion != 'skipped' && steps.gate.outputs.code != '0'
         env:
           GH_TOKEN: ${{ secrets.FACTORY_GH_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/factory.yml
+++ b/.github/workflows/factory.yml
@@ -198,6 +198,29 @@ jobs:
           token: ${{ secrets.FACTORY_GH_TOKEN }}
           persist-credentials: false
 
+      # THE DRAFT DEADLOCK. `factory-issue-fix` opens a DRAFT (its write ladder deliberately ends
+      # there), and a draft PR reports `mergeStateStatus: DRAFT`, which gate condition 8 rejects —
+      # so without this step the factory can NEVER land anything it produced. Readying is safe and
+      # reversible, and it happens only AFTER a human applied `fix-verified`, which IS the approval
+      # to land. If the gate then refuses, the PR is converted back to a draft below.
+      - name: Ready the draft (fix-verified is the human's approval to land)
+        env:
+          GH_TOKEN: ${{ secrets.FACTORY_GH_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          TARGET_REPO: ${{ github.repository }}
+          IS_DRAFT: ${{ github.event.pull_request.draft }}
+        run: |
+          set -euo pipefail
+          if [ "$IS_DRAFT" = "true" ]; then
+            gh pr ready "$PR_NUMBER" --repo "$TARGET_REPO"
+            echo "Converted #$PR_NUMBER from draft to ready so the gate can read a real merge state."
+          fi
+
+      # Condition 9 (`fixture_evidence`) is OPT-IN and currently has NO producer. Nothing in this
+      # workflow computes red-on-base / green-on-head from CI, and the value must NOT come from the
+      # fix agent's self-report — a model asserting its own work passed is exactly what §4 exists to
+      # prevent. Until a CI job writes `factory-evidence.json` (see the reproduction-harness issue),
+      # leave `requireFixtureEvidence: false`; flipping it today fails every PR at condition 9.
       - name: Build the gate input
         env:
           GH_TOKEN: ${{ secrets.FACTORY_GH_TOKEN }}
@@ -207,7 +230,8 @@ jobs:
         run: |
           set -euo pipefail
           node .factory-plugin/packages/factory-gate/bin/build-input.mjs \
-            --pr "$PR_NUMBER" --repo "$TARGET_REPO" --base "$BASE_REF" --out gate-input.json
+            --pr "$PR_NUMBER" --repo "$TARGET_REPO" --base "$BASE_REF" --out gate-input.json \
+            $( [ -f factory-evidence.json ] && echo "--evidence factory-evidence.json" )
 
       # Exit 0 = merge, 2 = escalate, 1 = the gate itself broke. Three DISTINCT codes on purpose:
       # "the gate broke" must never be read as either answer. Only 0 reaches the merge step.
@@ -272,6 +296,11 @@ jobs:
         run: |
           set -euo pipefail
           gh pr edit "$PR_NUMBER" --repo "$TARGET_REPO" --add-label needs-you || true
+          # Put it back in draft so the write ladder still ends at a draft when the gate says no.
+          if [ "${{ github.event.pull_request.draft }}" = "true" ]; then
+            gh pr ready "$PR_NUMBER" --repo "$TARGET_REPO" --undo || true
+          fi
+
           if [ "$GATE_CODE" = "1" ]; then
             echo "::error::The factory gate FAILED TO RUN (exit 1). That is not a verdict — investigate before re-running."
             exit 1

--- a/.github/workflows/factory.yml
+++ b/.github/workflows/factory.yml
@@ -1,0 +1,268 @@
+# Software factory — scheduler, driver, and gated landing.
+#
+# The autonomous loop that takes an issue labelled `factory`, reproduces it, diagnoses it,
+# independently verifies it is a real defect, fixes it behind a draft PR, and merges only when a
+# deterministic model-free gate says every safety condition holds. The engine is the
+# shipofclaudius plugin; this file is the scheduler (L4) and the gate runner (L1).
+#
+# ⚠️ NOT ARMED YET. `secrets.FACTORY_GH_TOKEN` does not exist, so both write jobs no-op with a
+# clear message rather than half-running. Before arming, read `.factory/README.md`: the token must
+# be a DISTINCT IDENTITY FROM @schmug (GitHub forbids self-approval, so a code-owner token can
+# never satisfy `require_code_owner_review` on the `main-protection` ruleset — this is #299), and
+# the repo still has no rollback lever.
+#
+# ⚠️ `pull_request_target` RUNS WITH REPOSITORY WRITE ACCESS. This workflow therefore NEVER checks
+# out, builds, or executes pull-request-authored code. The `land` job checks out the BASE ref only,
+# and the gate is a zero-dependency Node program run with no install step. Do NOT add `npm ci`, a
+# build, or `ref: github.event.pull_request.head.sha` to that job, and do NOT interpolate
+# attacker-controlled context (PR title/body/branch name) into any `run:` block: either would hand
+# repository write access to whoever opened the PR.
+
+name: Software factory
+
+on:
+  issues:
+    types: [labeled]
+  pull_request_target:
+    types: [labeled] # the human-minted `fix-verified` trust token arrives here
+  schedule:
+    - cron: "0 */4 * * *"
+  workflow_dispatch:
+    inputs:
+      issue:
+        description: "Issue number to advance (blank = oldest in the factory queue)"
+        required: false
+        type: string
+      stop_after:
+        description: "Advance at most this far: reproduce | diagnose | verify | fix"
+        required: false
+        default: reproduce
+        type: string
+
+# Never cancel mid-write: a cancelled `advance` can leave a half-pushed branch, and a cancelled
+# `land` can leave a merge in an unknown state.
+concurrency:
+  group: factory-${{ github.event.issue.number || github.event.pull_request.number || 'cron' }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  FACTORY_PLUGIN_REPO: schmug/shipofclaudius
+  FACTORY_PLUGIN_REF: main
+
+jobs:
+  # ── 1. KILL SWITCH — cheap, model-free, and first. Everything else needs: it. ────────────────
+  killswitch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: read
+    outputs:
+      paused: ${{ steps.check.outputs.paused }}
+      armed: ${{ steps.check.outputs.armed }}
+    steps:
+      - id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          FACTORY_TOKEN_PRESENT: ${{ secrets.FACTORY_GH_TOKEN != '' }}
+        run: |
+          set -euo pipefail
+          n="$(gh issue list --label pipeline-paused --state open --limit 1 --json number --jq 'length')"
+          if [ "$n" != "0" ]; then
+            echo "paused=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Factory PAUSED — an open issue carries \`pipeline-paused\`. Remove it to resume."
+          else
+            echo "paused=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "armed=${FACTORY_TOKEN_PRESENT}" >> "$GITHUB_OUTPUT"
+          if [ "${FACTORY_TOKEN_PRESENT}" != "true" ]; then
+            echo "::notice::Factory is WIRED but NOT ARMED — secrets.FACTORY_GH_TOKEN is unset, so the write jobs will not run. See .factory/README.md."
+          fi
+
+  # ── 2. ADVANCE (L3 driver) — one run advances ONE issue by at most one phase. ────────────────
+  advance:
+    needs: killswitch
+    if: >-
+      needs.killswitch.outputs.paused == 'false' &&
+      needs.killswitch.outputs.armed == 'true' &&
+      (github.event_name == 'schedule' ||
+       github.event_name == 'workflow_dispatch' ||
+       (github.event_name == 'issues' &&
+        (github.event.label.name == 'factory' || github.event.label.name == 'needs-repro')))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          cache: "npm"
+      - run: npm ci
+
+      - name: Fetch the factory plugin
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ env.FACTORY_PLUGIN_REPO }}
+          ref: ${{ env.FACTORY_PLUGIN_REF }}
+          path: .factory-plugin
+          token: ${{ secrets.FACTORY_GH_TOKEN }}
+          persist-credentials: false
+
+      - name: Advance one issue
+        env:
+          GH_TOKEN: ${{ secrets.FACTORY_GH_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_PLUGIN_ROOT: ${{ github.workspace }}/.factory-plugin
+          # Passed through the ENVIRONMENT, never interpolated into the script body — these are
+          # numbers today, but keeping untrusted context out of `run:` text is the rule that stops
+          # a future field from becoming shell.
+          FACTORY_ISSUE: ${{ github.event.issue.number || inputs.issue }}
+          FACTORY_STOP_AFTER: ${{ inputs.stop_after || 'fix' }}
+          FACTORY_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Validate the dispatch inputs before they reach the model's prompt. Shell parameter
+          # expansion does not re-scan its result, so these cannot become shell — but they CAN
+          # become instructions to an agent, and an allowlist is cheaper than reasoning about that.
+          if [ -n "${FACTORY_ISSUE}" ]; then
+            case "${FACTORY_ISSUE}" in
+              ''|*[!0-9]*) echo "::error::issue must be a positive integer, got: ${FACTORY_ISSUE}"; exit 1 ;;
+            esac
+          fi
+          case "${FACTORY_STOP_AFTER}" in
+            reproduce|diagnose|verify|fix) ;;
+            *) echo "::error::stop_after must be one of reproduce|diagnose|verify|fix"; exit 1 ;;
+          esac
+
+          npm install -g @anthropic-ai/claude-code
+
+          # routine-anti-noise runs FIRST, as a mandatory gate: it is the purpose-built fix for the
+          # double-fire class of bug (one issue -> six duplicate PRs) and it honours human hold
+          # labels. The workflow's own idempotency preflight is the second line, not a substitute.
+          claude -p --permission-mode acceptEdits "
+          Run the routine-anti-noise skill on issue ${FACTORY_ISSUE:-(the oldest factory-queue issue)}
+          in ${FACTORY_REPO}. If it returns skip:true, STOP and report the reason — do nothing else.
+
+          Otherwise run the factory-issue-fix skill with:
+            issue: ${FACTORY_ISSUE:-(omit — let it self-bootstrap from the factory queue)}
+            repo: ${FACTORY_REPO}
+            stopAfter: ${FACTORY_STOP_AFTER}
+
+          Then apply the returned transition.labels with gh (add and remove exactly what it lists,
+          nothing else) and post transition.comment as an issue comment if it is non-empty. Commit
+          the returned report as report.md on the factory branch if that branch exists. Do NOT
+          merge anything, do NOT mark any PR ready, and do NOT push to main.
+          " 2>&1 | tee advance.log
+
+  # ── 3. LAND (L1 gate) — NO MODEL RUNS IN THIS JOB. It is `gh` plus a zero-dependency Node
+  # program, so an instruction injected into an issue or PR body has nothing to act on. ─────────
+  land:
+    needs: killswitch
+    if: >-
+      needs.killswitch.outputs.paused == 'false' &&
+      needs.killswitch.outputs.armed == 'true' &&
+      github.event_name == 'pull_request_target' &&
+      github.event.label.name == 'fix-verified'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      # THE GATE-FROM-MAIN INVARIANT. Check out the BASE ref, never the PR head: the rules a PR is
+      # judged by must not be editable by that PR. `.factory/**` and `.github/workflows/**` are on
+      # the gate's MANDATORY denylist too, so even a mis-wired checkout escalates rather than merges.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+
+      # The gate itself, versioned independently of the repo it judges. No `npm ci` — it has zero
+      # dependencies on purpose, so there is no install step to compromise.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ env.FACTORY_PLUGIN_REPO }}
+          ref: ${{ env.FACTORY_PLUGIN_REF }}
+          path: .factory-plugin
+          token: ${{ secrets.FACTORY_GH_TOKEN }}
+          persist-credentials: false
+
+      - name: Build the gate input
+        env:
+          GH_TOKEN: ${{ secrets.FACTORY_GH_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          TARGET_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          node .factory-plugin/packages/factory-gate/bin/build-input.mjs \
+            --pr "$PR_NUMBER" --repo "$TARGET_REPO" --base "$BASE_REF" --out gate-input.json
+
+      # Exit 0 = merge, 2 = escalate, 1 = the gate itself broke. Three DISTINCT codes on purpose:
+      # "the gate broke" must never be read as either answer. Only 0 reaches the merge step.
+      - name: Run the gate
+        id: gate
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -uo pipefail
+          CONFIG_ARG=""
+          # `.factory/gate.json` here came from the BASE checkout above, not from the PR.
+          [ -f .factory/gate.json ] && CONFIG_ARG="--config .factory/gate.json"
+          node .factory-plugin/packages/factory-gate/bin/gate.mjs \
+            --input gate-input.json $CONFIG_ARG \
+            --config-source "${BASE_REF}@${GITHUB_SHA}" \
+            --verdict-out verdict.json --comment-out comment.md
+          echo "code=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Post the audit comment
+        env:
+          GH_TOKEN: ${{ secrets.FACTORY_GH_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          TARGET_REPO: ${{ github.repository }}
+          GATE_CODE: ${{ steps.gate.outputs.code }}
+        run: |
+          set -euo pipefail
+          if [ ! -f comment.md ]; then
+            printf '### Factory gate — ⛔ escalate\n\nThe gate produced no verdict (exit %s). Merging nothing.\n' "$GATE_CODE" > comment.md
+          fi
+          gh pr comment "$PR_NUMBER" --repo "$TARGET_REPO" --body-file comment.md
+
+      - name: Squash-merge (only on a clean pass)
+        if: steps.gate.outputs.code == '0'
+        env:
+          GH_TOKEN: ${{ secrets.FACTORY_GH_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          TARGET_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # No --admin (it would bypass the very protections the gate mirrors) and no
+          # --delete-branch (a predecessor in a stack may still need the ref).
+          gh pr merge "$PR_NUMBER" --repo "$TARGET_REPO" --squash
+
+      - name: Escalate
+        if: steps.gate.outputs.code != '0'
+        env:
+          GH_TOKEN: ${{ secrets.FACTORY_GH_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          TARGET_REPO: ${{ github.repository }}
+          GATE_CODE: ${{ steps.gate.outputs.code }}
+        run: |
+          set -euo pipefail
+          gh pr edit "$PR_NUMBER" --repo "$TARGET_REPO" --add-label needs-you || true
+          if [ "$GATE_CODE" = "1" ]; then
+            echo "::error::The factory gate FAILED TO RUN (exit 1). That is not a verdict — investigate before re-running."
+            exit 1
+          fi
+          echo "::notice::Gate escalated (exit 2) — see the audit comment on the PR. Merged nothing."


### PR DESCRIPTION
Adopts the autonomous issue→fix→merge loop from [schmug/shipofclaudius#63](https://github.com/schmug/shipofclaudius/pull/63).

## ⚠️ WIRED, NOT ARMED

`secrets.FACTORY_GH_TOKEN` does not exist, so the `advance` and `land` jobs **no-op with a clear notice** rather than half-running. Nothing can auto-merge today, and three independent things still gate that — see [`.factory/README.md`](.factory/README.md):

1. **`fix-verified` is human-minted.** `requireFixtureEvidence: false` because this repo has no reproduction harness, so the reproduce phase has no mechanical definition of done.
2. **The write token must be a distinct identity from @schmug.** GitHub forbids self-approval, so a code-owner token can never satisfy `require_code_owner_review` on `main-protection`. That's #299.
3. **There is no rollback lever.** Production deploys leave GitHub entirely via the Cloudflare Git integration, so a bad auto-merged change can't be reverted from here.

## What's here

**`.factory/gate.json`** — the merge gate's config, read from `main` on every run and never from the PR. The denylist mirrors `.github/CODEOWNERS` and **adds** the security/money paths that aren't currently code-owned: `src/auth/**`, `src/account/**`, `src/billing/**`, `src/webhooks/**`, `src/rate-limit-do.ts`, `mta-sts-worker/**`, `scripts/routine-gate/**`. `.factory/**`, `.github/workflows/**` and CODEOWNERS are added *automatically* by the gate and cannot be removed by this file — a PR must never be able to widen the rules it's judged by.

**`.github/workflows/factory.yml`** — `killswitch` → `advance` → `land`.

The `land` job **runs no model at all**: it's `gh` plus a zero-dependency Node program, so text injected into a public issue body has nothing to act on — an injected instruction cannot move a `<=` comparison. It checks out the **base** ref, never the PR head, which is what makes the `pull_request_target` trigger safe; there's no `npm ci` and no build step in it. `workflow_dispatch` inputs are allowlist-validated before they reach the driver's prompt, and all GitHub context flows through `env:`, never interpolated into `run:` bodies. Action SHAs match the existing pins so the action-pin integrity check passes.

**`.github/ISSUE_TEMPLATE/`** — the repo had none at all. The bug form makes the ` ```scope ` block **required**, which is the gate's single most common escalation cause.

## Verified end to end

Ran the real gate binary against this exact `.factory/gate.json`:

| Case | Result |
|---|---|
| A clean, in-scope PR | **exit 0 — merge** |
| **Real PR #653** (dependabot) | exit 2 — unallowlisted author, no `fix-verified`, no `Closes #N`, `mta-sts-worker/**` risk path, 382 lines > 250, no scope block |
| Self-editing `.factory/**` / `.github/workflows/**` / CODEOWNERS | exit 2 — `no_risk_paths` |
| Touching `src/analyzers/**` · `src/shared/scoring.ts` · `src/billing/**` | exit 2 — `no_risk_paths` |
| Scope drift · oversize · pending required check · `BLOCKED` merge state | exit 2 — the matching condition |

That exercise also caught a real bug in the gate package (`gh api` takes no `-R`, which would have failed `ci_green` on every PR forever) — fixed upstream in shipofclaudius#63 before this PR was opened.

## Settled empirically while wiring this

`.github/CODEOWNERS` is **enforcing**, not advisory. The `main-protection` ruleset is `active` with `require_code_owner_review: true`, `required_approving_review_count: 0`, one required check (`check`), and **no bypass actors**. `CLAUDE.md` is correct; `MAINTAINERS.md`, `docs/OSPS-DEVIATIONS.md` and `.claude/workflows/pr-triage.js` all say advisory and are wrong. Filed separately rather than mixed into this PR.

## Not in this PR

The reproduction harness, the coverage floor, the rollback lever, the bot identity, and the `src/index.ts` bottleneck are filed as follow-up issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)