### PR TITLE
refactor: extract static/branding/PWA-asset routes into src/routes/static.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,21 +70,11 @@ import {
   type RateLimitResult,
   rateLimitHeaders,
 } from "./rate-limit.js";
+import { staticRoutes } from "./routes/static.js";
 import { scrubSentryEvent } from "./sentry-scrub.js";
 import { normalizeDomain } from "./shared/domain.js";
-import { listIndexableScanDomains } from "./shared/indexable-domains.js";
 import { watchlistCapFor } from "./shared/limits.js";
 import { parseScoringConfig } from "./shared/scoring-config.js";
-import { CSS_PATH, JS_PATH } from "./views/assets.js";
-import {
-  APPLE_TOUCH_ICON_BASE64,
-  FAVICON_ICO_BASE64,
-  FAVICON_SVG,
-  ICON_192_BASE64,
-  ICON_512_BASE64,
-  OG_IMAGE_PNG_BASE64,
-  webManifest,
-} from "./views/favicon.js";
 import {
   renderApiDocs,
   renderBimiCard,
@@ -135,8 +125,6 @@ import {
 } from "./views/markdown.js";
 import { renderMxHub, renderMxProviderPage } from "./views/mx.js";
 import { renderPricingPage } from "./views/pricing.js";
-import { JS } from "./views/scripts.js";
-import { CSS } from "./views/styles.js";
 import { fireBulkScanWebhooks } from "./webhooks/triggers.js";
 
 // Durable Object class for the atomic rate limiter (GHSA-v7qc-7qh8-h69g).
@@ -362,6 +350,9 @@ app.get("/_dev/dashboard", async (c) => {
 // Stripe webhook (public — signature-verified). Self-gates on
 // isBillingEnabled so self-host deploys without Stripe env still boot.
 app.route("/webhooks", stripeWebhookRoutes);
+
+// Static assets, health check, and crawler-facing infrastructure (#661).
+app.route("/", staticRoutes);
 
 function markdownResponse(c: Context, body: string, status = 200) {
   return c.body(body, status as 200, {
@@ -804,52 +795,6 @@ app.get("/api/check/email/stream", async (c) => {
   });
 });
 
-app.get("/logo.svg", (c) => {
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" version="1.2" baseProfile="tiny-ps" viewBox="0 0 512 512">
-  <title>dmarcheck</title>
-  <rect width="512" height="512" rx="64" fill="#0a0a0a"/>
-  <text x="256" y="310" font-family="monospace" font-size="220" fill="#f97316" text-anchor="middle">@</text>
-  <circle cx="210" cy="210" r="28" fill="white"/>
-  <circle cx="302" cy="210" r="28" fill="white"/>
-  <circle cx="216" cy="218" r="14" fill="#0a0a0f"/>
-  <circle cx="308" cy="218" r="14" fill="#0a0a0f"/>
-  <rect x="196" y="380" width="20" height="40" rx="8" fill="#ea580c"/>
-  <rect x="246" y="380" width="20" height="32" rx="8" fill="#ea580c"/>
-  <rect x="296" y="380" width="20" height="40" rx="8" fill="#ea580c"/>
-</svg>`;
-  return c.body(svg, 200, {
-    "Content-Type": "image/svg+xml",
-    "Cache-Control": "public, max-age=86400",
-  });
-});
-
-app.get("/og-image.svg", (c) => {
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
-  <rect width="1200" height="630" fill="#0a0a0f"/>
-  <!-- Creature -->
-  <text x="340" y="310" font-family="monospace" font-size="180" fill="#f97316" text-anchor="middle">@</text>
-  <circle cx="300" cy="220" r="22" fill="white"/>
-  <circle cx="375" cy="220" r="22" fill="white"/>
-  <circle cx="305" cy="226" r="11" fill="#0a0a0f"/>
-  <circle cx="380" cy="226" r="11" fill="#0a0a0f"/>
-  <rect x="290" y="370" width="16" height="32" rx="6" fill="#ea580c"/>
-  <rect x="330" y="370" width="16" height="26" rx="6" fill="#ea580c"/>
-  <rect x="370" y="370" width="16" height="32" rx="6" fill="#ea580c"/>
-  <!-- Wordmark -->
-  <text x="500" y="300" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif" font-weight="800" font-size="72">
-    <tspan fill="#e4e4e7">dmar</tspan><tspan fill="#f97316">check</tspan>
-  </text>
-  <!-- Tagline -->
-  <text x="500" y="350" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif" font-size="24" fill="#71717a">DNS Email Security Analyzer</text>
-  <!-- BIMI badge -->
-  <text x="500" y="400" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif" font-size="18" fill="#f97316">Meet DMarcus — your email security sidekick</text>
-</svg>`;
-  return c.body(svg, 200, {
-    "Content-Type": "image/svg+xml",
-    "Cache-Control": "public, max-age=86400",
-  });
-});
-
 // Embeddable email-security badge for READMEs and dashboards. Always
 // returns a 200 SVG (even for invalid input or scan errors) so a badge
 // embed never renders as a broken image — error states are encoded into
@@ -897,85 +842,6 @@ app.get("/badge", async (c) => {
       "Cache-Control": "public, max-age=60",
     });
   }
-});
-
-app.get("/og-image.png", (c) => {
-  const buf = Uint8Array.from(atob(OG_IMAGE_PNG_BASE64), (ch) =>
-    ch.charCodeAt(0),
-  );
-  return c.body(buf, 200, {
-    "Content-Type": "image/png",
-    "Cache-Control": "public, max-age=86400",
-  });
-});
-
-// Content-hashed static assets with immutable caching
-app.get(CSS_PATH, (c) => {
-  return c.body(CSS, 200, {
-    "Content-Type": "text/css; charset=utf-8",
-    "Cache-Control": "public, max-age=31536000, immutable",
-  });
-});
-
-app.get(JS_PATH, (c) => {
-  return c.body(JS, 200, {
-    "Content-Type": "application/javascript; charset=utf-8",
-    "Cache-Control": "public, max-age=31536000, immutable",
-  });
-});
-
-app.get("/favicon.svg", (c) => {
-  return c.body(FAVICON_SVG, 200, {
-    "Content-Type": "image/svg+xml",
-    "Cache-Control": "public, max-age=86400",
-  });
-});
-
-app.get("/manifest.webmanifest", (c) => {
-  return c.body(webManifest(), 200, {
-    "Content-Type": "application/manifest+json",
-    "Cache-Control": "public, max-age=86400",
-  });
-});
-
-app.get("/favicon.ico", (c) => {
-  const buf = Uint8Array.from(atob(FAVICON_ICO_BASE64), (ch) =>
-    ch.charCodeAt(0),
-  );
-  return c.body(buf, 200, {
-    "Content-Type": "image/x-icon",
-    "Cache-Control": "public, max-age=86400",
-  });
-});
-
-app.get("/apple-touch-icon.png", (c) => {
-  const buf = Uint8Array.from(atob(APPLE_TOUCH_ICON_BASE64), (ch) =>
-    ch.charCodeAt(0),
-  );
-  return c.body(buf, 200, {
-    "Content-Type": "image/png",
-    "Cache-Control": "public, max-age=86400",
-  });
-});
-
-app.get("/icon-192.png", (c) => {
-  const buf = Uint8Array.from(atob(ICON_192_BASE64), (ch) => ch.charCodeAt(0));
-  return c.body(buf, 200, {
-    "Content-Type": "image/png",
-    "Cache-Control": "public, max-age=86400",
-  });
-});
-
-app.get("/icon-512.png", (c) => {
-  const buf = Uint8Array.from(atob(ICON_512_BASE64), (ch) => ch.charCodeAt(0));
-  return c.body(buf, 200, {
-    "Content-Type": "image/png",
-    "Cache-Control": "public, max-age=86400",
-  });
-});
-
-app.get("/health", (c) => {
-  return c.json({ status: "ok", timestamp: new Date().toISOString() });
 });
 
 // RFC 9727 API catalog — agents discover this via the Link header on HTML
@@ -1064,84 +930,6 @@ app.get("/llms.txt", (c) => {
   return c.body(LLMS_TXT, 200, {
     "Content-Type": "text/plain; charset=utf-8",
     "Cache-Control": "public, max-age=3600",
-  });
-});
-
-// Crawl guidance for search engines. Block the API namespace (Google was
-// logging `/api/check?domain=dmarc.mx` as "Crawled - currently not indexed"
-// noise) and CSV export URLs (each crawl triggers a full live DNS scan; the
-// X-Robots-Tag: noindex on text/csv stops indexing but not crawling, #521),
-// and point to the sitemap. `/*format=csv` uses only Google-supported
-// wildcards and cannot match plain /check?domain=X pages because `=` is
-// rejected by normalizeDomain.
-app.get("/robots.txt", (c) => {
-  const body = `User-agent: *
-Allow: /
-Disallow: /api/
-Disallow: /*format=csv
-Sitemap: https://dmarc.mx/sitemap.xml
-`;
-  return c.body(body, 200, {
-    "Content-Type": "text/plain; charset=utf-8",
-    "Cache-Control": "public, max-age=86400",
-  });
-});
-
-// Static URLs worth reinforcing to search engines. The /check entries are
-// generated from the curated allowlist in src/shared/indexable-domains.ts —
-// every domain listed there is also marked indexable on its scan page, so
-// the sitemap and the per-page robots meta stay in sync.
-const STATIC_SITEMAP_URLS: Array<{ loc: string; priority: string }> = [
-  { loc: "https://dmarc.mx/", priority: "1.0" },
-  { loc: "https://dmarc.mx/pricing", priority: "0.9" },
-  { loc: "https://dmarc.mx/scoring", priority: "0.8" },
-  { loc: "https://dmarc.mx/legal/privacy", priority: "0.3" },
-  { loc: "https://dmarc.mx/learn", priority: "0.7" },
-  { loc: "https://dmarc.mx/learn/dmarc", priority: "0.8" },
-  { loc: "https://dmarc.mx/learn/spf", priority: "0.8" },
-  { loc: "https://dmarc.mx/learn/dkim", priority: "0.7" },
-  { loc: "https://dmarc.mx/learn/bimi", priority: "0.6" },
-  { loc: "https://dmarc.mx/learn/mta-sts", priority: "0.7" },
-  { loc: "https://dmarc.mx/learn/security-txt", priority: "0.6" },
-  { loc: "https://dmarc.mx/learn/tls-rpt", priority: "0.6" },
-  { loc: "https://dmarc.mx/learn/dnssec", priority: "0.7" },
-  { loc: "https://dmarc.mx/learn/dane", priority: "0.6" },
-  { loc: "https://dmarc.mx/mx", priority: "0.7" },
-  { loc: "https://dmarc.mx/mx/outlook", priority: "0.8" },
-  { loc: "https://dmarc.mx/mx/google", priority: "0.8" },
-  { loc: "https://dmarc.mx/mx/mimecast", priority: "0.7" },
-  { loc: "https://dmarc.mx/mx/proofpoint", priority: "0.7" },
-  { loc: "https://dmarc.mx/mx/fastmail", priority: "0.6" },
-  { loc: "https://dmarc.mx/mx/zoho", priority: "0.6" },
-  { loc: "https://dmarc.mx/mx/amazon-ses", priority: "0.6" },
-  { loc: "https://dmarc.mx/mx/cloudflare", priority: "0.6" },
-  { loc: "https://dmarc.mx/llms.txt", priority: "0.2" },
-];
-const SITEMAP_LASTMOD = "2026-05-24";
-
-function buildSitemapUrls(): Array<{ loc: string; priority: string }> {
-  const scanUrls = listIndexableScanDomains().map((domain) => ({
-    loc: `https://dmarc.mx/check?domain=${encodeURIComponent(domain)}`,
-    priority: "0.6",
-  }));
-  return [...STATIC_SITEMAP_URLS, ...scanUrls];
-}
-
-app.get("/sitemap.xml", (c) => {
-  const urls = buildSitemapUrls()
-    .map(
-      ({ loc, priority }) =>
-        `  <url><loc>${loc}</loc><lastmod>${SITEMAP_LASTMOD}</lastmod><priority>${priority}</priority></url>`,
-    )
-    .join("\n");
-  const body = `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-${urls}
-</urlset>
-`;
-  return c.body(body, 200, {
-    "Content-Type": "application/xml; charset=utf-8",
-    "Cache-Control": "public, max-age=86400",
   });
 });
 

--- a/src/routes/static.ts
+++ b/src/routes/static.ts
@@ -1,0 +1,223 @@
+import { Hono } from "hono";
+import { listIndexableScanDomains } from "../shared/indexable-domains.js";
+import { CSS_PATH, JS_PATH } from "../views/assets.js";
+import {
+  APPLE_TOUCH_ICON_BASE64,
+  FAVICON_ICO_BASE64,
+  FAVICON_SVG,
+  ICON_192_BASE64,
+  ICON_512_BASE64,
+  OG_IMAGE_PNG_BASE64,
+  webManifest,
+} from "../views/favicon.js";
+import { JS } from "../views/scripts.js";
+import { CSS } from "../views/styles.js";
+
+// Static assets, health check, and crawler-facing infrastructure — mounted at
+// "/" by src/index.ts. No auth, no rate limiting, no user-input validation:
+// every handler here returns a fixed or precomputed body, which is why this
+// group can live outside the CODEOWNERS-gated wiring file (#661).
+export const staticRoutes = new Hono();
+
+staticRoutes.get("/logo.svg", (c) => {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" version="1.2" baseProfile="tiny-ps" viewBox="0 0 512 512">
+  <title>dmarcheck</title>
+  <rect width="512" height="512" rx="64" fill="#0a0a0a"/>
+  <text x="256" y="310" font-family="monospace" font-size="220" fill="#f97316" text-anchor="middle">@</text>
+  <circle cx="210" cy="210" r="28" fill="white"/>
+  <circle cx="302" cy="210" r="28" fill="white"/>
+  <circle cx="216" cy="218" r="14" fill="#0a0a0f"/>
+  <circle cx="308" cy="218" r="14" fill="#0a0a0f"/>
+  <rect x="196" y="380" width="20" height="40" rx="8" fill="#ea580c"/>
+  <rect x="246" y="380" width="20" height="32" rx="8" fill="#ea580c"/>
+  <rect x="296" y="380" width="20" height="40" rx="8" fill="#ea580c"/>
+</svg>`;
+  return c.body(svg, 200, {
+    "Content-Type": "image/svg+xml",
+    "Cache-Control": "public, max-age=86400",
+  });
+});
+
+staticRoutes.get("/og-image.svg", (c) => {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <rect width="1200" height="630" fill="#0a0a0f"/>
+  <!-- Creature -->
+  <text x="340" y="310" font-family="monospace" font-size="180" fill="#f97316" text-anchor="middle">@</text>
+  <circle cx="300" cy="220" r="22" fill="white"/>
+  <circle cx="375" cy="220" r="22" fill="white"/>
+  <circle cx="305" cy="226" r="11" fill="#0a0a0f"/>
+  <circle cx="380" cy="226" r="11" fill="#0a0a0f"/>
+  <rect x="290" y="370" width="16" height="32" rx="6" fill="#ea580c"/>
+  <rect x="330" y="370" width="16" height="26" rx="6" fill="#ea580c"/>
+  <rect x="370" y="370" width="16" height="32" rx="6" fill="#ea580c"/>
+  <!-- Wordmark -->
+  <text x="500" y="300" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif" font-weight="800" font-size="72">
+    <tspan fill="#e4e4e7">dmar</tspan><tspan fill="#f97316">check</tspan>
+  </text>
+  <!-- Tagline -->
+  <text x="500" y="350" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif" font-size="24" fill="#71717a">DNS Email Security Analyzer</text>
+  <!-- BIMI badge -->
+  <text x="500" y="400" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif" font-size="18" fill="#f97316">Meet DMarcus — your email security sidekick</text>
+</svg>`;
+  return c.body(svg, 200, {
+    "Content-Type": "image/svg+xml",
+    "Cache-Control": "public, max-age=86400",
+  });
+});
+
+staticRoutes.get("/og-image.png", (c) => {
+  const buf = Uint8Array.from(atob(OG_IMAGE_PNG_BASE64), (ch) =>
+    ch.charCodeAt(0),
+  );
+  return c.body(buf, 200, {
+    "Content-Type": "image/png",
+    "Cache-Control": "public, max-age=86400",
+  });
+});
+
+// Content-hashed static assets with immutable caching
+staticRoutes.get(CSS_PATH, (c) => {
+  return c.body(CSS, 200, {
+    "Content-Type": "text/css; charset=utf-8",
+    "Cache-Control": "public, max-age=31536000, immutable",
+  });
+});
+
+staticRoutes.get(JS_PATH, (c) => {
+  return c.body(JS, 200, {
+    "Content-Type": "application/javascript; charset=utf-8",
+    "Cache-Control": "public, max-age=31536000, immutable",
+  });
+});
+
+staticRoutes.get("/favicon.svg", (c) => {
+  return c.body(FAVICON_SVG, 200, {
+    "Content-Type": "image/svg+xml",
+    "Cache-Control": "public, max-age=86400",
+  });
+});
+
+staticRoutes.get("/manifest.webmanifest", (c) => {
+  return c.body(webManifest(), 200, {
+    "Content-Type": "application/manifest+json",
+    "Cache-Control": "public, max-age=86400",
+  });
+});
+
+staticRoutes.get("/favicon.ico", (c) => {
+  const buf = Uint8Array.from(atob(FAVICON_ICO_BASE64), (ch) =>
+    ch.charCodeAt(0),
+  );
+  return c.body(buf, 200, {
+    "Content-Type": "image/x-icon",
+    "Cache-Control": "public, max-age=86400",
+  });
+});
+
+staticRoutes.get("/apple-touch-icon.png", (c) => {
+  const buf = Uint8Array.from(atob(APPLE_TOUCH_ICON_BASE64), (ch) =>
+    ch.charCodeAt(0),
+  );
+  return c.body(buf, 200, {
+    "Content-Type": "image/png",
+    "Cache-Control": "public, max-age=86400",
+  });
+});
+
+staticRoutes.get("/icon-192.png", (c) => {
+  const buf = Uint8Array.from(atob(ICON_192_BASE64), (ch) => ch.charCodeAt(0));
+  return c.body(buf, 200, {
+    "Content-Type": "image/png",
+    "Cache-Control": "public, max-age=86400",
+  });
+});
+
+staticRoutes.get("/icon-512.png", (c) => {
+  const buf = Uint8Array.from(atob(ICON_512_BASE64), (ch) => ch.charCodeAt(0));
+  return c.body(buf, 200, {
+    "Content-Type": "image/png",
+    "Cache-Control": "public, max-age=86400",
+  });
+});
+
+staticRoutes.get("/health", (c) => {
+  return c.json({ status: "ok", timestamp: new Date().toISOString() });
+});
+
+// Crawl guidance for search engines. Block the API namespace (Google was
+// logging `/api/check?domain=dmarc.mx` as "Crawled - currently not indexed"
+// noise) and CSV export URLs (each crawl triggers a full live DNS scan; the
+// X-Robots-Tag: noindex on text/csv stops indexing but not crawling, #521),
+// and point to the sitemap. `/*format=csv` uses only Google-supported
+// wildcards and cannot match plain /check?domain=X pages because `=` is
+// rejected by normalizeDomain.
+staticRoutes.get("/robots.txt", (c) => {
+  const body = `User-agent: *
+Allow: /
+Disallow: /api/
+Disallow: /*format=csv
+Sitemap: https://dmarc.mx/sitemap.xml
+`;
+  return c.body(body, 200, {
+    "Content-Type": "text/plain; charset=utf-8",
+    "Cache-Control": "public, max-age=86400",
+  });
+});
+
+// Static URLs worth reinforcing to search engines. The /check entries are
+// generated from the curated allowlist in src/shared/indexable-domains.ts —
+// every domain listed there is also marked indexable on its scan page, so
+// the sitemap and the per-page robots meta stay in sync.
+const STATIC_SITEMAP_URLS: Array<{ loc: string; priority: string }> = [
+  { loc: "https://dmarc.mx/", priority: "1.0" },
+  { loc: "https://dmarc.mx/pricing", priority: "0.9" },
+  { loc: "https://dmarc.mx/scoring", priority: "0.8" },
+  { loc: "https://dmarc.mx/legal/privacy", priority: "0.3" },
+  { loc: "https://dmarc.mx/learn", priority: "0.7" },
+  { loc: "https://dmarc.mx/learn/dmarc", priority: "0.8" },
+  { loc: "https://dmarc.mx/learn/spf", priority: "0.8" },
+  { loc: "https://dmarc.mx/learn/dkim", priority: "0.7" },
+  { loc: "https://dmarc.mx/learn/bimi", priority: "0.6" },
+  { loc: "https://dmarc.mx/learn/mta-sts", priority: "0.7" },
+  { loc: "https://dmarc.mx/learn/security-txt", priority: "0.6" },
+  { loc: "https://dmarc.mx/learn/tls-rpt", priority: "0.6" },
+  { loc: "https://dmarc.mx/learn/dnssec", priority: "0.7" },
+  { loc: "https://dmarc.mx/learn/dane", priority: "0.6" },
+  { loc: "https://dmarc.mx/mx", priority: "0.7" },
+  { loc: "https://dmarc.mx/mx/outlook", priority: "0.8" },
+  { loc: "https://dmarc.mx/mx/google", priority: "0.8" },
+  { loc: "https://dmarc.mx/mx/mimecast", priority: "0.7" },
+  { loc: "https://dmarc.mx/mx/proofpoint", priority: "0.7" },
+  { loc: "https://dmarc.mx/mx/fastmail", priority: "0.6" },
+  { loc: "https://dmarc.mx/mx/zoho", priority: "0.6" },
+  { loc: "https://dmarc.mx/mx/amazon-ses", priority: "0.6" },
+  { loc: "https://dmarc.mx/mx/cloudflare", priority: "0.6" },
+  { loc: "https://dmarc.mx/llms.txt", priority: "0.2" },
+];
+const SITEMAP_LASTMOD = "2026-05-24";
+
+function buildSitemapUrls(): Array<{ loc: string; priority: string }> {
+  const scanUrls = listIndexableScanDomains().map((domain) => ({
+    loc: `https://dmarc.mx/check?domain=${encodeURIComponent(domain)}`,
+    priority: "0.6",
+  }));
+  return [...STATIC_SITEMAP_URLS, ...scanUrls];
+}
+
+staticRoutes.get("/sitemap.xml", (c) => {
+  const urls = buildSitemapUrls()
+    .map(
+      ({ loc, priority }) =>
+        `  <url><loc>${loc}</loc><lastmod>${SITEMAP_LASTMOD}</lastmod><priority>${priority}</priority></url>`,
+    )
+    .join("\n");
+  const body = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
+</urlset>
+`;
+  return c.body(body, 200, {
+    "Content-Type": "application/xml; charset=utf-8",
+    "Cache-Control": "public, max-age=86400",
+  });
+});


### PR DESCRIPTION
## Summary

- PR 1 of N splitting `src/index.ts` (#661) into `src/routes/*`. Extracts the no-auth, no-validation, no-rate-limit routes — logo/OG/favicon/icon assets, content-hashed CSS/JS, `/health`, `/robots.txt`, `/sitemap.xml` — into a new `src/routes/static.ts` Hono sub-router, mounted via `app.route("/", staticRoutes)`.
- Matches the extraction pattern already established by `authRoutes`/`dashboardRoutes`/`stripeWebhookRoutes`. Chose this group first because it has zero security surface (no auth, no user input, no rate limiting), making it the lowest-risk way to prove the pattern before moving riskier groups.
- Behavior-preserving: every extracted handler is byte-for-byte identical (same path, status, headers, body); only the module it lives in changed.

## Owner / zone steps

None.

## Security notes

None. This PR moves code, it doesn't add or remove any input validation, auth, or rate-limiting logic — none of the extracted routes touch any of those. `src/index.ts` is CODEOWNERS-gated, so this PR is opened for human review rather than auto-merge.

## Testing

- `npm run typecheck` — clean.
- `npm run lint` — clean (189 files checked, no fixes needed).
- `npm test` — 1500 passing (same as base branch), 0 test files edited. The 1 failing test (`test/integration/mta-sts-runtime.test.ts`) is a pre-existing, unrelated live-network integration test — it fails identically on `main` in this sandbox (no outbound access to fetch dmarc.mx's real MTA-STS policy), confirmed via `git stash`.

## Choices made

- New file grouped as "static" (assets + health + SEO/crawler infra) rather than exactly mirroring the issue's example groups (scan/account/billing/inbox/api/dashboard) — those already have dedicated modules or are covered by the follow-up issues below; "static" is the natural first slice since it's the only group with zero security-relevant logic.
- Mounted at `app.route("/", staticRoutes)` (root prefix) since these are independent top-level paths, same pattern Hono supports and already implied by how `app` composes sub-routers.

## Deferred

Per #661's explicit instruction to do this "in several PRs, one area at a time," the rest of the split is filed as follow-up issues (all "Part of #661"):
- #665 — agent-discovery / API-surface endpoints
- #666 — marketing/content pages
- #667 — core scan routes
- #668 — inbox test-email routes
- #669 — rate-limit wiring + input-validation primitives → gated module (the piece #661 calls out by name)

The final #661 acceptance criterion (a throwaway PR demonstrating a route-only change touches no CODEOWNERS-gated path) requires all of the above plus the CODEOWNERS narrowing in #659 to land first — not shippable from this PR alone.

## Refs

Part of #661


---
_Generated by [Claude Code](https://claude.ai/code/session_016kb18UugnzA1BC322yeikF)_