### PR TITLE
ci: exempt the Claude Code agent identity from DCO, as Cursor's already is

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -79,8 +79,16 @@ jobs:
             # Skip automated commits that cannot run `git commit -s`.
             # Skip commits whose author name contains [bot], is github-actions,
             # or carries a known coding-agent author email (Cursor's cloud
-            # agent authors as "Cursor Agent" with no [bot] suffix, so the
-            # name heuristics miss it — see PR #494/#513).
+            # agent authors as "Cursor Agent" with no [bot] suffix, and Claude
+            # Code's routines author as "Claude", so the name heuristics miss
+            # both — see PR #494/#513 for Cursor, #663/#671/#672 for Claude).
+            #
+            # These are PROVENANCE exemptions, not a security control. Anyone can
+            # set their git author email to one of these strings; the guard that
+            # actually matters is that these identities can only push through a
+            # token this repo issued. Keep the list to no-reply addresses on
+            # vendor-controlled domains, which no human contributor would
+            # legitimately author from.
             if echo "$author_name" | grep -qF '[bot]'; then
               echo "SKIP $sha — bot name ($author_name)"
               continue
@@ -91,6 +99,10 @@ jobs:
             fi
             if [ "$author_email" = "cursoragent@cursor.com" ]; then
               echo "SKIP $sha — Cursor agent author"
+              continue
+            fi
+            if [ "$author_email" = "noreply@anthropic.com" ]; then
+              echo "SKIP $sha — Claude Code agent author"
               continue
             fi
 


### PR DESCRIPTION
Every PR the autonomous single-issue routine opens fails DCO. Three are red on it right now — #663, #671, #672 — and it is a **deadlock the routine cannot escape by itself**.

## Why

The routine authors as `Claude <noreply@anthropic.com>`, which matches none of the three existing exemptions in `.github/workflows/dco.yml`:

```
[bot] in author name  ·  github-actions  ·  cursoragent@cursor.com
```

It cannot run `git commit -s` on its own behalf any more than the Cursor agent can — which is exactly why `cursoragent@cursor.com` was added in #494/#513. This is the same case, one vendor later.

The deadlock: the fix lives in `.github/workflows/`, which is CODEOWNERS-gated, **and** the routine's own operating rules bar it from modifying CI config. So it cannot unblock itself no matter how many times it fires. It needs a human-authored PR — this one.

Anticipated in the software factory design spec §12.4 ("register the identity in `dco.yml`'s bot allowlist beside `cursoragent@cursor.com`"). It only became load-bearing now that something is actually generating agent PRs.

## Verification

Replayed the patched conditions against the **real** commits on the three blocked PRs, plus the current head of `main` as a control:

| Commit | Author | Verdict |
|---|---|---|
| `34487fc5` (#663) | `Claude <noreply@anthropic.com>` | SKIP (Claude Code) |
| `d28618d5` (#671) | `Claude <noreply@anthropic.com>` | SKIP (Claude Code) |
| `cbad7b05` (#672) | `Claude <noreply@anthropic.com>` | SKIP (Claude Code) |
| `faa1dacd` (main) | `schmug <…@users.noreply.github.com>` | **REQUIRES SIGN-OFF** |

The exemption unblocks the agent and does not widen to human contributors.

## What else changed

The comment block now states what this list actually is: a **provenance** exemption, not a security control. Anyone can set their git author email to one of these strings — what actually gates the push is the token this repo issued. Keeping the list to no-reply addresses on vendor-controlled domains is the invariant worth writing down for whoever adds the next entry.

## Scope

One file, one new condition, plus comments. No change to the signing requirement for anyone else, no change to the merge-commit or `[bot]` heuristics, no change to `CODEOWNERS`.

## Note

This PR touches `.github/workflows/`, so it needs your approving review by design — the same CODEOWNERS rule whose rationale is "a PR could otherwise rewrite its own merge gate."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
