### PR TITLE
ci(release): guard the five steps below the skip block, and stop signing the wrong release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,10 +87,21 @@ jobs:
           gh release create "$VERSION" --title "$VERSION" --notes "$NOTES" sbom.cdx.json
 
       - name: Generate SHA256SUMS
+        if: steps.check.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
+          set -euo pipefail
+          # Backstop for the guard above. `gh release download ""` does NOT error — it falls back
+          # to the LATEST release, so an empty VERSION silently digests the wrong tag's archives.
+          # This is the failure mode that hid behind a red X from 2026-07-06: the step ran on
+          # skipped releases and only died because sbom.cdx.json was absent. If it had existed,
+          # this workflow would have signed and published a SHA256SUMS for the wrong release.
+          if [ -z "${VERSION:-}" ]; then
+            echo "::error::VERSION is empty — the release was skipped but this step ran anyway, which means a step below the guarded block is missing its skip guard."
+            exit 1
+          fi
           SLUG="schmug/dmarcheck"
           # Download the auto-generated source archives GitHub creates for each release tag.
           # These may take a few seconds to appear; retry once if the first attempt fails.
@@ -107,6 +118,7 @@ jobs:
             "dmarcheck-${VERSION}.zip" > SHA256SUMS
 
       - name: Install cosign (Sigstore)
+        if: steps.check.outputs.skip != 'true'
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
           # Pin the cosign CLI explicitly so the signing binary can't silently
@@ -115,10 +127,12 @@ jobs:
           cosign-release: 'v3.0.6'
 
       - name: Sign SHA256SUMS with Sigstore keyless signing
+        if: steps.check.outputs.skip != 'true'
         run: |
           cosign sign-blob --yes SHA256SUMS --bundle SHA256SUMS.bundle
 
       - name: Upload SHA256SUMS and signature bundle
+        if: steps.check.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
@@ -126,6 +140,7 @@ jobs:
           gh release upload "$VERSION" SHA256SUMS SHA256SUMS.bundle
 
       - name: Verify SHA256SUMS signature (post-release smoke)
+        if: steps.check.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
@@ -145,3 +160,8 @@ jobs:
             --certificate-identity-regexp "https://github.com/schmug/dmarcheck/.github/workflows/release.yml" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
             verify-SHA256SUMS
+          # A valid signature over the WRONG file still verifies. Bind the attestation to THIS
+          # release by asserting the digested archive names carry this version.
+          grep -q "dmarcheck-${VERSION}.tar.gz" verify-SHA256SUMS \
+            && grep -q "dmarcheck-${VERSION}.zip" verify-SHA256SUMS \
+            || { echo "::error::SHA256SUMS does not describe ${VERSION} — refusing to vouch for it."; exit 1; }


### PR DESCRIPTION
`Release` has failed on **every push to `main` since 2026-07-06**. The standing red X was hiding a supply-chain integrity bug, not just noise.

## What happens

`Check for releasable commits` correctly sets `skip=true` when everything since the last tag is deps/chore. Every step through `Create GitHub Release` carries `if: steps.check.outputs.skip != 'true'`. **The five steps below it never got the guard.**

From run [31097645246](https://github.com/schmug/dmarcheck/actions/runs/31097645246):

```
success  Check for releasable commits     "Skipping release — all commits since v2026.8.3 are deps/chore only"
skipped  Generate CycloneDX SBOM          ← guarded
skipped  Create GitHub Release            ← guarded
failure  Generate SHA256SUMS              ← NO GUARD, ran with VERSION: (empty)
skipped  Install cosign (Sigstore)        ← NO GUARD
skipped  Sign SHA256SUMS                  ← NO GUARD
skipped  Upload SHA256SUMS                ← NO GUARD
skipped  Verify SHA256SUMS signature      ← NO GUARD
```

The four below the failure only *look* guarded — they skip because the job already failed (implicit `success()`), not by design. Guard only the failing step and they would start running on skipped releases.

## Why it is worse than a red check

**`gh release download ""` does not error — it falls back to the LATEST release.**

Proof from that run: `sha256sum` prints one error line per missing file, and printed **exactly one**, for `sbom.cdx.json`. So both source archives downloaded successfully — from `v2026.8.3`, a release that run had nothing to do with.

The step failed *only* because the SBOM was absent. Had `sbom.cdx.json` existed for any reason, this workflow would have:

1. digested the wrong release's source archives,
2. Sigstore-signed the result,
3. uploaded it as `SHA256SUMS`, and
4. **passed its own verification smoke test** — because that test proves the signature is valid, never that the digests match the tag being released.

A workflow whose entire purpose is supply-chain integrity would have published a cryptographically valid attestation for the wrong artifacts, and reported success.

## Changes

| | |
|---|---|
| **The fix** | `if: steps.check.outputs.skip != 'true'` on all five trailing steps |
| **Backstop** | `Generate SHA256SUMS` now fails loudly on an empty `VERSION` instead of silently digesting the latest release. The guard is the fix; this catches whoever appends a sixth step below the guarded block |
| **Smoke test** | Bound to the release — asserts `SHA256SUMS` actually names this version's archives. A valid signature over the wrong file still verifies |

+20 lines, one file, no behaviour change on a real release.

## Verification

- YAML parses.
- All **nine** shell blocks pass `bash -n`.
- The empty-`VERSION` backstop emits its `::error::` and exits 1 when run with `VERSION` unset.

Cannot be end-to-end tested without a real release; the next deps-only push to `main` should show `Release` skipping cleanly instead of failing, and the next releasable push exercises the full path.

## Note

This is the same shape as a defect found in the software factory's own `factory.yml` earlier today — a guarded block that someone appended to without extending the guard. That one now has shape-tests asserting the guard chain; `release.yml` has none, and a test that every step after `Check for releasable commits` carries the skip guard would have caught this a month ago.

Worth knowing for the factory: gate condition 8 rejects `UNSTABLE`, and a chronically-red non-required workflow on `main` is one way PRs end up there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
