### PR TITLE
ci(release): verify against the current repo name — the rename broke Sigstore

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
             echo "::error::VERSION is empty — the release was skipped but this step ran anyway, which means a step below the guarded block is missing its skip guard."
             exit 1
           fi
-          SLUG="schmug/dmarcheck"
+          SLUG="${{ github.repository }}"
           # Download the auto-generated source archives GitHub creates for each release tag.
           # These may take a few seconds to appear; retry once if the first attempt fails.
           gh release download "$VERSION" --repo "$SLUG" --archive=tar.gz \
@@ -145,7 +145,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          SLUG="schmug/dmarcheck"
+          SLUG="${{ github.repository }}"
           # Download the just-uploaded files; retry once for asset-propagation lag.
           gh release download "$VERSION" --repo "$SLUG" \
             --pattern "SHA256SUMS" --output verify-SHA256SUMS || \
@@ -155,9 +155,18 @@ jobs:
             --pattern "SHA256SUMS.bundle" --output verify-SHA256SUMS.bundle || \
           gh release download "$VERSION" --repo "$SLUG" \
             --pattern "SHA256SUMS.bundle" --output verify-SHA256SUMS.bundle
+          # The SAN carries the repo name AT SIGNING TIME. schmug/dmarcheck was renamed to
+          # schmug/dmarc.mx, so a regex pinned to the old name rejects every new signature —
+          # this is what turned Release red on releasable commits (the missing skip guard,
+          # fixed in #678, covered the non-releasable ones). Both names are accepted so that
+          # re-verifying a pre-rename tag still passes. Deliberately a LITERAL alternation
+          # rather than ${{ github.repository }}: this asserts WHICH identities we trust, and
+          # sourcing that from the same context the workload runs in would let a rename
+          # silently redefine the trust anchor instead of failing loudly. Dots are escaped —
+          # unescaped, `dmarc.mx` also matches `dmarcXmx`.
           cosign verify-blob \
             --bundle verify-SHA256SUMS.bundle \
-            --certificate-identity-regexp "https://github.com/schmug/dmarcheck/.github/workflows/release.yml" \
+            --certificate-identity-regexp "https://github\.com/schmug/(dmarcheck|dmarc\.mx)/\.github/workflows/release\.yml" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
             verify-SHA256SUMS
           # A valid signature over the WRONG file still verifies. Bind the attestation to THIS


### PR DESCRIPTION
`schmug/dmarcheck` was renamed to **`schmug/dmarc.mx`**. Sigstore stamps the repo name *at signing time* into the certificate SAN, but the verification regex still pins the old name, so `cosign verify-blob` rejects every new signature.

From run [31099380422](https://github.com/schmug/dmarcheck/actions/runs/31099380422), on the merge of #678:

```
expected  https://github.com/schmug/dmarcheck/.github/workflows/release.yml
got       https://github.com/schmug/dmarc.mx/.github/workflows/release.yml@refs/heads/main
```

## This is the second of two independent bugs

`Release` has been red on **every** push since 2026-07-06, and the two halves failed for different reasons:

| Commit type | Failure | Fixed by |
|---|---|---|
| non-releasable (deps/chore) | `Generate SHA256SUMS` ran unguarded with an empty `VERSION` | #678 |
| releasable | `cosign verify-blob` rejects the renamed identity | **this PR** |

Fixing the first is what made the second visible. That run got all the way through `Generate SHA256SUMS` → `Sign` → `Upload` before failing at the smoke test — steps that had never once been reached.

## Why it hid for a month

The two `SLUG="schmug/dmarcheck"` lines were **not** the cause. `gh` follows GitHub's rename redirect, so they still work today. Only cosign — comparing an exact cryptographic identity — has no redirect to save it.

They become `${{ github.repository }}` here anyway, so a future rename cannot desync them.

## The identity stays a literal alternation, deliberately

```
https://github\.com/schmug/(dmarcheck|dmarc\.mx)/\.github/workflows/release\.yml
```

Not `${{ github.repository }}`. This line asserts **which identities we trust**, and sourcing that from the same context the workload runs in would let a rename silently redefine the trust anchor rather than fail loudly. A trust anchor that auto-follows its subject is not a trust anchor.

Both names are accepted so re-verifying a pre-rename tag still passes. Dots are escaped — unescaped, `dmarc.mx` also matches `dmarcXmx`.

## Not affected

**`v2026.8.4` is correctly published and signed.** Its `SHA256SUMS` names `dmarcheck-v2026.8.4.tar.gz` and `.zip`, so the binding check added in #678 passes. Only the post-release smoke test could not verify it. No artifact needs re-signing.

## Verification

- YAML parses; all **9** shell blocks pass `bash -n`.
- The identity regex was tested against the **actual SAN** from run 31099380422 plus five negative cases:

| Case | Result |
|---|---|
| real SAN, `dmarc.mx` | matches |
| pre-rename `dmarcheck` | matches |
| different owner (`evil/dmarc.mx`) | rejected |
| `dmarcXmx` (unescaped-dot bypass) | rejected |
| different workflow (`deploy.yml`) | rejected |
| `githubXcom` (unescaped-dot bypass) | rejected |

Full end-to-end confirmation needs one more releasable commit — merging this is itself one, so its own `Release` run is the test.

## Note

Two independent bugs sat in a supply-chain workflow for a month behind a single red X, and neither was findable without fixing the other first. Worth remembering when triaging a standing failure: a red check can mask a second red check.

`.github/workflows/**` is on the software factory's mandatory denylist, so the factory would never auto-merge a change here — the right call for a file whose worst failure mode is "valid signature, wrong artifacts."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
