### PR TITLE
feat: add a production rollback lever (#657)

### DIFF
--- a/.factory/README.md
+++ b/.factory/README.md
@@ -22,9 +22,12 @@ anything today** and that is deliberate. Three independent things still gate it:
    @schmug**. GitHub forbids self-approval, so a token acting as the code owner can never satisfy
    the `require_code_owner_review` rule on `main-protection`. Until that identity exists the
    `advance` and `land` jobs cannot run.
-3. **There is no rollback lever.** Production deploys currently leave GitHub entirely via the
-   Cloudflare Git integration, so a bad auto-merged change cannot be reverted from here. A factory
-   without a revert path is not a factory.
+3. **The rollback lever is built but undrilled.** `.github/workflows/rollback.yml` (#657) gives
+   production a revert path from GitHub: `pin-version` shifts traffic back to a previous Worker
+   version in seconds with no PR and no review, and `revert-commit` opens the `revert:` PR that
+   makes it durable. Runbook: [docs/rollback.md](../docs/rollback.md). **It has not yet been
+   exercised against production**, and an untested rollback lever is not a rollback lever — run
+   the drill in the runbook and record it on #657 before treating this blocker as cleared.
 
 Do not raise `allowlistAuthors` off a reviewed list, and do not set `requireFixtureEvidence: true`,
 until those are resolved.

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -1,0 +1,406 @@
+name: Rollback
+
+# The production revert path (#657).
+#
+# Production deploys leave GitHub entirely: a merge to `main` is picked up by
+# the Cloudflare Git integration (Workers Builds), so no Actions run owns the
+# deploy, there is no job to re-run and no artifact to roll back to.
+# `prod-smoke.yml` can DETECT a bad deploy but cannot undo one. This workflow
+# is the undo.
+#
+# It offers three actions, deliberately ordered fastest-first:
+#
+#   inspect        (default, READ-ONLY) — what is live right now, and which
+#                  versions are eligible to roll back to. Always run this
+#                  first; the version ids it prints are the input to the next
+#                  step.
+#
+#   pin-version    (SECONDS, no PR, no review) — `wrangler rollback` shifts
+#                  100% of traffic to a previously-uploaded Worker version.
+#                  This is the emergency lever. It touches no git history and
+#                  is therefore subject to no branch protection, no required
+#                  check and no CODEOWNERS review.
+#
+#   revert-commit  (MINUTES, needs a PR) — opens a `revert:` PR against main.
+#                  This is the DURABLE half: a version pin is undone by the
+#                  very next push to main, because that push triggers a fresh
+#                  Git-integration deploy which becomes the active version.
+#                  Until the revert lands, main still contains the bad code.
+#
+# The two are complements, not alternatives. Real incident order is
+# inspect → pin-version (stop the bleeding) → revert-commit (make it stick).
+# See docs/rollback.md for the full runbook and its preconditions.
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "What to do (start with inspect)"
+        type: choice
+        required: true
+        default: inspect
+        options:
+          - inspect
+          - pin-version
+          - revert-commit
+      version_id:
+        description: "pin-version: Worker version UUID from inspect. Blank = the version uploaded before the current one."
+        type: string
+        required: false
+        default: ""
+      commit:
+        description: "revert-commit: the SHA on main to revert (7-40 hex chars)."
+        type: string
+        required: false
+        default: ""
+      reason:
+        description: "Why we are rolling back. Recorded in the Cloudflare deployment message and the PR body."
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+# One rollback at a time. Never cancel one in flight — a half-applied traffic
+# shift is worse than a queued one.
+concurrency:
+  group: rollback
+  cancel-in-progress: false
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # READ-ONLY. Safe to run at any time, including as the first step of a drill.
+  # ---------------------------------------------------------------------------
+  inspect:
+    if: ${{ inputs.action == 'inspect' || inputs.action == 'pin-version' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          cache: "npm"
+      - run: npm ci
+
+      # Fail fast and legibly rather than letting wrangler emit a generic auth
+      # error five steps later, mid-incident.
+      - name: Check Cloudflare credentials are present
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CLOUDFLARE_API_TOKEN:-}" ] || [ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]; then
+            echo "::error::CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID are not set. The token needs Workers Scripts:Edit on the account that owns this Worker. Use the git revert path (action: revert-commit) until they are configured."
+            exit 1
+          fi
+
+      - name: Show the active deployment
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## Active deployment"
+            echo ""
+            echo '```'
+            npx wrangler deployments status 2>&1 || echo "(wrangler deployments status failed — see the step log)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # `wrangler versions list` returns the 10 most recent versions. Cloudflare
+      # retains the last 100 for rollback purposes; if the version you need is
+      # older than the 10 shown, fetch it from the Cloudflare dashboard
+      # (Workers & Pages -> this Worker -> Deployments).
+      - name: List rollback candidates
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          npx wrangler versions list --json > versions.json 2>/dev/null || {
+            echo "::warning::--json listing failed; falling back to human-readable output."
+            {
+              echo "## Recent versions"
+              echo ""
+              echo '```'
+              npx wrangler versions list 2>&1 || true
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          }
+          {
+            echo "## Rollback candidates (10 most recent)"
+            echo ""
+            echo "| Version ID | Created | Author | Source |"
+            echo "|---|---|---|---|"
+            jq -r '.[] | "| `\(.id)` | \(.metadata.created_on // "?") | \(.metadata.author_email // "?") | \(.metadata.source // "?") |"' versions.json \
+              || echo "| (unexpected \`versions list --json\` shape — see step log) | | | |"
+            echo ""
+            echo "Re-run this workflow with **action: pin-version** and the chosen Version ID."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------------
+  # MUTATES PRODUCTION TRAFFIC. No PR, no review — that is the point.
+  # ---------------------------------------------------------------------------
+  pin-version:
+    if: ${{ inputs.action == 'pin-version' }}
+    needs: inspect
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      # gh workflow run prod-smoke.yml — verifies the rollback actually landed.
+      actions: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          cache: "npm"
+      - run: npm ci
+
+      # Every dispatch input reaches the shell through the environment, never
+      # through `${{ }}` interpolation into a run body: `reason` is free text
+      # typed into a web form by a human under stress, and this job holds a
+      # Cloudflare deploy token.
+      - name: Validate version_id
+        env:
+          VERSION_ID: ${{ inputs.version_id }}
+        run: |
+          set -euo pipefail
+          if [ -n "${VERSION_ID:-}" ] && ! printf '%s' "$VERSION_ID" | grep -qE '^[0-9a-f-]{36}$'; then
+            echo "::error::version_id must be a Worker version UUID (36 chars, hex and dashes) or blank. Got a value that does not match."
+            exit 1
+          fi
+
+      - name: Roll traffic back
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          VERSION_ID: ${{ inputs.version_id }}
+          REASON: ${{ inputs.reason }}
+          ACTOR: ${{ github.actor }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # --message is what makes `wrangler rollback` non-interactive; without
+          # it the command waits on a TTY prompt that never comes and the job
+          # burns its timeout doing nothing.
+          ROLLBACK_MESSAGE="Rollback by ${ACTOR}: ${REASON} (${RUN_URL})"
+          if [ -n "${VERSION_ID:-}" ]; then
+            echo "Rolling back to version $VERSION_ID"
+            npx wrangler rollback "$VERSION_ID" --message "$ROLLBACK_MESSAGE"
+          else
+            echo "No version_id given — rolling back to the version uploaded before the current one."
+            npx wrangler rollback --message "$ROLLBACK_MESSAGE"
+          fi
+
+      - name: Record the new active deployment
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## Traffic rolled back"
+            echo ""
+            echo '```'
+            npx wrangler deployments status 2>&1 || true
+            echo '```'
+            echo ""
+            echo "> **This is temporary.** The next push to \`main\` triggers a fresh"
+            echo "> Cloudflare Git-integration deploy, which supersedes this pin and"
+            echo "> puts the bad code back. Land the \`revert:\` PR before anything"
+            echo "> else merges — re-run this workflow with **action: revert-commit**."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Close the loop: prove the rollback actually fixed the live surface
+      # rather than assuming it did. workflow_dispatch is one of the two events
+      # GITHUB_TOKEN is still allowed to trigger, so this really does start a run.
+      - name: Trigger prod smoke against the rolled-back deploy
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh workflow run prod-smoke.yml \
+            || echo "::warning::Could not trigger prod-smoke automatically — run it manually to confirm the rollback."
+
+  # ---------------------------------------------------------------------------
+  # Opens the durable revert PR. Does not itself write to main: `main-protection`
+  # requires a PR and has an empty bypass_actors list, so nothing — including
+  # this workflow — can push to main directly.
+  # ---------------------------------------------------------------------------
+  revert-commit:
+    if: ${{ inputs.action == 'revert-commit' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Validate commit SHA
+        env:
+          COMMIT: ${{ inputs.commit }}
+        run: |
+          set -euo pipefail
+          if ! printf '%s' "$COMMIT" | grep -qE '^[0-9a-f]{7,40}$'; then
+            echo "::error::commit must be a 7-40 character lowercase hex SHA. Refusing to pass unvalidated input to git."
+            exit 1
+          fi
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          ref: main
+          # Prefer the factory identity when it exists. This matters beyond
+          # authorship: a PR opened with GITHUB_TOKEN does NOT trigger
+          # `pull_request` workflows, so CI never runs on it and the required
+          # `check` context never reports — leaving the revert PR permanently
+          # unmergeable. A PAT-opened PR triggers CI normally. Until the
+          # bot-identity split lands, the fallback path works but needs one
+          # manual nudge (close + reopen the PR); the summary below says so.
+          token: ${{ secrets.FACTORY_GH_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Create the revert branch
+        id: revert
+        env:
+          COMMIT: ${{ inputs.commit }}
+          REASON: ${{ inputs.reason }}
+          ACTOR: ${{ github.actor }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          # Resolve and confirm the target is actually on main. Reverting a SHA
+          # that never shipped would produce a nonsense diff.
+          FULL_SHA=$(git rev-parse --verify "${COMMIT}^{commit}")
+          if ! git merge-base --is-ancestor "$FULL_SHA" origin/main; then
+            echo "::error::$FULL_SHA is not an ancestor of origin/main — nothing to roll back."
+            exit 1
+          fi
+
+          SUBJECT=$(git log -1 --format=%s "$FULL_SHA")
+          SHORT_SHA=$(git rev-parse --short "$FULL_SHA")
+          BRANCH="rollback/revert-${SHORT_SHA}-${RUN_ID}"
+
+          # Author as the bot so the DCO workflow's provenance exemption applies
+          # (it skips authors whose name contains "[bot]"). A human-authored
+          # revert would need a Signed-off-by trailer this job cannot honestly
+          # produce on someone else's behalf.
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+
+          # main enforces linear history, so commits here are single-parent.
+          # Handle a merge commit anyway rather than failing obscurely.
+          PARENT_COUNT=$(( $(git rev-list --parents -n 1 "$FULL_SHA" | wc -w) - 1 ))
+          if [ "$PARENT_COUNT" -gt 1 ]; then
+            git revert --no-commit -m 1 "$FULL_SHA"
+          else
+            git revert --no-commit "$FULL_SHA"
+          fi || {
+            echo "::error::git revert hit a conflict — $FULL_SHA cannot be reverted cleanly by machine. Roll back traffic with action: pin-version, then craft the revert by hand."
+            git revert --abort 2>/dev/null || true
+            exit 1
+          }
+
+          # printf with %s keeps the untrusted subject/reason as arguments, never
+          # as a format string.
+          {
+            printf 'revert: %s\n\n' "$SUBJECT"
+            printf 'This reverts commit %s.\n\n' "$FULL_SHA"
+            printf 'Reason: %s\n' "$REASON"
+            printf 'Rolled back by: %s\n' "$ACTOR"
+            printf 'Workflow run: %s\n' "$RUN_URL"
+          } > "$RUNNER_TEMP/revert-msg.txt"
+
+          git commit -F "$RUNNER_TEMP/revert-msg.txt"
+          git push origin "$BRANCH"
+
+          {
+            echo "branch=$BRANCH"
+            echo "full_sha=$FULL_SHA"
+            echo "short_sha=$SHORT_SHA"
+            echo "subject=$SUBJECT"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Open the revert PR
+        env:
+          GH_TOKEN: ${{ secrets.FACTORY_GH_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          HAS_PAT: ${{ secrets.FACTORY_GH_TOKEN != '' }}
+          BRANCH: ${{ steps.revert.outputs.branch }}
+          FULL_SHA: ${{ steps.revert.outputs.full_sha }}
+          SHORT_SHA: ${{ steps.revert.outputs.short_sha }}
+          SUBJECT: ${{ steps.revert.outputs.subject }}
+          REASON: ${{ inputs.reason }}
+          ACTOR: ${{ github.actor }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          # Idempotent label creation, same pattern as prod-smoke.yml — avoids
+          # hard-coupling this workflow to a one-time manual setup step.
+          gh label create rollback --color "b60205" \
+            --description "Reverts a change that reached production" 2>/dev/null || true
+
+          {
+            printf 'Rolls back `%s` — %s\n\n' "$SHORT_SHA" "$SUBJECT"
+            printf '**Reason:** %s\n\n' "$REASON"
+            printf 'Requested by @%s via the Rollback workflow (%s).\n\n' "$ACTOR" "$RUN_URL"
+            printf -- '---\n\n'
+            printf 'Reverts %s in full. Merging this makes the rollback durable: until it\n' "$FULL_SHA"
+            printf 'lands, `main` still contains the reverted change and the next\n'
+            printf 'Git-integration deploy will put it back in production.\n'
+          } > "$RUNNER_TEMP/pr-body.md"
+
+          if [ "$HAS_PAT" != "true" ]; then
+            {
+              printf '\n> [!IMPORTANT]\n'
+              printf '> This PR was opened with `GITHUB_TOKEN`, so GitHub suppressed the\n'
+              printf '> `pull_request` event and **CI did not start**. The required `check`\n'
+              printf '> context will never report and the PR cannot merge as-is.\n'
+              printf '> Close and immediately reopen this PR to trigger CI.\n'
+            } >> "$RUNNER_TEMP/pr-body.md"
+          fi
+
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "revert: ${SUBJECT}" \
+            --body-file "$RUNNER_TEMP/pr-body.md" \
+            --label rollback
+
+          PR_URL=$(gh pr view "$BRANCH" --json url --jq .url)
+
+          # Squash only: main requires linear history and merge commits are
+          # disabled at the repo level. Auto-merge is best-effort — it will not
+          # fire while CI is absent, nor while a code owner review is pending if
+          # the reverted change touched a CODEOWNERS path.
+          gh pr merge "$BRANCH" --auto --squash \
+            || echo "::warning::Could not enable auto-merge; merge the PR manually once checks are green."
+
+          {
+            echo "## Revert PR opened"
+            echo ""
+            echo "$PR_URL"
+            echo ""
+            echo "Reverts \`$SHORT_SHA\` — $SUBJECT"
+            echo ""
+            if [ "$HAS_PAT" != "true" ]; then
+              echo "> [!IMPORTANT]"
+              echo "> Opened with \`GITHUB_TOKEN\`, so CI did **not** start automatically."
+              echo "> Close and reopen the PR to trigger the required \`check\` run."
+            fi
+            echo ""
+            echo "If the reverted change touched a path in \`.github/CODEOWNERS\`, this PR"
+            echo "also needs a code-owner approval. That gate is intentional — use"
+            echo "**action: pin-version** to stop the bleeding while review happens."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,16 @@ Database migration rules: see [src/db/CLAUDE.md](src/db/CLAUDE.md)
 - GitHub Releases page is the project changelog
 - Tags are created automatically; do not create manual tags
 
+## Rollback
+
+- `.github/workflows/rollback.yml` (#657) is the production revert path. Deploys go out via the Cloudflare Git integration with no Actions job owning them, so there is nothing to re-run — this workflow is the only undo. Full runbook: `docs/rollback.md`
+- Three `workflow_dispatch` actions: **`inspect`** (read-only; lists the active deployment and rollback candidates), **`pin-version`** (`wrangler rollback` — shifts traffic to a previous Worker version in seconds, no PR, no review), **`revert-commit`** (opens the `revert:` PR). `inspect` is the default so a mis-click cannot move traffic
+- **`pin-version` is temporary.** The next push to `main` redeploys from git and supersedes the pin. Treat `main` as frozen until the revert PR lands
+- A code rollback does **not** undo D1 schema, KV/DO data, bindings, or secrets. It is safe against schema only because migrations are additive-only (`scripts/migration-lint/`, see `src/db/CLAUDE.md`); a destructive migration through the escape hatch breaks that assumption
+- **No CODEOWNERS exemption accompanies this**, deliberately — CODEOWNERS matches the paths in a PR's diff, and a revert PR's diff is whatever the reverted commit touched, so no path rule can exempt "reverts". `.factory/gate.json`'s denylist is already a superset of CODEOWNERS, so anything the factory can auto-merge is outside every code-owned path and so is its revert. Reasoning in full in `docs/rollback.md`; do not "fix" this by un-owning the workflow, which holds `contents: write` and the Cloudflare deploy token
+- Every dispatch input reaches the shell through `env:`, never `${{ }}` interpolation into a `run:` body — `test/rollback-workflow.test.ts` fails the build if that regresses, along with SHA-pinning, the least-privilege `permissions:` block, and hardcoded repo slugs (the #679 rename trap)
+- A revert commit **is** releasable and cuts a CalVer tag on purpose (the Releases page is the changelog, and a rollback changes what is live). `cliff.toml` groups it under **Reverted**; `scripts/release/__tests__/releasable.test.ts` pins both
+
 ## GitHub Issues
 
 - After committing or merging work, check open issues (`gh issue list`) to see if any were resolved and should be closed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -65,6 +65,27 @@ dmarcheck is a rolling release deployed continuously from `main`. There are
 no long-lived branches or LTS versions. The only supported version is the
 current contents of `main` / the deployed Worker.
 
+## Rolling back a bad deploy
+
+Because deploys go out through the Cloudflare Git integration rather than a
+GitHub Actions job, there is no deployment to re-run and no artifact to
+redeploy. The revert path is the **Rollback** workflow
+([.github/workflows/rollback.yml](.github/workflows/rollback.yml)), run from
+Actions → Rollback → Run workflow by anyone with write access:
+
+- **`pin-version`** shifts production traffic back to a previously-uploaded
+  Worker version in seconds, with no PR and no review. This is the lever to
+  pull first when the live service is broken — including when the break is a
+  security regression.
+- **`revert-commit`** opens the `revert:` PR that makes it durable. A version
+  pin is superseded by the next push to `main`, so the revert must land before
+  anything else merges.
+
+A code rollback does **not** roll back D1 schema, KV/Durable Object data, or
+bindings. Read [docs/rollback.md](docs/rollback.md) before using it — it
+documents the preconditions, the failure modes, and why no CODEOWNERS
+exemption accompanies it.
+
 ## Vulnerability management
 
 We run automated software-composition analysis (SCA) and static analysis (SAST)

--- a/cliff.toml
+++ b/cliff.toml
@@ -45,6 +45,11 @@ commit_parsers = [
     # Covers conventional `chore(deps)` / `chore:` and dependabot's raw "Bump X".
     { message = "^chore", skip = true },
     { message = "^[Bb]ump ", skip = true },
+    # Production rollbacks (#657). Deliberately NOT skip = true: a revert
+    # changes what is live, so it must appear in the release notes rather than
+    # falling through to "Other". Matches both the conventional `revert:`
+    # prefix the rollback workflow writes and git's default `Revert "..."`.
+    { message = "^[Rr]evert", group = "Reverted" },
     { body = ".*", group = "Other" },
 ]
 filter_commits = false

--- a/docs/rollback.md
+++ b/docs/rollback.md
@@ -188,7 +188,15 @@ drifts silently.
 
 ## Drill
 
-An untested rollback lever is not a rollback lever. The drill is:
+An untested rollback lever is not a rollback lever.
+
+> [!NOTE]
+> GitHub only offers the "Run workflow" button for `workflow_dispatch`
+> workflows that exist on the **default branch**. This workflow cannot be
+> dispatched — not even the read-only `inspect` action — until it has merged
+> to `main`. The drill necessarily happens after merge, not before it.
+
+The drill is:
 
 1. `action: inspect` — confirm credentials work and versions are listed.
    Read-only; safe to run any time.

--- a/docs/rollback.md
+++ b/docs/rollback.md
@@ -1,0 +1,211 @@
+# Production rollback runbook
+
+How to undo a bad production deploy of the main Worker.
+
+## Why this document exists
+
+Production deploys leave GitHub entirely. A merge to `main` is picked up by the
+**Cloudflare Git integration** (Workers Builds), which builds and deploys
+without any GitHub Actions job owning it. That means there is no workflow to
+re-run, no artifact to redeploy, and no "revert this deployment" button.
+[`prod-smoke.yml`](../.github/workflows/prod-smoke.yml) can *detect* a bad
+deploy and file an incident issue, but it cannot undo one.
+
+[`rollback.yml`](../.github/workflows/rollback.yml) is the undo.
+
+## Who runs it
+
+Anyone with **write access** to the repository — GitHub only offers the
+`workflow_dispatch` "Run workflow" button to those collaborators. In practice
+that is the maintainer. No Cloudflare dashboard login is needed; the workflow
+uses the `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` repository secrets.
+
+Run it from **Actions → Rollback → Run workflow**.
+
+## The two levers, and why you need both
+
+| | `pin-version` | `revert-commit` |
+|---|---|---|
+| What it does | Shifts 100% of production traffic to a previously-uploaded Worker version | Opens a `revert:` PR against `main` |
+| Time to take effect | **Seconds** (typically <60s end to end, most of which is `npm ci`) | **Minutes to hours** — bounded by CI, and by review if the change touched a code-owned path |
+| Needs a PR? | No | Yes |
+| Needs review? | No | Only if the reverted change touched a [CODEOWNERS](../.github/CODEOWNERS) path |
+| Durable? | **No** — superseded by the next push to `main` | Yes |
+
+They are complements, not alternatives.
+
+`pin-version` stops the bleeding immediately, but it is **temporary**: the next
+push to `main` triggers a fresh Git-integration deploy, and that new version
+becomes active — putting the bad code straight back. Until the revert lands,
+`main` still contains the defect.
+
+> [!IMPORTANT]
+> After a `pin-version`, treat `main` as frozen. Land the revert PR before
+> anything else merges, or the next unrelated merge will silently undo your
+> rollback.
+
+## Procedure
+
+### 1. Inspect (read-only — always start here)
+
+Run **Rollback** with `action: inspect`. It prints the currently active
+deployment and the 10 most recent versions, with their version IDs, creation
+times and authors, into the workflow run summary.
+
+Copy the version ID you want to return to. It is normally the entry directly
+below the current one.
+
+Cloudflare retains the **100 most recent versions**; if you need something
+older than the 10 listed, get its ID from the Cloudflare dashboard under
+Workers & Pages → the Worker → Deployments.
+
+### 2. Pin the previous version (the emergency lever)
+
+Run **Rollback** with:
+
+- `action: pin-version`
+- `version_id`: the ID from step 1 — or **leave blank** to fall back to the
+  version uploaded immediately before the current one
+- `reason`: a sentence. It is recorded in the Cloudflare deployment message and
+  is what you will read in six months.
+
+The job runs `wrangler rollback`, prints the new active deployment, and
+automatically triggers `prod-smoke.yml` so you get an independent check that
+the live surface actually recovered.
+
+### 3. Revert the commit (make it durable)
+
+Run **Rollback** with:
+
+- `action: revert-commit`
+- `commit`: the SHA on `main` to revert (7–40 hex characters)
+- `reason`: same sentence
+
+The job verifies the SHA is an ancestor of `main`, reverts it on a
+`rollback/revert-<sha>-<run-id>` branch, opens a PR labelled `rollback`, and
+enables auto-merge (squash — `main` requires linear history).
+
+Merge that PR. The Git integration then deploys the reverted `main`, which
+supersedes the version pin from step 2 with the same code. Production and
+`main` are back in agreement.
+
+## What a version rollback does *not* undo
+
+`wrangler rollback` reverts **executing code only**. It is not a time machine
+for state. Specifically:
+
+- **D1 schema is not rolled back.** `migrate.yml` applies migrations
+  separately. This is safe by construction rather than by luck: migrations in
+  this repo are **additive-only**, enforced by `scripts/migration-lint/`, because
+  the migration workflow and the Cloudflare deploy already race with no ordering
+  guarantee (see [src/db/CLAUDE.md](../src/db/CLAUDE.md)). Old code is therefore
+  expected to run against newer schema. If you ever land a genuinely destructive
+  migration through the escape hatch, a code rollback across it is **not** safe.
+- **KV, Durable Object and D1 *data* are untouched.** Anything the bad version
+  wrote stays written. Rolling back the code does not un-write a corrupt
+  `INBOX_TOKENS` entry or a bad `scan_history` row.
+- **Bindings and secrets are not restored.** Cloudflare's documentation is
+  explicit that resources connected to the Worker are unchanged by a rollback.
+- **The `mta-sts-worker` is a separate deployment** with its own
+  [workflow](../.github/workflows/deploy-mta-sts.yml). This lever does not touch it.
+
+## Failure modes to expect
+
+| Symptom | Cause and what to do |
+|---|---|
+| `pin-version` fails with a Durable Object error | Cloudflare **blocks** a rollback across a Durable Object class lifecycle change. If a `[[migrations]]` entry for `RateLimiterDO` landed between the two versions, you must roll forward with a fix instead. |
+| `pin-version` fails citing a missing binding | The target version references a KV/D1/R2/queue binding that no longer exists. Pick a newer version, or roll forward. |
+| The version you want is not listed | Older than the 100 retained versions. Use `revert-commit`. |
+| `inspect` fails on credentials | `CLOUDFLARE_API_TOKEN` needs **Workers Scripts: Edit** on the account owning the Worker. It is the same secret `deploy-mta-sts.yml` uses; account-scoped tokens cover both Workers, but a token scoped to only the MTA-STS Worker will not. Use `revert-commit` meanwhile. |
+| `revert-commit` fails with a conflict | The commit cannot be reverted mechanically because later commits touched the same lines. Use `pin-version` to hold the line, then write the revert by hand. |
+| The revert PR sits with no checks running | See below. |
+
+### The revert PR shows no CI
+
+GitHub deliberately suppresses workflow triggers for events raised by
+`GITHUB_TOKEN`, to prevent recursive runs. A PR opened by the workflow with the
+default token therefore does **not** fire `pull_request`, so CI never starts,
+the required `check` context never reports, and the PR cannot merge.
+
+**Workaround:** close the PR and immediately reopen it. That is a human action
+and fires the event normally. The workflow detects this case and prints the
+instruction in both the PR body and the run summary.
+
+**Proper fix:** once `secrets.FACTORY_GH_TOKEN` exists (the bot-identity split,
+[#299](https://github.com/schmug/dmarc.mx/issues/299)), the workflow picks it up
+automatically — it already prefers that secret and falls back only when it is
+absent. No workflow change will be needed.
+
+## On the CODEOWNERS exemption
+
+[Issue #657](https://github.com/schmug/dmarc.mx/issues/657) asked for a
+CODEOWNERS exemption "for that path so a revert never needs an approving review
+to land." **This repo does not have one, deliberately.** The reasoning:
+
+1. **CODEOWNERS cannot express it.** Ownership is matched on the paths in a
+   PR's diff. A revert PR's diff is, by definition, the paths the reverted
+   commit touched. Un-owning `.github/workflows/rollback.yml` would exempt
+   *edits to the rollback workflow itself* — not reverts. There is no
+   path-based way to say "PRs that are reverts skip review."
+2. **It would be the wrong file to un-own.** `rollback.yml` holds
+   `contents: write`, `pull-requests: write`, `actions: write` and the
+   Cloudflare deploy token. `/.github/` is code-owned precisely because "a PR
+   can otherwise rewrite its own merge gate." Un-owning the most privileged
+   workflow in the repo to buy nothing is a bad trade.
+3. **The gap it was meant to close is already closed.** The factory's merge
+   gate (`.factory/gate.json`) refuses to auto-merge any PR touching its
+   `riskPathDenylist`, which is a **superset** of CODEOWNERS and additionally
+   force-includes `.github/**`, `.factory/**` and `CODEOWNERS`. So every change
+   the factory can land unattended is, by construction, outside every
+   code-owned path — and so is its revert. Those revert PRs need no approval
+   today and will need none after the bot-identity split.
+4. **For the remaining case, review is correct.** A human-authored change to
+   `src/index.ts` is code-owned, so its revert is too. Reverting input
+   validation or rate limiting on an unreviewed automated trigger is a
+   capability worth *not* having — and `pin-version` already restores service
+   in seconds without touching git, so the review costs no downtime.
+
+Note that today the gate is even looser than the above: GitHub does not request
+review from a PR's own author, and @schmug is the sole code owner, so a
+@schmug-authored PR on a code-owned path merges freely regardless. The analysis
+above is written for the post-#299 state, where that no longer holds. See
+[#658](https://github.com/schmug/dmarc.mx/issues/658).
+
+If the maintainer decides review-free git reverts are worth it anyway, the
+mechanism is a `bypass_actors` entry on the `main-protection` ruleset (a repo
+setting, not a file in this repo). That is strictly *wider* than a CODEOWNERS
+exemption, which is the main argument against it.
+
+## Release side effects
+
+A revert lands on `main` like any other commit, so `Release` runs and cuts a
+CalVer tag. **This is intended.** The GitHub Releases page is this project's
+changelog, and a rollback changes what is running in production; suppressing
+the tag would leave the changelog asserting that reverted code is still live.
+`cliff.toml` groups these commits under a **Reverted** heading, and
+`scripts/release/__tests__/releasable.test.ts` pins both behaviours so neither
+drifts silently.
+
+## Drill
+
+An untested rollback lever is not a rollback lever. The drill is:
+
+1. `action: inspect` — confirm credentials work and versions are listed.
+   Read-only; safe to run any time.
+2. `action: pin-version` with the previous version ID and
+   `reason: "scheduled rollback drill"`. Confirm `prod-smoke` goes green
+   against the rolled-back deploy.
+3. Roll forward by re-running the Cloudflare Git integration deploy for
+   `main`'s current head (or `action: pin-version` back to the version you
+   started on). Confirm `prod-smoke` is green again.
+4. `action: revert-commit` against a low-risk, easily-reverted commit to
+   confirm the PR path works end to end, then close the PR without merging if
+   the revert is not actually wanted.
+5. Record the run URLs and timings in
+   [#657](https://github.com/schmug/dmarc.mx/issues/657).
+
+> [!NOTE]
+> **Drill status: not yet run.** Steps 1–5 are the maintainer's to execute —
+> they mutate live production traffic. Until they are done and recorded, treat
+> this lever as untested and do not count #657 as satisfying the arming
+> precondition in [`.factory/README.md`](../.factory/README.md).

--- a/scripts/release/__tests__/releasable.test.ts
+++ b/scripts/release/__tests__/releasable.test.ts
@@ -59,6 +59,26 @@ describe("isReleasable", () => {
   });
 });
 
+// A rollback (#657) lands a revert commit on main, which triggers Release like
+// any other push. That it cuts a CalVer tag is DELIBERATE, not an oversight:
+// the GitHub Releases page is this project's changelog, and a rollback changes
+// what is running in production. Suppressing the tag would leave the changelog
+// asserting that the reverted code is still live. These tests pin that choice
+// so nobody "fixes" it into a skip pattern later without reading this comment.
+describe("revert commits (rollback lever, #657)", () => {
+  it("treats a conventional 'revert:' commit as releasable", () => {
+    expect(isReleasable(["revert: feat: add SPF strict mode (rollback of abc1234)"])).toBe(true);
+  });
+
+  it("treats git's default 'Revert \"...\"' subject as releasable", () => {
+    expect(isReleasable(['Revert "feat: add SPF strict mode"'])).toBe(true);
+  });
+
+  it("stays releasable when the revert is batched with skippable chores", () => {
+    expect(isReleasable(["chore(deps): bump vitest", "revert: bad analyzer change"])).toBe(true);
+  });
+});
+
 describe("sanitizeLastTag", () => {
   it("passes through CalVer tags unchanged", () => {
     expect(sanitizeLastTag("v2026.4.1")).toBe("v2026.4.1");
@@ -106,5 +126,24 @@ describe("cliff.toml sync", () => {
     }
     const ourPatterns = new Set<string>(SKIP_PATTERN_SOURCES);
     expect(ourPatterns).toEqual(cliffSkip);
+  });
+
+  // Reverts are releasable (see above), so they WILL appear in release notes.
+  // Without a parser of their own they fall through to the `body = ".*"`
+  // catch-all and land under "Other" — a rollback is the single most
+  // important line a changelog can carry, so it gets its own group.
+  it("groups revert commits under 'Reverted' ahead of the catch-all parser", () => {
+    const tomlLines = readFileSync(resolve(process.cwd(), "cliff.toml"), "utf8").split("\n");
+
+    const revertIdx = tomlLines.findIndex(
+      (l) => /message = "\^\[Rr\]evert"/.test(l) && /group = "Reverted"/.test(l),
+    );
+    const catchAllIdx = tomlLines.findIndex((l) => /body = "\.\*"/.test(l));
+
+    expect(revertIdx).toBeGreaterThan(-1);
+    expect(catchAllIdx).toBeGreaterThan(-1);
+    expect(revertIdx).toBeLessThan(catchAllIdx);
+    // Must not be skip = true, or the rollback would silently stop releasing.
+    expect(tomlLines[revertIdx]).not.toMatch(/skip = true/);
   });
 });

--- a/test/rollback-workflow.test.ts
+++ b/test/rollback-workflow.test.ts
@@ -1,0 +1,106 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// Invariants for the production rollback lever (#657). This is the one
+// workflow an operator runs while production is broken, so the failure modes
+// that matter are the ones that only surface at 3am:
+//
+//   - a `${{ inputs.* }}` interpolated straight into a `run:` body is a shell
+//     injection carrying `contents: write` (the `reason` input is free text),
+//   - a hardcoded repo slug silently breaks on a rename — schmug/dmarcheck →
+//     schmug/dmarc.mx already did exactly this to the release workflow (#679),
+//   - an unpinned action is an unreviewed dependency in the rollback path.
+//
+// These assertions are tripwires, not a YAML parser: they exist so a later
+// edit that reintroduces one of those shapes fails in CI rather than during an
+// incident.
+
+const WORKFLOW_PATH = ".github/workflows/rollback.yml";
+const workflow = readFileSync(resolve(process.cwd(), WORKFLOW_PATH), "utf8");
+const lines = workflow.split("\n");
+
+// `${{ inputs.x }}` / `${{ github.event.inputs.x }}` in any form.
+const INPUT_EXPR = /\$\{\{[^}]*\binputs\./;
+// Two legal homes for one:
+//   VERSION_ID: ${{ inputs.version_id }}   — an UPPER_SNAKE env mapping; the
+//     shell then reads "$VERSION_ID", which it does not re-parse.
+//   if: ${{ inputs.action == 'pin-version' }} — a job/step condition,
+//     evaluated by the Actions expression engine and never by a shell.
+// Anything else means the value reaches a `run:` body as literal text.
+const SAFE_HOST = /^\s*(?:[A-Z][A-Z0-9_]*:\s*\$\{\{|if:\s*\$\{\{)/;
+
+describe("rollback workflow — shell-injection safety", () => {
+  it("never interpolates a dispatch input anywhere but an env mapping or an if:", () => {
+    const offenders = lines
+      .map((line, i) => ({ line, lineNo: i + 1 }))
+      .filter(({ line }) => INPUT_EXPR.test(line) && !SAFE_HOST.test(line));
+
+    expect(
+      offenders.map(
+        ({ line, lineNo }) => `${WORKFLOW_PATH}:${lineNo}: ${line.trim()}`,
+      ),
+    ).toEqual([]);
+  });
+
+  it("validates the version_id and commit inputs against an anchored allowlist regex", () => {
+    // Both reach a git/wrangler argv. Anchored character-class validation is
+    // what keeps an operator typo (or a malicious dispatch) from becoming an
+    // argument-injection primitive.
+    expect(workflow).toMatch(/\[0-9a-f\]\{7,40\}\$/);
+    expect(workflow).toMatch(/\[0-9a-f-\]\{36\}\$/);
+  });
+});
+
+describe("rollback workflow — rename resilience (#679)", () => {
+  it("uses github.repository instead of a hardcoded owner/repo slug", () => {
+    // Regex rather than a string literal: biome's noTemplateCurlyInString
+    // flags a bare "${{ ... }}" inside quotes.
+    expect(workflow).toMatch(/\$\{\{\s*github\.repository\s*\}\}/);
+  });
+
+  it("hardcodes neither the old nor the current repo slug", () => {
+    // The release workflow's Sigstore identity regexp is a deliberate
+    // exception (it pins WHICH identity we trust). A rollback lever has no
+    // such need, so any literal slug here is a rename trap.
+    expect(workflow).not.toMatch(/schmug\/dmarcheck/);
+    expect(workflow).not.toMatch(/schmug\/dmarc\.mx/);
+  });
+});
+
+describe("rollback workflow — supply chain", () => {
+  it("pins every action by full 40-character commit SHA", () => {
+    // Steps are list items, so the line reads "- uses: owner/repo@sha".
+    const uses = lines
+      .map((l) => l.trim().replace(/^-\s*/, ""))
+      .filter((l) => l.startsWith("uses:"))
+      .map((l) => l.replace(/^uses:\s*/, ""));
+
+    expect(uses.length).toBeGreaterThan(0);
+    for (const action of uses) {
+      expect(action).toMatch(/@[0-9a-f]{40}(\s|$)/);
+    }
+  });
+
+  it("declares an explicit least-privilege top-level permissions block", () => {
+    expect(workflow).toMatch(/^permissions:\n {2}contents: read$/m);
+  });
+});
+
+describe("rollback workflow — operator safety", () => {
+  it("defaults the dispatch to the read-only inspect action", () => {
+    // A rollback form that defaults to a mutating action is one mis-click from
+    // shifting production traffic. `inspect` must be the default choice.
+    const actionInput = workflow.slice(workflow.indexOf("      action:"));
+    const defaultLine = actionInput.match(/default:\s*(\S+)/);
+    expect(defaultLine?.[1]).toBe("inspect");
+  });
+
+  it("passes --message to wrangler rollback so it never blocks on a TTY prompt", () => {
+    // `wrangler rollback` prompts interactively unless --message is supplied.
+    // Without it the job hangs until the job timeout, mid-incident.
+    expect(workflow).toMatch(
+      /wrangler rollback[^\n]*--message|--message[^\n]*\n[^\n]*ROLLBACK/,
+    );
+  });
+});


### PR DESCRIPTION
Closes #657.

## What this adds

Production deploys leave GitHub entirely via the Cloudflare Git integration, so no Actions run owns a deploy — there is no workflow to re-run and no artifact to redeploy. [`prod-smoke.yml`](.github/workflows/prod-smoke.yml) can *detect* a bad deploy but cannot undo one.

[`.github/workflows/rollback.yml`](.github/workflows/rollback.yml) is the undo. Three `workflow_dispatch` actions:

| Action | Effect | Time | PR? | Review? |
|---|---|---|---|---|
| `inspect` (default) | Read-only. Active deployment + 10 most recent rollback candidates | seconds | no | no |
| `pin-version` | `wrangler rollback` — shifts 100% of traffic to a previous Worker version, then triggers `prod-smoke` to prove it landed | seconds | no | **no** |
| `revert-commit` | Opens the `revert:` PR that makes the rollback durable | minutes | yes | only if the reverted commit touched a code-owned path |

They are complements. A version pin is superseded by the next push to `main`, so `main` must be treated as frozen until the revert lands — the workflow says so in its run summary.

Runbook: **[docs/rollback.md](docs/rollback.md)** — who runs it, what each action does, time to take effect, what a rollback does *not* undo (D1 schema, KV/DO data, bindings, secrets), and the failure modes.

## ⚠️ The production drill is outstanding

Acceptance criterion 1 of #657 — exercise the path once, deliberately, against production and record the result — is **not done**. It mutates live traffic, so it is the maintainer's to run, not an agent's. The procedure is [in the runbook](docs/rollback.md#drill); step 1 (`inspect`) is read-only and safe to run right now to verify credentials.

Until it is drilled, `.factory/README.md` blocker #3 stays open — this PR rewords it from "there is no rollback lever" to "the rollback lever is built but undrilled" rather than clearing it.

**One precondition worth checking first:** `pin-version` reuses `CLOUDFLARE_API_TOKEN`, which today is only exercised by `deploy-mta-sts.yml`. It needs **Workers Scripts: Edit** on the account owning the main Worker. If it is scoped to the MTA-STS Worker only, `inspect` will fail — that is what step 1 of the drill is for.

## On the CODEOWNERS exemption — deliberately not included

#657 asked for one. I did not write it, because it cannot do what the issue wants and would cost something real:

1. **CODEOWNERS cannot express it.** Ownership matches the paths in a PR's diff, and a revert PR's diff *is* the reverted commit's paths. Un-owning `rollback.yml` would exempt edits to the rollback workflow, not reverts. There is no path-based way to say "reverts skip review."
2. **It is the worst file in the repo to un-own.** `rollback.yml` carries `contents: write`, `pull-requests: write`, `actions: write` and the Cloudflare deploy token. `/.github/` is code-owned precisely because "a PR can otherwise rewrite its own merge gate."
3. **The gap is already closed.** `.factory/gate.json`'s `riskPathDenylist` is a superset of CODEOWNERS and force-includes `.github/**`, `.factory/**`, `CODEOWNERS`. So everything the factory can land unattended is outside every code-owned path — and so is its revert. Those revert PRs need no approval now, and none after #299.
4. **For the remainder, review is correct** — and costs no downtime, because `pin-version` restores service in seconds without touching git.

Per the handoff, I verified the premise rather than designing around it: ruleset `14716629` is `require_code_owner_review: true`, `required_approving_review_count: 0`, `bypass_actors: []`, required context `check`; dependabot PR #647 has 1 requested reviewer while a @schmug-authored PR gets 0. So the gate does not currently block a maintainer-authored revert at all. The analysis above is written for the post-#299 state — see #658.

If you want review-free git reverts anyway, the mechanism is a `bypass_actors` entry on the ruleset (a repo setting, not a file here), which is strictly *wider* than a CODEOWNERS exemption. Your call; happy to follow up.

## #678 / #679 lessons applied

- **No hardcoded repo slug** — `${{ github.repository }}` throughout. A test asserts neither the old nor the current slug appears.
- **No guard that a later step can fall out of** — all three actions are gated at *job* level, not step level, so appending a step cannot miss an `if:` the way #678's did.
- **No shell injection** — every dispatch input reaches the shell via `env:`, never `${{ }}` in a `run:` body. `reason` is free text typed by a human under stress into a job holding a deploy token. Both SHA-ish inputs are validated against anchored allowlists before reaching git/wrangler argv.
- `--message` is passed to `wrangler rollback` so it cannot block on a TTY prompt that never comes.

## Release behaviour

A revert lands on `main` and cuts a CalVer tag. **That is intended, not a surprise** — the Releases page is this project's changelog and a rollback changes what is live; suppressing the tag would leave the changelog claiming reverted code is still deployed. `cliff.toml` gains a `Reverted` group so it is labelled rather than dumped into "Other", and the release tests pin both halves.

## Known rough edge, self-healing

A PR opened with `GITHUB_TOKEN` does not fire `pull_request`, so CI never starts and the required `check` never reports. The workflow prefers `secrets.FACTORY_GH_TOKEN` and falls back only when absent; in the fallback case it prints "close and reopen this PR to trigger CI" in both the PR body and the run summary. Once #299 lands, this resolves with no workflow change.

## Verification

- `npm run lint` clean, `npm run typecheck` clean, `npm test` **1532 passing / 0 failing** (96 files).
- New `test/rollback-workflow.test.ts` (8 assertions) pins the injection, rename, pinning, permissions and operator-safety invariants.
- Workflow YAML parsed and structurally checked; all 12 embedded `run` blocks shellcheck clean (only SC2016 on markdown backticks inside single-quoted `printf` formats, which is intended).
- The `revert-commit` git logic was executed against a scratch repo, including a commit whose subject was `feat: add $(touch /tmp/PWNED) \`id\` "quoted" 100% wild` — reverted correctly, subject preserved verbatim, no injection, authored as `github-actions[bot]` so DCO skips it. The conflict path was exercised separately and aborts cleanly with an actionable error.
- **No production resource was touched.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
